### PR TITLE
fix: show Applications folder icon in DMG installer

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,20 @@
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist"
     },
+    "dmg": {
+      "contents": [
+        {
+          "x": 130,
+          "y": 220
+        },
+        {
+          "x": 410,
+          "y": 220,
+          "type": "link",
+          "path": "/Applications"
+        }
+      ]
+    },
     "win": {
       "icon": "assets/icons/icon.ico",
       "target": [


### PR DESCRIPTION
Add dmg.contents configuration to display the actual Applications folder icon instead of a dashed outline, making it clearer for users to drag the app to install.

https://claude.ai/code/session_01FdaxWe8FQojpXxPyCtpYMs