### PR TITLE
fix: correct Apple Music resolver ID in auto-advance polling

### DIFF
--- a/app.js
+++ b/app.js
@@ -8595,7 +8595,7 @@ const Parachord = () => {
       } else {
         console.warn('⚠️ Main process polling not available');
       }
-    } else if (resolverId === 'apple-music' && track.appleMusicId) {
+    } else if (resolverId === 'applemusic' && track.appleMusicId) {
       // Apple Music native playback via MusicKit
       console.log(`🔄 Starting Apple Music playback polling via main process...`);
       console.log(`   Track: ${track.title} by ${track.artist}`);


### PR DESCRIPTION
The startAutoAdvancePolling function was checking for 'apple-music' but the actual resolver ID is 'applemusic' (no hyphen). This prevented the main process polling from starting for Apple Music playback, causing auto-advance to not work when a track finished.

https://claude.ai/code/session_01KzzKneVtFh4kPhXBE8bjGT