### PR TITLE
fix: chart songs resolution not triggering automatically

### DIFF
--- a/app.js
+++ b/app.js
@@ -29136,8 +29136,8 @@ useEffect(() => {
             },
             onScroll: handleChartsScroll,
             ref: (el) => {
-              if (el && chartsTab === 'songs') {
-                chartSongsScrollContainerRef.current = el;
+              chartSongsScrollContainerRef.current = el;
+              if (el && !chartSongsScrollContainerReady) {
                 setChartSongsScrollContainerReady(true);
               }
             }


### PR DESCRIPTION
Remove the chartsTab condition from scroll container ref callback. The ref should be set unconditionally so the IntersectionObserver can properly track visible songs regardless of tab state.

https://claude.ai/code/session_017Vzxbm6Eivoi15hcTUAYmJ