### PR TITLE
fix: clear stale visible track IDs when recommendations filter changes

### DIFF
--- a/app.js
+++ b/app.js
@@ -11808,6 +11808,8 @@ const Parachord = () => {
     // Clear stale visible track IDs when filter changes (or on initial setup)
     // This ensures the IntersectionObserver can properly detect "new" visible tracks
     visibleRecommendationsTrackIds.current.clear();
+    // Also reset the scheduler's context visibility so tracks can be re-enqueued
+    updateSchedulerVisibility('recommendations-tracks', []);
 
     // Wait for scroll container to be available
     const scrollContainer = recommendationsScrollContainerRef.current;


### PR DESCRIPTION
When switching source filters (All/ListenBrainz/Last.fm), two issues prevented tracks from resolving:

1. The visibleRecommendationsTrackIds ref retained stale IDs from the previous filter state, causing the IntersectionObserver to not detect tracks as "new"

2. The scheduler's context.visibleTracks also retained stale IDs, preventing tracks from being re-enqueued even when they weren't resolved yet

Changes:
- Clear visibleRecommendationsTrackIds when the effect re-runs
- Reset scheduler context visibility by calling updateSchedulerVisibility([])
- Add recommendationsSourceFilter to effect dependencies

https://claude.ai/code/session_017LGNzy6EW1DL3g5WVTmADu