### PR TITLE
Skip progress tracking for browser-based playback sources

### DIFF
--- a/app.js
+++ b/app.js
@@ -6242,12 +6242,14 @@ const Parachord = () => {
   useEffect(() => {
     // Skip progress tracking for streaming tracks (Spotify) - they have their own polling
     // Skip for local files - they use HTML5 Audio with timeupdate event
+    // Skip for browser-based tracks (YouTube, Bandcamp) - they use extension events
     // Also skip if duration is 0 or missing to prevent infinite handleNext loop
     const isStreamingTrack = currentTrack?.sources?.spotify || currentTrack?.spotifyUri;
     const isLocalFile = currentTrack?.filePath || currentTrack?.sources?.localfiles;
+    const isBrowserTrack = browserPlaybackActive || isExternalPlayback;
     const hasValidDuration = currentTrack?.duration && currentTrack.duration > 0;
 
-    if (isPlaying && audioContext && currentTrack && !isStreamingTrack && !isLocalFile && hasValidDuration) {
+    if (isPlaying && audioContext && currentTrack && !isStreamingTrack && !isLocalFile && !isBrowserTrack && hasValidDuration) {
       const interval = setInterval(() => {
         const elapsed = (audioContext.currentTime - startTime);
         if (elapsed >= currentTrack.duration) {
@@ -6263,7 +6265,7 @@ const Parachord = () => {
       }, 100);
       return () => clearInterval(interval);
     }
-  }, [isPlaying, audioContext, currentTrack, startTime]);
+  }, [isPlaying, audioContext, currentTrack, startTime, browserPlaybackActive, isExternalPlayback]);
 
   // Smooth progress interpolation for Spotify tracks
   // API polling happens every 5 seconds, but we want smooth 1-second visual updates


### PR DESCRIPTION
## Summary
Updated the progress tracking logic to skip browser-based playback sources (YouTube, Bandcamp) that rely on extension events rather than the Web Audio API for playback control.

## Changes
- Added check for `browserPlaybackActive` and `isExternalPlayback` flags to identify browser-based tracks
- Skip progress interval tracking when browser-based playback is active, preventing duplicate progress updates
- Updated the useEffect dependency array to include `browserPlaybackActive` and `isExternalPlayback` to ensure the effect re-runs when these states change

## Implementation Details
The progress tracking interval was previously only skipping Spotify streams and local files. This change extends that logic to also skip browser-based playback sources that handle their own progress tracking through extension events. This prevents conflicts between the Web Audio API interval-based tracking and the extension event-based tracking used by browser sources.

https://claude.ai/code/session_01LwznTbZYJeaa6U3FST8Mn9