### PR TITLE
perf: reduce stuck-at-zero threshold for faster track transitions

### DIFF
--- a/main.js
+++ b/main.js
@@ -80,7 +80,7 @@ const spotifyPoller = {
   POLL_INTERVAL: 20000, // 20 seconds - more reliable for background execution
   RECOVERY_INTERVAL: 30000, // 30 seconds for recovery
   MAX_ERRORS: 3,
-  MAX_STUCK_AT_ZERO: 3,
+  MAX_STUCK_AT_ZERO: 2, // Reduced from 3 for faster track transitions
 
   async start(token, trackUri, trackTitle, trackArtist) {
     console.log('🔄 [Main] Starting Spotify polling...');


### PR DESCRIPTION
Reduced MAX_STUCK_AT_ZERO from 3 to 2, cutting the maximum wait time when Spotify reports 0% progress from 60s to 40s. One confirmation poll still prevents false positives.

https://claude.ai/code/session_01RbVbo48Vm2jL5LaKZqSHB5