### PR TITLE
fix: add drag handle at top of main content area

### DIFF
--- a/app.js
+++ b/app.js
@@ -19465,8 +19465,13 @@ useEffect(() => {
       // Main content area
       React.createElement('div', {
         ref: mainContentRef,
-        className: 'flex-1 flex flex-col overflow-hidden bg-white'
+        className: 'flex-1 flex flex-col overflow-hidden bg-white relative'
       },
+        // Draggable title bar area (space for macOS traffic lights) - mirrors sidebar drag area
+        React.createElement('div', {
+          className: 'h-8 drag flex-shrink-0 absolute top-0 left-0 right-0 z-10',
+          style: { pointerEvents: 'auto' }
+        }),
 
     // External Track Prompt Modal - refined styling
     showExternalPrompt && pendingExternalTrack && React.createElement('div', {


### PR DESCRIPTION
The main content area was missing a window drag region, so users couldn't drag the app window from above the content. Added an 8px tall drag area (matching the sidebar) as an absolute overlay at the top of the main content area.

https://claude.ai/code/session_01VV7Kx56MAu4NSDt3rj4AZ3