### PR TITLE
fix: stop HTML5 audio when skipping between resolvers

### DIFF
--- a/app.js
+++ b/app.js
@@ -7218,6 +7218,13 @@ const Parachord = () => {
     console.log('🎵 Playing track:', trackOrSource.title, 'by', trackOrSource.artist);
     setTrackLoading(true); // Show loading state in playbar
 
+    // Stop HTML5 Audio if playing (local files, SoundCloud) - do this first to prevent overlap
+    if (audioRef.current && !audioRef.current.paused) {
+      console.log('⏹️ Stopping HTML5 audio before new track');
+      audioRef.current.pause();
+      audioRef.current.currentTime = 0;
+    }
+
     // Stop any active browser playback before starting new track
     if (browserPlaybackActive && activeExtensionTabId) {
       console.log('⏹️ Stopping browser playback before playing new track');
@@ -8842,6 +8849,13 @@ const Parachord = () => {
         pollingRecoveryRef.current = null;
       }
 
+      // Stop HTML5 Audio if playing (local files, SoundCloud)
+      if (audioRef.current && !audioRef.current.paused) {
+        console.log('⏹️ Stopping HTML5 audio before next track');
+        audioRef.current.pause();
+        audioRef.current.currentTime = 0;
+      }
+
       // Notify scrobble manager that current track is ending
       if (window.scrobbleManager) {
         window.scrobbleManager.onTrackEnd();
@@ -9076,6 +9090,13 @@ const Parachord = () => {
     if (externalTrackIntervalRef.current) {
       clearInterval(externalTrackIntervalRef.current);
       externalTrackIntervalRef.current = null;
+    }
+
+    // Stop HTML5 Audio if playing (local files, SoundCloud)
+    if (audioRef.current && !audioRef.current.paused) {
+      console.log('⏹️ Stopping HTML5 audio before previous track');
+      audioRef.current.pause();
+      audioRef.current.currentTime = 0;
     }
     setIsExternalPlayback(false);
     setShowExternalPrompt(false);


### PR DESCRIPTION
Add audioRef cleanup to handlePlay, handleNext, and handlePrevious to ensure HTML5 Audio (used by SoundCloud and local files) is properly stopped when transitioning to/from tracks using different resolvers.

Previously, skipping from a SoundCloud track to a Spotify track (or vice versa) could cause audio overlap because the HTML5 Audio element wasn't explicitly paused during the transition.

https://claude.ai/code/session_019rLbSXxR86o93fA6owg3sR