### PR TITLE
fix: preserve filename when saving playlist to prevent duplicates

### DIFF
--- a/app.js
+++ b/app.js
@@ -13317,8 +13317,10 @@ ${tracks}
       const xspfContent = generateXSPF(playlist);
 
       // Create playlist data object for storage
+      // Use existing filename, or generate one from ID to ensure consistent updates
       const playlistData = {
         id: playlist.id,
+        filename: playlist.filename || `${playlist.id}.xspf`,
         title: playlist.title,
         creator: playlist.creator,
         tracks: playlist.tracks,


### PR DESCRIPTION
The savePlaylistToStore function was not including the filename property when saving playlists. For Spotify-synced playlists that don't have a filename, this caused the electron store to create a new file instead of updating the existing one, resulting in duplicate playlists.

Fix: Generate a consistent filename from the playlist ID if one doesn't exist (e.g., "spotify-playlist-abc123.xspf").

https://claude.ai/code/session_01Gkdx24E6iFAvEiLCMKRsK1