### PR TITLE
Disable shuffle when exiting Collection Station

### DIFF
--- a/app.js
+++ b/app.js
@@ -20043,6 +20043,14 @@ const getCurrentPlaybackState = async () => {
             sources: ['spotify']
             // Note: _playbackContext is intentionally not set here since this is an external track change
           });
+
+          // If exiting Collection Station, turn off shuffle
+          if (playbackContext?.name === 'Collection Station') {
+            console.log('📻 Exiting Collection Station - turning off shuffle');
+            setShuffleMode(false);
+            originalQueueRef.current = null;
+            setPlaybackContext(null);
+          }
         } else {
           // Same track - update metadata while preserving original ID and playback context
           setCurrentTrack(prev => ({


### PR DESCRIPTION
## Summary
Added logic to automatically disable shuffle mode and clear the playback context when the user exits Collection Station during playback.

## Changes
- Added a check in the playback state handler to detect when exiting Collection Station
- When exiting Collection Station, the following actions are performed:
  - Shuffle mode is disabled via `setShuffleMode(false)`
  - The original queue reference is cleared (`originalQueueRef.current = null`)
  - The playback context is reset to null
- Added console logging for debugging purposes

## Implementation Details
This change ensures that shuffle state doesn't persist after leaving Collection Station, providing a cleaner user experience and preventing unexpected playback behavior when transitioning to other playback contexts.

https://claude.ai/code/session_01RbVbo48Vm2jL5LaKZqSHB5