### PR TITLE
fix: prevent Space key from triggering play/pause when typing in modals

### DIFF
--- a/app.js
+++ b/app.js
@@ -6496,11 +6496,7 @@ const Parachord = () => {
             searchInputRef.current?.focus();
             break;
           case 'play-pause':
-            if (isPlaying) {
-              handlePause();
-            } else if (currentTrack) {
-              handlePlay(currentTrack);
-            }
+            handlePlayPause();
             break;
           case 'next-track':
             handleNext(true);
@@ -7684,11 +7680,26 @@ const Parachord = () => {
     fetchMissingCovers();
   }, [activeView, playlists]);
 
-  // Keyboard shortcuts - Escape navigates back from search view
+  // Keyboard shortcuts - Escape navigates back from search view, Space for play/pause
   useEffect(() => {
     const handleKeyDown = (e) => {
       if (e.key === 'Escape' && activeView === 'search') {
         navigateBack();
+      }
+
+      // Space for play/pause - only when not typing in a text input
+      if (e.key === ' ' || e.code === 'Space') {
+        const activeElement = document.activeElement;
+        const isTyping = activeElement && (
+          activeElement.tagName === 'INPUT' ||
+          activeElement.tagName === 'TEXTAREA' ||
+          activeElement.isContentEditable
+        );
+
+        if (!isTyping) {
+          e.preventDefault(); // Prevent page scroll
+          handlePlayPauseRef.current?.();
+        }
       }
     };
 

--- a/main.js
+++ b/main.js
@@ -985,7 +985,7 @@ app.whenReady().then(() => {
       submenu: [
         {
           label: 'Play/Pause',
-          accelerator: 'Space',
+          // Space accelerator removed - handled in renderer to avoid triggering during text input
           click: () => mainWindow?.webContents.send('menu-action', 'play-pause')
         },
         {


### PR DESCRIPTION
The Space bar accelerator on the Play/Pause menu item was firing globally, even when typing in text inputs like the AI modal. This caused playback to skip forward/backward when pressing space while typing.

- Removed Space accelerator from the Playback menu in main process
- Added Space key handler in renderer that checks if user is typing
- Also fixed "handlePause is not defined" error by using handlePlayPause()

https://claude.ai/code/session_01QX82xNAr8K7cXhs2LFmkDb