### PR TITLE
Improve Apple Music playback detection and resolver rate limiting

### DIFF
--- a/native/musickit-helper/Sources/main.swift
+++ b/native/musickit-helper/Sources/main.swift
@@ -237,13 +237,18 @@ class MusicKitBridge {
             "status": playbackStatusString(state.playbackStatus),
             "position": player.playbackTime
         ]
-        // Include current song ID if available (for detecting track changes)
+        // Include current song ID and duration if available (for detecting track changes and end-of-track)
         // Note: entry.id is the queue entry ID, not the song catalog ID
         // We need to get the song's catalog ID from the underlying item
         if let entry = player.queue.currentEntry {
-            // Try to get the song's catalog ID from the entry's item
+            // Try to get the song's catalog ID and duration from the entry's item
             if let song = entry.item as? Song {
                 result["songId"] = song.id.rawValue
+                result["songTitle"] = song.title
+                // Include duration if available (in seconds)
+                if let duration = song.duration {
+                    result["duration"] = duration
+                }
             } else {
                 // Fall back to entry title for comparison (less reliable but better than nothing)
                 result["songTitle"] = entry.title


### PR DESCRIPTION
## Summary
This PR improves the reliability of Apple Music playback detection and implements proper rate limiting for the iTunes API resolver to prevent hitting API limits during batch track resolution.

## Key Changes

### Apple Music Playback Detection (main.js)
- **Added playback confirmation logic**: Tracks whether the expected song has actually started playing before detecting song changes, preventing false positives during track transitions
- **Improved end-of-track detection**: Now distinguishes between user pauses and natural track endings by checking if playback stopped near the end of the track
- **Enhanced duration handling**: Uses duration from MusicKit's Song object when available, improving accuracy of progress tracking
- **Better polling logic**: Adds 1.5s delay before first poll to give MusicKit time to start the new track
- **Fallback detection**: Added position-based end-of-track detection as a safety net

### Swift Helper Updates (musickit-helper)
- **Extended state reporting**: Now includes song title and duration in polling responses
- **Better track identification**: Provides both song ID and title for more reliable track change detection

### Resolver Rate Limiting (app.js)
- **Separated resolver processing**: iTunes/Apple Music resolvers now process sequentially with 500ms delays between requests, while other resolvers (Spotify, etc.) process in parallel
- **Configurable delays**: Added `ITUNES_DELAY_MS` constant for easy tuning of rate limit compliance
- **Increased batch delays**: Raised inter-batch delay from 100ms to 200ms for better API courtesy
- **Code cleanup**: Simplified conditional logic and improved code readability

### UI/UX Improvements
- **Fixed playlist cover fetching**: Now fetches covers on both playlists and home views
- **Improved playlist navigation**: Changed direct state setting to use `loadPlaylist()` function for consistent behavior
- **Fixed tutorial state persistence**: Uses refs to avoid stale closures when saving resolver settings and order

## Implementation Details
- The playback confirmation mechanism prevents the poller from triggering song-changed events while MusicKit is still transitioning between tracks
- Rate limiting for iTunes API respects the ~20 req/min limit by spacing requests 500ms apart
- The distinction between paused-at-end and user-pause prevents unwanted track advancement when users manually pause playback

https://claude.ai/code/session_01M7XkSD9hYLvYcJYDvnFAmh