### PR TITLE
fix: correct syntax error in handlePlayPause from Apple Music changes

### DIFF
--- a/app.js
+++ b/app.js
@@ -9089,16 +9089,15 @@ const Parachord = () => {
 
     // Toggle local playback (demo audio fallback)
     if (!audioContext) return;
-      if (isPlaying) {
-        setIsPlaying(false);
-        if (currentSource) {
-          try { currentSource.stop(); setCurrentSource(null); } catch (e) {}
-        }
-      } else {
-        if (audioContext.state === 'suspended') await audioContext.resume();
-        setIsPlaying(true);
-        playDemoAudio(currentTrack);
+    if (isPlaying) {
+      setIsPlaying(false);
+      if (currentSource) {
+        try { currentSource.stop(); setCurrentSource(null); } catch (e) {}
       }
+    } else {
+      if (audioContext.state === 'suspended') await audioContext.resume();
+      setIsPlaying(true);
+      playDemoAudio(currentTrack);
     }
   };
 


### PR DESCRIPTION
Fixed indentation and removed orphaned closing brace that was left when refactoring the else block to use early returns.

https://claude.ai/code/session_01NXtrsLnGJHAiCPo1QdGWKe