### PR TITLE
fix: add window config to DMG for proper icon display

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,14 +98,18 @@
     "dmg": {
       "icon": "assets/icons/icon.icns",
       "iconSize": 80,
+      "window": {
+        "width": 540,
+        "height": 380
+      },
       "contents": [
         {
           "x": 130,
-          "y": 220
+          "y": 180
         },
         {
           "x": 410,
-          "y": 220,
+          "y": 180,
           "type": "link",
           "path": "/Applications"
         }


### PR DESCRIPTION
Add explicit window dimensions to DMG config which may help Finder properly render the Applications folder icon.

https://claude.ai/code/session_01FdaxWe8FQojpXxPyCtpYMs