### PR TITLE
Add configurable media key handling modes

### DIFF
--- a/app.js
+++ b/app.js
@@ -3320,6 +3320,9 @@ const Parachord = () => {
   const [soundcloudToken, setSoundcloudToken] = useState(null);
   const [soundcloudConnected, setSoundcloudConnected] = useState(false);
 
+  // Media key handling mode: 'always' | 'non-spotify' | 'never'
+  const [mediaKeyMode, setMediaKeyMode] = useState('always');
+
   // Meta Services state (Last.fm, ListenBrainz, etc.)
   const [metaServices, setMetaServices] = useState([]); // Loaded meta service plug-ins
   const [metaServiceConfigs, setMetaServiceConfigs] = useState({}); // { lastfm: { username, apiKey }, listenbrainz: { username, userToken } }
@@ -10624,6 +10627,24 @@ const Parachord = () => {
       saveCacheToStore();
     };
   }, []);
+
+  // Load media key mode setting on mount
+  useEffect(() => {
+    const loadMediaKeyMode = async () => {
+      if (window.electron?.mediaKeys) {
+        const mode = await window.electron.mediaKeys.getMode();
+        setMediaKeyMode(mode);
+      }
+    };
+    loadMediaKeyMode();
+  }, []);
+
+  // Notify main process when playback source changes (for 'non-spotify' media key mode)
+  useEffect(() => {
+    if (window.electron?.mediaKeys && currentTrack?.resolver) {
+      window.electron.mediaKeys.updatePlaybackSource(currentTrack.resolver);
+    }
+  }, [currentTrack?.resolver]);
 
   // Save last active view when it changes
   useEffect(() => {
@@ -31781,6 +31802,153 @@ useEffect(() => {
                       })
                     )
                   ),
+                ),
+
+                // Media Keys Section
+                React.createElement('div', {
+                  style: {
+                    backgroundColor: '#ffffff',
+                    border: '1px solid rgba(0, 0, 0, 0.06)',
+                    borderRadius: '12px',
+                    padding: '24px',
+                    boxShadow: '0 1px 3px rgba(0, 0, 0, 0.04)'
+                  }
+                },
+                  React.createElement('div', { style: { marginBottom: '16px' } },
+                    React.createElement('h3', {
+                      style: {
+                        fontSize: '11px',
+                        fontWeight: '600',
+                        color: '#9ca3af',
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.08em'
+                      }
+                    }, 'Media Keys'),
+                    React.createElement('p', {
+                      style: {
+                        fontSize: '12px',
+                        color: '#9ca3af',
+                        marginTop: '4px'
+                      }
+                    }, 'Control how Parachord responds to media keys')
+                  ),
+                  React.createElement('p', {
+                    style: {
+                      fontSize: '13px',
+                      color: '#6b7280',
+                      marginBottom: '20px',
+                      lineHeight: '1.6'
+                    }
+                  }, 'When using the Spotify plugin, Spotify also runs in the background and may capture media keys. Choose how Parachord should handle potential conflicts.'),
+                  // Radio options for media key mode
+                  React.createElement('div', { style: { display: 'flex', flexDirection: 'column', gap: '12px' } },
+                    // Always option
+                    React.createElement('label', {
+                      style: {
+                        display: 'flex',
+                        alignItems: 'flex-start',
+                        gap: '12px',
+                        padding: '12px',
+                        borderRadius: '8px',
+                        backgroundColor: mediaKeyMode === 'always' ? 'rgba(124, 58, 237, 0.08)' : 'rgba(0, 0, 0, 0.02)',
+                        cursor: 'pointer',
+                        border: mediaKeyMode === 'always' ? '1px solid rgba(124, 58, 237, 0.3)' : '1px solid transparent'
+                      }
+                    },
+                      React.createElement('input', {
+                        type: 'radio',
+                        name: 'mediaKeyMode',
+                        value: 'always',
+                        checked: mediaKeyMode === 'always',
+                        onChange: async (e) => {
+                          const mode = e.target.value;
+                          setMediaKeyMode(mode);
+                          if (window.electron?.mediaKeys) {
+                            await window.electron.mediaKeys.setMode(mode);
+                          }
+                        },
+                        style: { marginTop: '2px', accentColor: '#7c3aed' }
+                      }),
+                      React.createElement('div', null,
+                        React.createElement('p', { style: { fontSize: '13px', fontWeight: '500', color: '#374151' } }, 'Always capture'),
+                        React.createElement('p', { style: { fontSize: '12px', color: '#9ca3af', marginTop: '2px' } },
+                          'Parachord always handles media keys. May conflict with Spotify.'
+                        )
+                      )
+                    ),
+                    // Non-Spotify option
+                    React.createElement('label', {
+                      style: {
+                        display: 'flex',
+                        alignItems: 'flex-start',
+                        gap: '12px',
+                        padding: '12px',
+                        borderRadius: '8px',
+                        backgroundColor: mediaKeyMode === 'non-spotify' ? 'rgba(124, 58, 237, 0.08)' : 'rgba(0, 0, 0, 0.02)',
+                        cursor: 'pointer',
+                        border: mediaKeyMode === 'non-spotify' ? '1px solid rgba(124, 58, 237, 0.3)' : '1px solid transparent'
+                      }
+                    },
+                      React.createElement('input', {
+                        type: 'radio',
+                        name: 'mediaKeyMode',
+                        value: 'non-spotify',
+                        checked: mediaKeyMode === 'non-spotify',
+                        onChange: async (e) => {
+                          const mode = e.target.value;
+                          setMediaKeyMode(mode);
+                          if (window.electron?.mediaKeys) {
+                            await window.electron.mediaKeys.setMode(mode);
+                            // Update based on current playback source
+                            if (currentTrack?.resolver) {
+                              await window.electron.mediaKeys.updatePlaybackSource(currentTrack.resolver);
+                            }
+                          }
+                        },
+                        style: { marginTop: '2px', accentColor: '#7c3aed' }
+                      }),
+                      React.createElement('div', null,
+                        React.createElement('p', { style: { fontSize: '13px', fontWeight: '500', color: '#374151' } }, 'Only when not using Spotify'),
+                        React.createElement('p', { style: { fontSize: '12px', color: '#9ca3af', marginTop: '2px' } },
+                          'Let Spotify handle media keys when playing via Spotify Connect. Parachord handles them for other sources.'
+                        )
+                      )
+                    ),
+                    // Never option
+                    React.createElement('label', {
+                      style: {
+                        display: 'flex',
+                        alignItems: 'flex-start',
+                        gap: '12px',
+                        padding: '12px',
+                        borderRadius: '8px',
+                        backgroundColor: mediaKeyMode === 'never' ? 'rgba(124, 58, 237, 0.08)' : 'rgba(0, 0, 0, 0.02)',
+                        cursor: 'pointer',
+                        border: mediaKeyMode === 'never' ? '1px solid rgba(124, 58, 237, 0.3)' : '1px solid transparent'
+                      }
+                    },
+                      React.createElement('input', {
+                        type: 'radio',
+                        name: 'mediaKeyMode',
+                        value: 'never',
+                        checked: mediaKeyMode === 'never',
+                        onChange: async (e) => {
+                          const mode = e.target.value;
+                          setMediaKeyMode(mode);
+                          if (window.electron?.mediaKeys) {
+                            await window.electron.mediaKeys.setMode(mode);
+                          }
+                        },
+                        style: { marginTop: '2px', accentColor: '#7c3aed' }
+                      }),
+                      React.createElement('div', null,
+                        React.createElement('p', { style: { fontSize: '13px', fontWeight: '500', color: '#374151' } }, 'Never capture'),
+                        React.createElement('p', { style: { fontSize: '12px', color: '#9ca3af', marginTop: '2px' } },
+                          'Parachord never handles media keys. Use this if you prefer Spotify or other apps to control playback.'
+                        )
+                      )
+                    )
+                  )
                 ),
 
                 // Dialogs Section - Reset "Don't show again" preferences

--- a/preload.js
+++ b/preload.js
@@ -101,6 +101,13 @@ contextBridge.exposeInMainWorld('electron', {
     });
   },
 
+  // Media key settings
+  mediaKeys: {
+    getMode: () => ipcRenderer.invoke('media-keys-get-mode'),
+    setMode: (mode) => ipcRenderer.invoke('media-keys-set-mode', mode),
+    updatePlaybackSource: (source) => ipcRenderer.invoke('media-keys-update-playback-source', source)
+  },
+
   // Plugin operations
   resolvers: {
     loadBuiltin: () => ipcRenderer.invoke('resolvers-load-builtin'),


### PR DESCRIPTION
## Summary
This PR adds configurable media key handling to allow users to control how Parachord responds to system media keys, particularly when using the Spotify plugin which may also capture these keys.

## Key Changes

- **New media key modes**: Added three configurable modes for media key handling:
  - `always`: Parachord always captures media keys (default, may conflict with Spotify)
  - `non-spotify`: Parachord only captures media keys when not playing via Spotify (smart conflict avoidance)
  - `never`: Parachord never captures media keys (lets other apps handle them)

- **Settings UI**: Added a new "Media Keys" section in the settings panel with radio button options to select the preferred mode, with clear descriptions of each option's behavior

- **Dynamic registration**: Implemented IPC handlers in the main process to dynamically register/unregister media key shortcuts based on the selected mode, rather than requiring an app restart

- **Playback source tracking**: Added logic to detect the current playback source (resolver) and automatically adjust media key capture in `non-spotify` mode when switching between Spotify and other sources

- **Persistence**: Media key mode preference is saved to the electron store and restored on app startup

## Implementation Details

- State management: Added `mediaKeyMode` state in the React component with useEffect hooks to load settings on mount and track playback source changes
- IPC handlers: Three new handlers (`media-keys-set-mode`, `media-keys-get-mode`, `media-keys-update-playback-source`) manage communication between renderer and main process
- Preload API: Exposed media key methods through the electron context bridge for secure IPC access
- Smart mode: The `non-spotify` mode automatically unregisters media keys when Spotify is the active source and re-registers them for other sources

https://claude.ai/code/session_01M9yvFstRsbbTDvvUUnYfmb