### PR TITLE
Persist auto-pinned friend IDs to storage

### DIFF
--- a/app.js
+++ b/app.js
@@ -8276,6 +8276,13 @@ const Parachord = () => {
     }
   }, [pinnedFriendIds, cacheLoaded]);
 
+  // Persist auto-pinned friend IDs to storage (only after cache is loaded to avoid overwriting)
+  useEffect(() => {
+    if (cacheLoaded && window.electron?.store) {
+      window.electron.store.set('autoPinnedFriendIds', autoPinnedFriendIds);
+    }
+  }, [autoPinnedFriendIds, cacheLoaded]);
+
   // Persist AI include history preference (only after cache is loaded to avoid overwriting)
   useEffect(() => {
     if (cacheLoaded && window.electron?.store) {
@@ -11883,6 +11890,14 @@ const Parachord = () => {
         const dedupedIds = [...new Set(savedPinnedFriendIds)];
         setPinnedFriendIds(dedupedIds);
         console.log(`📌 Loaded ${dedupedIds.length} pinned friends from storage`);
+      }
+
+      const savedAutoPinnedFriendIds = await window.electron.store.get('autoPinnedFriendIds');
+      if (savedAutoPinnedFriendIds && Array.isArray(savedAutoPinnedFriendIds)) {
+        // Dedupe in case duplicates were saved
+        const dedupedIds = [...new Set(savedAutoPinnedFriendIds)];
+        setAutoPinnedFriendIds(dedupedIds);
+        console.log(`📌 Loaded ${dedupedIds.length} auto-pinned friends from storage`);
       }
 
       // Load volume normalization offsets


### PR DESCRIPTION
## Summary
Add persistence for auto-pinned friend IDs to electron store, allowing the auto-pinned state to be maintained across app sessions.

## Changes
- Added a new `useEffect` hook to persist `autoPinnedFriendIds` to storage whenever the state changes (only after cache is loaded to prevent overwriting)
- Added logic to load saved `autoPinnedFriendIds` from storage during app initialization
- Implemented deduplication of loaded IDs to prevent duplicates from being stored
- Added console logging for debugging purposes

## Implementation Details
- The persistence follows the same pattern as the existing `pinnedFriendIds` persistence
- The cache loaded check ensures we don't overwrite stored data during initial app load
- Deduplication uses `Set` to ensure only unique friend IDs are stored and loaded
- The feature integrates with the existing electron store mechanism

https://claude.ai/code/session_01JgLY3uJk7xi2g1fxhQ6Wod