### PR TITLE
Fix playback state handling for SoundCloud and queue exhaustion

### DIFF
--- a/app.js
+++ b/app.js
@@ -6873,14 +6873,16 @@ const Parachord = () => {
   useEffect(() => {
     // Skip progress tracking for streaming tracks (Spotify) - they have their own polling
     // Skip for local files - they use HTML5 Audio with timeupdate event
+    // Skip for SoundCloud - also uses HTML5 Audio with timeupdate event
     // Skip for browser-based tracks (YouTube, Bandcamp) - they use extension events
     // Also skip if duration is 0 or missing to prevent infinite handleNext loop
     const isStreamingTrack = currentTrack?.sources?.spotify || currentTrack?.spotifyUri;
     const isLocalFile = currentTrack?.filePath || currentTrack?.sources?.localfiles;
+    const isSoundCloud = currentTrack?.sources?.soundcloud || currentTrack?._activeResolver === 'soundcloud';
     const isBrowserTrack = browserPlaybackActive || isExternalPlayback;
     const hasValidDuration = currentTrack?.duration && currentTrack.duration > 0;
 
-    if (isPlaying && audioContext && currentTrack && !isStreamingTrack && !isLocalFile && !isBrowserTrack && hasValidDuration) {
+    if (isPlaying && audioContext && currentTrack && !isStreamingTrack && !isLocalFile && !isSoundCloud && !isBrowserTrack && hasValidDuration) {
       const interval = setInterval(() => {
         const elapsed = (audioContext.currentTime - startTime);
         if (elapsed >= currentTrack.duration) {
@@ -9229,6 +9231,8 @@ const Parachord = () => {
 
       if (queue.length === 0) {
         console.log('No queue set, cannot go to next track');
+        // Set isPlaying to false since playback has ended
+        setIsPlaying(false);
         return;
       }
 
@@ -9240,6 +9244,8 @@ const Parachord = () => {
 
       if (nextTrackIndex === -1) {
         console.log('⚠️ No playable tracks in queue');
+        // Set isPlaying to false since playback has ended
+        setIsPlaying(false);
         return;
       }
 


### PR DESCRIPTION
## Summary
This PR fixes playback state management issues by properly handling SoundCloud tracks in progress tracking and ensuring the playing state is correctly updated when the queue is exhausted.

## Key Changes
- **SoundCloud progress tracking**: Added SoundCloud to the list of sources that should skip the progress tracking interval, since SoundCloud uses HTML5 Audio with timeupdate events (similar to local files)
- **Queue exhaustion handling**: Set `isPlaying` to `false` when the queue is empty or contains no playable tracks, preventing the player from remaining in a playing state when playback cannot continue

## Implementation Details
- SoundCloud detection checks both `currentTrack?.sources?.soundcloud` and `currentTrack?._activeResolver === 'soundcloud'` to ensure comprehensive coverage
- The playback state is now properly reset in two scenarios:
  1. When attempting to advance to the next track but the queue is empty
  2. When no playable tracks are found in the queue
- This prevents UI inconsistencies where the player appears to be playing but no audio is actually being produced

https://claude.ai/code/session_01PTZ4YTEAqftgvwnmFm7wen