### PR TITLE
style: use playbar gray-800 color for loading wordmark

### DIFF
--- a/app.js
+++ b/app.js
@@ -23195,7 +23195,7 @@ useEffect(() => {
       React.createElement('div', {
         className: 'loading-wordmark'
       },
-        React.createElement(ParachordWordmark, { fill: '#7c3aed', height: 52 })
+        React.createElement(ParachordWordmark, { fill: '#1f2937', height: 52 })
       ),
       // Animated loading dots
       React.createElement('div', {

--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@
       width: 6px;
       height: 6px;
       border-radius: 50%;
-      background-color: #a78bfa;
+      background-color: #6b7280;
     }
 
     .loading-dot:nth-child(1) { animation: loadingDotPulse 1.4s ease-in-out infinite; }


### PR DESCRIPTION
Change wordmark fill from purple (#7c3aed) to gray-800 (#1f2937) to match the playbar's blue-gray color scheme. Also update loading dots to gray-500 (#6b7280) for consistency.

https://claude.ai/code/session_01SpGU98M8FyHLk8BxtdUpPx