### PR TITLE
fix: merge resolved sources in handlePlay for proper resolver priority

### DIFF
--- a/app.js
+++ b/app.js
@@ -7737,6 +7737,14 @@ const Parachord = () => {
     let sourceToPlay = trackOrSource;
 
     if (trackOrSource.sources && typeof trackOrSource.sources === 'object' && !Array.isArray(trackOrSource.sources)) {
+      // Merge in resolved sources from trackSources state if available
+      // This ensures we have all available sources including those resolved in background
+      const resolvedSources = trackSources[trackOrSource.id] || {};
+      if (Object.keys(resolvedSources).length > 0) {
+        trackOrSource = { ...trackOrSource, sources: { ...trackOrSource.sources, ...resolvedSources } };
+        sourceToPlay = trackOrSource;
+      }
+
       // We have a track with multiple sources - select the best one
       let availableResolvers = Object.keys(trackOrSource.sources);
 
@@ -28453,7 +28461,8 @@ useEffect(() => {
                       const tracksAfter = sorted.slice(index + 1);
                       const context = { type: 'library', name: 'Collection' };
                       setQueueWithContext(tracksAfter, context);
-                      handlePlay(track);
+                      // Pass track with merged sources (original + resolved) so handlePlay can use all available resolvers
+                      handlePlay({ ...track, sources: effectiveSources });
                     },
                     onContextMenu: (e) => {
                       e.preventDefault();


### PR DESCRIPTION
When playing a track from Collection, the resolved sources (like Apple Music) were not being passed to handlePlay, causing it to only use the original track sources (like localfiles). Now:
1. Collection view passes effectiveSources when playing a track
2. handlePlay merges sources from trackSources state as a fallback

This ensures the highest priority resolver (based on user's settings) is used.

https://claude.ai/code/session_01FdaxWe8FQojpXxPyCtpYMs