### PR TITLE
Change default release type filter to show all releases

### DIFF
--- a/app.js
+++ b/app.js
@@ -3174,7 +3174,7 @@ const Parachord = () => {
   const [artistImage, setArtistImage] = useState(null); // Artist image from Spotify
   const [artistImagePosition, setArtistImagePosition] = useState('center 25%'); // Face-centered position
   const [artistReleases, setArtistReleases] = useState([]); // Discography
-  const [releaseTypeFilter, setReleaseTypeFilter] = useState('album'); // album, ep, single, live, compilation
+  const [releaseTypeFilter, setReleaseTypeFilter] = useState('all'); // all, album, ep, single, live, compilation
   const [isHeaderCollapsed, setIsHeaderCollapsed] = useState(false); // Artist page header collapse state
   const [artistPageTab, setArtistPageTab] = useState('music'); // music | biography | related
   const [artistSearchOpen, setArtistSearchOpen] = useState(false);
@@ -3879,23 +3879,9 @@ const Parachord = () => {
     { value: 'alpha-desc', label: 'Z-A' }
   ];
 
-  // Set smart default release type filter based on available releases
+  // Set default release type filter to 'all' to show complete discography
   const setSmartReleaseTypeFilter = useCallback((releases) => {
-    const hasAlbums = releases.some(r => r.releaseType === 'album');
-    const hasEPs = releases.some(r => r.releaseType === 'ep');
-    const hasSingles = releases.some(r => r.releaseType === 'single');
-
-    if (hasAlbums) {
-      setReleaseTypeFilter('album');
-    } else if (hasEPs) {
-      setReleaseTypeFilter('ep');
-    } else if (hasSingles) {
-      setReleaseTypeFilter('single');
-    } else {
-      // Fallback to first available type
-      const firstType = releases[0]?.releaseType;
-      if (firstType) setReleaseTypeFilter(firstType);
-    }
+    setReleaseTypeFilter('all');
   }, []);
 
   // Filter and sort charts


### PR DESCRIPTION
## Summary
Updated the artist discography filter to display all release types by default instead of intelligently selecting a single type based on available releases.

## Changes
- Changed initial `releaseTypeFilter` state from `'album'` to `'all'`
- Simplified `setSmartReleaseTypeFilter()` function to always set filter to `'all'` instead of implementing smart detection logic
- Removed conditional logic that prioritized albums, then EPs, then singles based on availability
- Updated inline comments to reflect the new behavior

## Rationale
This change provides a better user experience by showing the complete discography upfront rather than hiding release types. Users can now see all available releases immediately and use the filter controls to narrow down by type if desired, rather than having certain releases hidden by default.

https://claude.ai/code/session_01DV5DZPg9pX91pzbigfudzT