### PR TITLE
feat: show 4 weeks of Weekly Jams on home page

### DIFF
--- a/app.js
+++ b/app.js
@@ -15721,9 +15721,9 @@ ${tracks}
 
       if (weeklyPlaylists.length === 0) return null;
 
-      // Get this week's and last week's playlists (first two most recent)
+      // Get recent weekly playlists (enough to fill the row on home page)
       const results = [];
-      for (let i = 0; i < Math.min(2, weeklyPlaylists.length); i++) {
+      for (let i = 0; i < Math.min(4, weeklyPlaylists.length); i++) {
         const weeklyJam = weeklyPlaylists[i];
         const playlistId = weeklyJam.playlist?.identifier?.split('/').pop();
         if (!playlistId) continue;
@@ -15731,7 +15731,8 @@ ${tracks}
         // Parse the date from the title to create a friendly label
         const title = weeklyJam.playlist?.title || 'Weekly Jam';
         const dateMatch = title.match(/(\d{4}-\d{2}-\d{2})/);
-        let weekLabel = i === 0 ? 'This Week' : 'Last Week';
+        // Generate week labels: This Week, Last Week, 2 Weeks Ago, 3 Weeks Ago
+        let weekLabel = i === 0 ? 'This Week' : i === 1 ? 'Last Week' : `${i} Weeks Ago`;
 
         results.push({
           id: playlistId,


### PR DESCRIPTION
Increased from 2 to 4 weeks to fill the row. Labels now show "This Week", "Last Week", "2 Weeks Ago", "3 Weeks Ago".

https://claude.ai/code/session_01EnDAdWyZxScbGrxvpXdyh2