### PR TITLE
fix: pre-fetch artist bio for tooltip on page load

### DIFF
--- a/app.js
+++ b/app.js
@@ -10263,6 +10263,12 @@ const Parachord = () => {
         }
       })();
 
+      // Pre-fetch artist bio early (non-blocking) for tooltip on artist name
+      (async () => {
+        const bioData = await getArtistBio(artist.name, artist.id);
+        setArtistBio(bioData === null ? false : bioData);
+      })();
+
       // Step 2: Fetch artist's release-groups (albums, EPs, singles) with staggered requests
       // Using release-groups instead of releases to avoid duplicates (each album appears once)
       // MusicBrainz rate limits to ~1 req/sec, so we stagger by 500ms to stay under limit


### PR DESCRIPTION
The bio tooltip on the artist name now works immediately without needing to visit the Biography tab first. Bio is fetched early alongside the artist image.

https://claude.ai/code/session_01AbdjtvD69SzmWpmuL6LJmM