### PR TITLE
fix: consistent vertical spacing in playbar track info

### DIFF
--- a/app.js
+++ b/app.js
@@ -32500,7 +32500,7 @@ React.createElement('div', {
                   };
                   const currentIconColor = resolverIconColors[currentResolverId] || '#A855F7';
 
-                  return React.createElement('div', { className: 'flex items-center gap-1.5 mt-1' },
+                  return React.createElement('div', { className: 'flex items-center gap-1.5' },
                     // Custom resolver selector with icon
                     React.createElement('div', { className: 'relative no-drag' },
                       // Current resolver button (icon + dropdown chevron if multiple sources)


### PR DESCRIPTION
Remove extra margin-top from the resolver dropdown row so that the spacing between title/artist and artist/resolver is consistent.

https://claude.ai/code/session_01CvfRqnmvRuqiDHK57LMBLU