### PR TITLE
fix: make sticky filter bar work in Related Artists tab

### DIFF
--- a/app.js
+++ b/app.js
@@ -22765,7 +22765,7 @@ React.createElement('div', {
                     : a.source === relatedArtistsSourceFilter || a.source === 'both'
                 );
 
-            return React.createElement('div', null,
+            return React.createElement(React.Fragment, null,
               // Sticky filter bar - show when both services are configured
               hasBothServicesConfigured && React.createElement('div', {
                 className: 'sticky top-0 z-10 flex items-center px-6 py-3 bg-white border-b border-gray-200'


### PR DESCRIPTION
The filter bar in the Related Artists tab was not sticking when scrolling because it was wrapped in an extra <div> element. For CSS `position: sticky` to work properly, the sticky element needs to be a direct child of the scrollable container.

Changed the wrapper from a plain div to React.Fragment so the filter bar becomes a direct child of the scrollable container, matching the pattern used in the Music tab and other views.

https://claude.ai/code/session_01Gkdx24E6iFAvEiLCMKRsK1