### PR TITLE
Fix Spotify authentication method name

### DIFF
--- a/app.js
+++ b/app.js
@@ -5794,7 +5794,7 @@ const Parachord = () => {
     if (!authStatus.authenticated) {
       // Trigger auth flow
       if (providerId === 'spotify') {
-        await window.electron.spotify.auth();
+        await window.electron.spotify.authenticate();
       }
       return;
     }


### PR DESCRIPTION
## Summary
Updated the Spotify authentication method call to use the correct method name in the Electron IPC bridge.

## Changes
- Changed `window.electron.spotify.auth()` to `window.electron.spotify.authenticate()` in the Parachord authentication flow

## Details
This fix ensures the authentication call matches the actual method name exposed by the Electron main process. The previous method name `auth()` was likely a typo or outdated reference, while `authenticate()` is the correct method signature for initiating Spotify OAuth flow.

https://claude.ai/code/session_011ohwcVrkj96TkaM8DR5jx7