### PR TITLE
Add skeleton loaders and update color scheme for music UI

### DIFF
--- a/app.js
+++ b/app.js
@@ -28223,7 +28223,7 @@ useEffect(() => {
                       },
                         React.createElement('div', {
                           className: 'w-full h-full grid grid-cols-2 grid-rows-2',
-                          style: { background: 'linear-gradient(135deg, #FFF8E1 0%, #FFECB3 100%)' }
+                          style: { background: 'linear-gradient(135deg, #e0e7ff 0%, #c7d2fe 100%)' }
                         },
                           weeklyJamCovers[jam.id]?.slice(0, 4).map((url, i) =>
                             React.createElement('img', {
@@ -28236,10 +28236,10 @@ useEffect(() => {
                             React.createElement('div', {
                               key: `placeholder-${i}`,
                               className: 'w-full h-full flex items-center justify-center',
-                              style: { backgroundColor: i % 2 === 0 ? '#FFE082' : '#FFECB3' }
+                              style: { backgroundColor: i % 2 === 0 ? '#c7d2fe' : '#e0e7ff' }
                             },
                               i === 0 && React.createElement('svg', {
-                                className: 'w-12 h-12 text-orange-400',
+                                className: 'w-12 h-12 text-indigo-300',
                                 fill: 'none',
                                 viewBox: '0 0 24 24',
                                 stroke: 'currentColor'


### PR DESCRIPTION
## Summary
This PR improves the user experience by adding skeleton loading states for the Top Artists and Top Albums tabs, and updates the color scheme from warm yellow/orange tones to cool indigo/purple tones throughout the music interface.

## Key Changes
- **Skeleton Loaders**: Replaced empty loading states with animated skeleton card grids for both Top Artists and Top Albums tabs, providing visual feedback while data loads
  - Top Artists: 12-column responsive grid with shimmer animation
  - Top Albums: 2-5 column responsive grid with staggered shimmer animations
- **Color Scheme Update**: Changed from yellow/orange palette to indigo/purple palette
  - Weekly jam cover gradient: `#FFF8E1/#FFECB3` → `#e0e7ff/#c7d2fe`
  - Placeholder backgrounds: `#FFE082/#FFECB3` → `#c7d2fe/#e0e7ff`
  - Icon color: `text-orange-400` → `text-indigo-300`

## Implementation Details
- Skeleton loaders use CSS gradient shimmer animations with staggered delays (`i * 50ms`) for a cascading effect
- Both skeleton grids maintain the same responsive layout as their respective content grids
- Skeleton cards include placeholder elements for images and text to match the final layout
- All animations use the existing `animate-shimmer` class with `backgroundSize: '200% 100%'`

https://claude.ai/code/session_01C2mkQme1hKumJ5Q3jjUa8M