### PR TITLE
fix: back button from collection albums returns to Collection

### DIFF
--- a/app.js
+++ b/app.js
@@ -11051,6 +11051,9 @@ const Parachord = () => {
         return;
       }
 
+      // Clear artist history so back button returns to Collection, not previous artist
+      setArtistHistory([]);
+
       // Show loading state immediately - set artist and navigate before search
       const artist = {
         name: album.artist,


### PR DESCRIPTION
When clicking an album from Collection, artistHistory wasn't being cleared. If the user had previously browsed artists, that stale history caused the back button to navigate to a previous artist instead of returning to Collection.

Now clears artistHistory in handleCollectionAlbumClick so the back button correctly returns to the Collection view.

https://claude.ai/code/session_VuneP