### PR TITLE
fix: reset shuffle state when queue is replaced with new content

### DIFF
--- a/app.js
+++ b/app.js
@@ -8896,6 +8896,13 @@ const Parachord = () => {
     console.log(`🏷️ Tagged ${taggedTracks.length} tracks with context:`, context.type);
     setCurrentQueue(taggedTracks);
     setPlaybackContext(context);
+    // Reset shuffle state when replacing queue with new content
+    // The new queue isn't shuffled, so the UI should reflect that
+    if (shuffleMode) {
+      setShuffleMode(false);
+      originalQueueRef.current = null;
+      console.log('🔀 Shuffle OFF - queue replaced with new content');
+    }
   };
 
   // Helper to add tracks to existing queue with context
@@ -24598,6 +24605,11 @@ React.createElement('div', {
                         });
                         // Set all tracks after first as queue
                         setCurrentQueue(tracksWithIds.slice(1));
+                        // Reset shuffle state when replacing queue
+                        if (shuffleMode) {
+                          setShuffleMode(false);
+                          originalQueueRef.current = null;
+                        }
                         // Play first track
                         handlePlay(tracksWithIds[0]);
                       }


### PR DESCRIPTION
When clicking on a new track (e.g., first track of an album) or starting playback of a new playlist, the queue is replaced but the shuffle state was not being reset. This caused the shuffle button to show as "on" even though the new queue was not shuffled.

- Reset shuffleMode and originalQueueRef in setQueueWithContext
- Also reset shuffle when playing hosted playlists directly

https://claude.ai/code/session_018dgH3dNqfhtX1F8HRqCVA4