### PR TITLE
Fix event listener cleanup and add previous track support

### DIFF
--- a/main.js
+++ b/main.js
@@ -1240,6 +1240,11 @@ app.whenReady().then(() => {
           click: () => mainWindow?.webContents.send('menu-action', 'play-pause')
         },
         {
+          label: 'Previous Track',
+          accelerator: 'CmdOrCtrl+Left',
+          click: () => mainWindow?.webContents.send('menu-action', 'previous-track')
+        },
+        {
           label: 'Next Track',
           accelerator: 'CmdOrCtrl+Right',
           click: () => mainWindow?.webContents.send('menu-action', 'next-track')

--- a/preload.js
+++ b/preload.js
@@ -108,9 +108,9 @@ contextBridge.exposeInMainWorld('electron', {
 
   // Media key handlers
   onMediaKey: (callback) => {
-    ipcRenderer.on('media-key', (event, action) => {
-      callback(action);
-    });
+    const handler = (event, action) => callback(action);
+    ipcRenderer.on('media-key', handler);
+    return () => ipcRenderer.removeListener('media-key', handler);
   },
 
   // Media key settings
@@ -122,9 +122,9 @@ contextBridge.exposeInMainWorld('electron', {
 
   // Menu action handlers
   onMenuAction: (callback) => {
-    ipcRenderer.on('menu-action', (event, action) => {
-      callback(action);
-    });
+    const handler = (event, action) => callback(action);
+    ipcRenderer.on('menu-action', handler);
+    return () => ipcRenderer.removeListener('menu-action', handler);
   },
 
   // Auto-updater


### PR DESCRIPTION
## Summary
This PR improves event listener management and adds support for previous track navigation via keyboard shortcuts and hardware media keys.

## Key Changes
- **Fixed memory leaks**: Updated `onMenuAction` and `onMediaKey` IPC handlers in preload.js to return cleanup functions that properly remove event listeners, preventing duplicate listeners from accumulating
- **Refactored menu action handler**: Simplified the useEffect in app.js by using early return pattern and properly handling cleanup
- **Added previous track support**: 
  - New menu action `previous-track` with `CmdOrCtrl+Left` keyboard shortcut in main.js
  - New media key handler for `previous` action in app.js
- **Improved state management**: Changed from direct state dependencies (`isPlaying`, `currentTrack`) to refs (`currentTrackRef`, `currentQueueRef`, `handlePlayPauseRef`, `handleNextRef`, `handlePreviousRef`) to avoid stale closures and unnecessary effect re-runs
- **Separated concerns**: Split media key handling into its own useEffect hook for better code organization

## Implementation Details
- The menu action and media key handlers now properly return cleanup functions that call `ipcRenderer.removeListener()`, ensuring listeners are removed when the component unmounts or dependencies change
- Changed the menu action useEffect dependency array from `[isPlaying, currentTrack]` to `[]` since handlers now use refs to access current values
- Added a new dedicated useEffect for hardware media key handling with proper cleanup
- The `export-playlist` action now uses refs to get current track/queue values instead of relying on closure state

https://claude.ai/code/session_01UPSZEgRe1m3qgLYoM2JuUF