### PR TITLE
fix: calculate album track count from collection tracks

### DIFF
--- a/app.js
+++ b/app.js
@@ -24830,7 +24830,7 @@ React.createElement('div', {
                 sorted.map((album, index) =>
                   React.createElement(CollectionAlbumCard, {
                     key: `${album.title}-${album.artist}-${index}`,
-                    album: { ...album, trackCount: 0 },
+                    album: { ...album, trackCount: collectionData.tracks.filter(t => t.artist === album.artist && t.album === album.title).length },
                     getAlbumArt: getAlbumArt,
                     onNavigate: () => handleCollectionAlbumClick(album),
                     animationDelay: Math.min(index * 30, 300)


### PR DESCRIPTION
The album track count in Collection > Albums was hardcoded to 0. Now it correctly counts tracks in the collection that match the album's artist and title.

https://claude.ai/code/session_VuneP