### PR TITLE
Style queue drawer scrollbar with dark theme styling

### DIFF
--- a/app.js
+++ b/app.js
@@ -34753,7 +34753,7 @@ React.createElement('div', {
       // Queue content - dark theme
       React.createElement('div', {
         ref: queueContentRef,
-        className: 'overflow-y-auto relative',
+        className: 'overflow-y-auto relative scrollable-content-dark',
         style: { height: (queueDrawerHeight - 44 - (playbackContext ? 32 : 0)) + 'px' },
         onDragEnter: (e) => handleDragEnter(e, 'queue'),
         onDragOver: (e) => handleDragOver(e, 'queue'),

--- a/index.html
+++ b/index.html
@@ -62,6 +62,25 @@
       background: rgba(0, 0, 0, 0.25);
     }
 
+    /* Scrollbar styling - dark theme (for queue drawer) */
+    .scrollable-content-dark::-webkit-scrollbar {
+      width: 12px;
+    }
+
+    .scrollable-content-dark::-webkit-scrollbar-track {
+      background: rgba(255, 255, 255, 0.05);
+      border-radius: 10px;
+    }
+
+    .scrollable-content-dark::-webkit-scrollbar-thumb {
+      background: rgba(255, 255, 255, 0.2);
+      border-radius: 10px;
+    }
+
+    .scrollable-content-dark::-webkit-scrollbar-thumb:hover {
+      background: rgba(255, 255, 255, 0.35);
+    }
+
     /* Loading animation */
     @keyframes spin {
       to { transform: rotate(360deg); }


### PR DESCRIPTION
## Summary
Added custom scrollbar styling to the queue drawer to improve visual consistency with the dark theme interface.

## Changes
- Added `scrollable-content-dark` CSS class to the queue content container in the queue drawer
- Implemented webkit scrollbar styles for dark theme with:
  - 12px scrollbar width
  - Semi-transparent white track background (5% opacity)
  - Semi-transparent white thumb with rounded corners (20% opacity)
  - Hover state with increased opacity (35%) for better interactivity

## Details
The scrollbar styling uses rgba colors to blend seamlessly with the dark theme background. The hover state provides visual feedback when users interact with the scrollbar, improving the overall user experience in the queue drawer.

https://claude.ai/code/session_01KGhxRtVUz3ZeZkghQ2nqEp