### PR TITLE
Remove Apple Music from volume control support

### DIFF
--- a/app.js
+++ b/app.js
@@ -34205,7 +34205,8 @@ useEffect(() => {
             // For Spotify, only enable volume on Computer devices (desktop app)
             // TVs, speakers, and other devices don't respond to remote volume commands reliably
             const spotifyVolumeSupported = !isSpotify || spotifyDevice?.type === 'Computer';
-            const volumeSupported = !currentTrack || currentResolverId === 'localfiles' || currentResolverId === 'soundcloud' || (isSpotify && spotifyVolumeSupported) || isAppleMusic;
+            // Note: Apple Music volume not supported - MusicKit's ApplicationMusicPlayer only supports system-level volume
+            const volumeSupported = !currentTrack || currentResolverId === 'localfiles' || currentResolverId === 'soundcloud' || (isSpotify && spotifyVolumeSupported);
             const isDisabled = !volumeSupported || browserPlaybackActive || isExternalPlayback;
             const resolverOffset = currentResolverId ? (resolverVolumeOffsets[currentResolverId] || 0) : 0;
             const hasOffset = resolverOffset !== 0;
@@ -34253,6 +34254,9 @@ useEffect(() => {
                 }
                 if (isSpotify && spotifyDevice && spotifyDevice.type !== 'Computer') {
                   return `Volume control not available on ${spotifyDevice.name || spotifyDevice.type}`;
+                }
+                if (isAppleMusic) {
+                  return 'Volume control not available for Apple Music';
                 }
                 return 'Volume control not available';
               }


### PR DESCRIPTION
## Summary
This PR removes Apple Music from the list of services that support volume control and adds a specific user-facing message explaining why volume control is unavailable for Apple Music.

## Changes
- **Removed Apple Music from `volumeSupported` logic**: Apple Music was previously included in the volume support check, but MusicKit's ApplicationMusicPlayer only supports system-level volume control, not app-level volume adjustments
- **Added Apple Music-specific tooltip message**: When volume control is unavailable for Apple Music, users now see a clear message: "Volume control not available for Apple Music" instead of a generic message
- **Added clarifying code comment**: Documented why Apple Music volume is not supported for future maintainers

## Implementation Details
The change ensures that:
1. The volume control UI element is properly disabled when Apple Music is the active service
2. Users receive specific feedback about why the control is unavailable, improving UX clarity
3. The logic aligns with MusicKit's actual capabilities, which only expose system-level volume control rather than application-level control

https://claude.ai/code/session_01VqVWkoDpo7dWdmtbWbfh4n