### PR TITLE
Fix album art flashing during track transitions

### DIFF
--- a/app.js
+++ b/app.js
@@ -4310,6 +4310,12 @@ const Parachord = () => {
     const prevArt = playbarAlbumArtRef.current;
 
     if (newArt !== prevArt) {
+      // If new art is null but we had previous art, keep showing the previous art
+      // This prevents flashing placeholder when transitioning between tracks
+      if (!newArt && prevArt) {
+        return;
+      }
+
       // Album art changed - trigger crossfade
       setPlaybarAlbumArt({
         current: newArt,
@@ -33207,9 +33213,9 @@ useEffect(() => {
                   className: 'bg-gray-700 rounded flex items-center justify-center overflow-hidden relative',
                   style: { width: '61px', height: '61px' }
                 },
-                  // Previous album art (fading out)
+                  // Previous album art (fading out) - use stable key to prevent DOM remounting flash
                   playbarAlbumArt.previous && React.createElement('img', {
-                    key: 'prev-art-' + playbarAlbumArt.previous,
+                    key: 'playbar-prev-art',
                     src: playbarAlbumArt.previous,
                     alt: '',
                     draggable: false,
@@ -33219,9 +33225,9 @@ useEffect(() => {
                       transition: 'opacity 0.3s ease-out'
                     }
                   }),
-                  // Current album art (fading in)
+                  // Current album art (fading in) - use stable key to prevent DOM remounting flash
                   playbarAlbumArt.current && React.createElement('img', {
-                    key: 'curr-art-' + playbarAlbumArt.current,
+                    key: 'playbar-curr-art',
                     src: playbarAlbumArt.current,
                     alt: currentTrack.album,
                     draggable: false,


### PR DESCRIPTION
## Summary
This PR fixes a visual glitch where the album art placeholder would briefly flash when transitioning between tracks with different artwork.

## Key Changes
- **Prevent null art from clearing previous art**: Added a guard clause to prevent updating the album art display when the new art is null but previous art exists. This keeps the previous artwork visible during transitions instead of showing a placeholder.
- **Stabilize React keys for album art images**: Changed the image keys from dynamic values (`'prev-art-' + playbarAlbumArt.previous` and `'curr-art-' + playbarAlbumArt.current`) to stable static keys (`'playbar-prev-art'` and `'playbar-curr-art'`). This prevents unnecessary DOM remounting and the associated visual flash when the image source changes.

## Implementation Details
The fix addresses two related issues:
1. The logic now preserves the previous album art when transitioning to a track without artwork, allowing the crossfade animation to complete smoothly
2. Using stable keys ensures React reuses the same DOM nodes and simply updates the `src` attribute, rather than destroying and recreating the image elements, which was causing the flash effect

This results in a smoother, more polished user experience during track transitions.

https://claude.ai/code/session_01FDXGpj6XLmcpciZhozXsTz