### PR TITLE
fix: remove drop-shadow and shimmer to fix pixelated wordmark edges

### DIFF
--- a/app.js
+++ b/app.js
@@ -23191,12 +23191,11 @@ useEffect(() => {
     !cacheLoaded ? React.createElement('div', {
       className: 'flex-1 flex flex-col items-center justify-center loading-screen'
     },
-      // Wordmark container with shimmer overlay
+      // Wordmark container
       React.createElement('div', {
-        className: 'loading-wordmark relative'
+        className: 'loading-wordmark'
       },
-        React.createElement(ParachordWordmark, { fill: '#7c3aed', height: 52 }),
-        React.createElement('div', { className: 'loading-shimmer-overlay' })
+        React.createElement(ParachordWordmark, { fill: '#7c3aed', height: 52 })
       ),
       // Animated loading dots
       React.createElement('div', {

--- a/index.html
+++ b/index.html
@@ -113,15 +113,6 @@
       }
     }
 
-    @keyframes loadingShimmer {
-      0% {
-        background-position: -200% center;
-      }
-      100% {
-        background-position: 200% center;
-      }
-    }
-
     .loading-screen {
       background: radial-gradient(circle at center, #ffffff 0%, #f9fafb 70%, #f3f4f6 100%);
     }
@@ -131,25 +122,7 @@
     }
 
     .loading-wordmark svg {
-      filter: drop-shadow(0 4px 12px rgba(124, 58, 237, 0.15));
-    }
-
-    .loading-shimmer-overlay {
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      background: linear-gradient(
-        90deg,
-        transparent 0%,
-        rgba(255, 255, 255, 0.6) 50%,
-        transparent 100%
-      );
-      background-size: 200% 100%;
-      animation: loadingShimmer 2s ease-in-out infinite;
-      animation-delay: 0.7s;
-      pointer-events: none;
+      display: block;
     }
 
     .loading-dot {


### PR DESCRIPTION
The CSS filter and overlay were causing rendering artifacts on the SVG wordmark. Simplified to clean SVG rendering with just the entrance animation and pulsing dots.

https://claude.ai/code/session_01SpGU98M8FyHLk8BxtdUpPx