### PR TITLE
fix: clear stale visible track IDs when recommendations filter changes

### DIFF
--- a/app.js
+++ b/app.js
@@ -11666,6 +11666,10 @@ const Parachord = () => {
     const tracks = recommendations.tracks;
     if (tracks.length === 0) return;
 
+    // Clear stale visible track IDs when filter changes (or on initial setup)
+    // This ensures the IntersectionObserver can properly detect "new" visible tracks
+    visibleRecommendationsTrackIds.current.clear();
+
     // Wait for scroll container to be available
     const scrollContainer = recommendationsScrollContainerRef.current;
     if (!scrollContainer) {
@@ -11715,7 +11719,7 @@ const Parachord = () => {
     });
 
     return () => recommendationsObserverRef.current?.disconnect();
-  }, [activeView, recommendationsTab, recommendations.tracks, updateSchedulerVisibility, recommendationsScrollContainerReady]);
+  }, [activeView, recommendationsTab, recommendations.tracks, updateSchedulerVisibility, recommendationsScrollContainerReady, recommendationsSourceFilter]);
 
   // Register page context for history tracks resolution
   useEffect(() => {


### PR DESCRIPTION
When switching source filters (All/ListenBrainz/Last.fm), the visibleRecommendationsTrackIds set retained stale IDs from the previous filter state. This caused the IntersectionObserver callback to not detect tracks as "new" visible tracks (since they were already in the set), resulting in updateSchedulerVisibility not being called and tracks not being queued for resolution.

Changes:
- Clear visibleRecommendationsTrackIds when the effect re-runs
- Add recommendationsSourceFilter to effect dependencies so it re-runs on filter change

https://claude.ai/code/session_017LGNzy6EW1DL3g5WVTmADu