### PR TITLE
feat: move ALL filter to first position in discography filter pills

### DIFF
--- a/app.js
+++ b/app.js
@@ -22091,12 +22091,12 @@ React.createElement('div', {
             // Release type filter pills
             React.createElement('div', { className: 'flex gap-2 flex-wrap' },
               [
+                { value: 'all', label: 'All' },
                 { value: 'album', label: 'Studio Albums' },
                 { value: 'ep', label: 'EPs' },
                 { value: 'single', label: 'Singles' },
                 { value: 'live', label: 'Live' },
-                { value: 'compilation', label: 'Compilations' },
-                { value: 'all', label: 'All' }
+                { value: 'compilation', label: 'Compilations' }
               ].map(({ value, label }) => {
                 const searchFiltered = filterArtistReleases(artistReleases);
                 const count = value === 'all'


### PR DESCRIPTION
Reordered the filter pills so ALL appears first (leftmost) followed by Studio Albums, EPs, Singles, Live, and Compilations.

https://claude.ai/code/session_01DV5DZPg9pX91pzbigfudzT