### PR TITLE
fix: ensure Spotify pauses when quitting app

### DIFF
--- a/main.js
+++ b/main.js
@@ -781,9 +781,21 @@ const pauseSpotifyPlayback = async () => {
   }
 };
 
+let isQuitting = false;
+
 app.on('before-quit', async (event) => {
-  // Pause Spotify before quitting - this is more reliable than beforeunload
+  // Prevent multiple quit attempts and ensure we wait for cleanup
+  if (isQuitting) return;
+
+  // Prevent default quit to allow async cleanup
+  event.preventDefault();
+  isQuitting = true;
+
+  // Pause Spotify before quitting
   await pauseSpotifyPlayback();
+
+  // Now actually quit
+  app.exit(0);
 });
 
 app.on('window-all-closed', async () => {


### PR DESCRIPTION
The before-quit handler was async but Electron doesn't wait for the promise to resolve - the app would quit before pauseSpotifyPlayback() completed. Now we:
1. Prevent the default quit behavior
2. Wait for Spotify to pause
3. Then call app.exit(0) to actually quit

https://claude.ai/code/session_01GrytJ1xRu3kpJjJpEjhJHo