### PR TITLE
Increase resolver icons container width from 90px to 140px

### DIFF
--- a/app.js
+++ b/app.js
@@ -1444,7 +1444,7 @@ const VirtualizedQueueList = React.memo(({
       // Resolver icons
       React.createElement('div', {
         className: 'flex items-center gap-1 justify-end',
-        style: { width: '90px', flexShrink: 0, minHeight: '20px' }
+        style: { width: '140px', flexShrink: 0, minHeight: '20px' }
       },
         isError ?
           React.createElement('button', {


### PR DESCRIPTION
## Summary
Adjusted the width of the resolver icons container in the VirtualizedQueueList component to provide more space for icon display and prevent layout issues.

## Changes
- Increased the `width` style property of the resolver icons container from `90px` to `140px`
- This affects the flex container that holds resolver status icons in the queue list

## Details
The resolver icons section was constrained to 90px, which may have caused icons to overflow or be cramped. Expanding this to 140px provides adequate spacing for proper icon rendering and improves the visual layout of the queue list items.

https://claude.ai/code/session_012hDawq75cpn8QgUJyU9oe9