### PR TITLE
fix: use filteredTracks when queueing from resolver icon in recommend…

### DIFF
--- a/app.js
+++ b/app.js
@@ -26977,7 +26977,7 @@ React.createElement('div', {
                                   className: 'no-drag',
                                   onClick: (e) => {
                                     e.stopPropagation();
-                                    const tracksAfter = recommendations.tracks.slice(index + 1);
+                                    const tracksAfter = filteredTracks.slice(index + 1);
                                     const context = { type: 'recommendations', name: 'Recommendations' };
                                     setQueueWithContext(tracksAfter, context);
                                     handlePlay({ ...track, preferredResolver: resolverId });


### PR DESCRIPTION
…ations

When clicking a resolver icon on a recommendation track with the Last.fm filter active, the code incorrectly used recommendations.tracks instead of filteredTracks to queue subsequent tracks. Since the index is based on the filtered array position, this caused wrong tracks to be queued.

https://claude.ai/code/session_017LGNzy6EW1DL3g5WVTmADu