### PR TITLE
Add SoundCloud icon support to ResolverIcon component

### DIFF
--- a/app.js
+++ b/app.js
@@ -863,6 +863,23 @@ const SERVICE_LOGO_PATHS = {
 
 // Helper to create resolver icon at any size
 const ResolverIcon = ({ resolverId, size = 14, fill = 'white' }) => {
+  // SoundCloud uses multi-element SVG matching assets/icons/soundcloud.svg
+  if (resolverId === 'soundcloud') {
+    return React.createElement('svg', {
+      viewBox: '0 0 64 64',
+      width: size,
+      height: size,
+      fill: fill,
+      style: { flexShrink: 0 }
+    },
+      React.createElement('rect', { x: '2', y: '28', width: '4', height: '16', rx: '2' }),
+      React.createElement('rect', { x: '10', y: '22', width: '4', height: '28', rx: '2' }),
+      React.createElement('rect', { x: '18', y: '16', width: '4', height: '40', rx: '2' }),
+      React.createElement('rect', { x: '26', y: '20', width: '4', height: '32', rx: '2' }),
+      React.createElement('rect', { x: '34', y: '24', width: '4', height: '24', rx: '2' }),
+      React.createElement('path', { d: 'M42 20c0-1.1.9-2 2-2h8c6.6 0 12 5.4 12 12s-5.4 12-12 12H44c-1.1 0-2-.9-2-2V20z' })
+    );
+  }
   const path = SERVICE_LOGO_PATHS[resolverId];
   if (!path) return null;
   return React.createElement('svg', {


### PR DESCRIPTION
## Summary
Added native SVG rendering support for the SoundCloud resolver icon in the ResolverIcon component, replacing the need for a separate SVG file reference.

## Changes
- Implemented inline SVG rendering for SoundCloud resolver icon using React.createElement
- The icon uses a multi-element design consisting of:
  - Five rounded rectangles of varying heights to create a waveform/equalizer effect
  - One path element for the circular play button on the right side
- Icon maintains the same viewBox (0 0 64 64) and styling as the original assets/icons/soundcloud.svg
- Respects the existing size and fill props for consistent styling with other resolver icons

## Implementation Details
- The SoundCloud icon check is placed at the beginning of the ResolverIcon component to handle it before falling back to the SERVICE_LOGO_PATHS lookup
- Uses flexShrink: 0 style to prevent icon squishing in flex layouts
- All rectangles use rx: '2' for rounded corners matching the original design
- The implementation is self-contained and doesn't require external SVG file imports

https://claude.ai/code/session_011Cf6KBg8SJdNLE9Lo4g4rc