### PR TITLE
Improve track duration handling with fallback defaults

### DIFF
--- a/app.js
+++ b/app.js
@@ -6061,7 +6061,7 @@ const Parachord = () => {
       title: track.title,
       artist: track.artist,
       album: track.album || '',
-      duration: track.duration || 0,
+      duration: track.duration || 180, // Default to 3 minutes if duration not scraped
       // These will be resolved by the resolution system
       source: null,
       resolvedBy: null,

--- a/parachord-extension/content.js
+++ b/parachord-extension/content.js
@@ -743,12 +743,25 @@
             const trackName = titleEl.textContent.trim();
             const trackArtist = artistEl ? artistEl.textContent.trim() : '';
 
+            // Extract duration from playlist item
+            let duration = 0;
+            const durationEl = item.querySelector('.time') ||
+                              item.querySelector('.track_time') ||
+                              item.querySelector('[class*="duration"]') ||
+                              item.querySelector('[class*="time"]');
+            if (durationEl) {
+              const match = durationEl.textContent.trim().match(/(\d+):(\d+)/);
+              if (match) {
+                duration = parseInt(match[1]) * 60 + parseInt(match[2]);
+              }
+            }
+
             if (trackName && trackArtist) {
               tracks.push({
                 title: trackName,
                 artist: trackArtist,
                 album: '',
-                duration: 0,
+                duration: duration,
                 position: index + 1,
                 url: trackUrl // Include Bandcamp URL if found
               });


### PR DESCRIPTION
## Summary
Enhanced track duration extraction and handling to provide better fallback values when duration data is unavailable. This improves the user experience by ensuring tracks have reasonable default durations instead of zero values.

## Key Changes
- **Content script enhancement**: Added robust duration extraction logic in the Bandcamp playlist scraper that attempts to parse duration from multiple possible DOM selectors (`.time`, `.track_time`, `[class*="duration"]`, `[class*="time"]`)
- **Duration parsing**: Implemented regex-based parsing to convert MM:SS format to total seconds
- **Fallback default**: Changed the default duration from 0 to 180 seconds (3 minutes) when duration cannot be scraped or is not available
- **Consistency**: Updated both the scraper output and the main app's track object creation to use the improved duration handling

## Implementation Details
- The duration extraction attempts multiple CSS selectors to handle variations in HTML structure across different Bandcamp pages
- Duration values are converted from MM:SS string format to total seconds for consistent internal representation
- The 3-minute default provides a reasonable estimate for typical music tracks when actual duration data is unavailable

https://claude.ai/code/session_01Pac1srwh2Kigrc4WqnBuks