### PR TITLE
feat: add workflow to sync browser extension to dedicated repo

### DIFF
--- a/.github/workflows/sync-repos.yml
+++ b/.github/workflows/sync-repos.yml
@@ -1,0 +1,95 @@
+name: Sync to Dedicated Repos
+
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - 'parachord-extension/**'
+  workflow_dispatch:
+    inputs:
+      sync_extension:
+        description: 'Sync browser extension'
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  sync-browser-extension:
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' && github.event.inputs.sync_extension == 'true' ||
+      github.event_name == 'push'
+
+    steps:
+      - name: Checkout main repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for extension changes
+        id: check_changes
+        if: github.event_name == 'push'
+        run: |
+          # Get the list of changed files
+          CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "")
+
+          # Check if any extension files changed
+          if echo "$CHANGED_FILES" | grep -q "^parachord-extension/"; then
+            echo "extension_changed=true" >> $GITHUB_OUTPUT
+            echo "Extension files changed:"
+            echo "$CHANGED_FILES" | grep "^parachord-extension/"
+          else
+            echo "extension_changed=false" >> $GITHUB_OUTPUT
+            echo "No extension files changed"
+          fi
+
+      - name: Sync to parachord-browser-extension repo
+        if: |
+          github.event_name == 'workflow_dispatch' ||
+          steps.check_changes.outputs.extension_changed == 'true'
+        env:
+          SYNC_TOKEN: ${{ secrets.REPO_SYNC_TOKEN }}
+        run: |
+          if [ -z "$SYNC_TOKEN" ]; then
+            echo "::error::REPO_SYNC_TOKEN secret is not set. Please add a personal access token with repo scope."
+            exit 1
+          fi
+
+          # Configure git
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Clone the target repo
+          TARGET_REPO="https://x-access-token:${SYNC_TOKEN}@github.com/Parachord/parachord-browser-extension.git"
+          git clone "$TARGET_REPO" target-repo
+
+          # Get the source commit info for the sync commit message
+          SOURCE_COMMIT=$(git rev-parse --short HEAD)
+          SOURCE_MSG=$(git log -1 --pretty=format:"%s")
+
+          # Remove old files from target (except .git)
+          cd target-repo
+          find . -mindepth 1 -maxdepth 1 ! -name '.git' ! -name '.github' -exec rm -rf {} +
+
+          # Copy extension files to target
+          cp -r ../parachord-extension/* .
+
+          # Check if there are changes to commit
+          if git diff --quiet && git diff --staged --quiet; then
+            echo "No changes to sync"
+            exit 0
+          fi
+
+          # Stage and commit
+          git add -A
+          git commit -m "Sync from parachord monorepo
+
+Source commit: $SOURCE_COMMIT
+Original message: $SOURCE_MSG
+
+Automated sync from https://github.com/Parachord/parachord"
+
+          # Push changes
+          git push origin main || git push origin master
+
+          echo "Successfully synced browser extension to dedicated repo"

--- a/docs/development/REPO_SYNC.md
+++ b/docs/development/REPO_SYNC.md
@@ -1,0 +1,75 @@
+# Repository Sync
+
+This monorepo contains components that are also published to dedicated repositories for standalone distribution. Changes made here are automatically synced to those repos.
+
+## Synced Components
+
+| Component | Source Path | Dedicated Repo |
+|-----------|-------------|----------------|
+| Browser Extension | `parachord-extension/` | [Parachord/parachord-browser-extension](https://github.com/Parachord/parachord-browser-extension) |
+
+## How It Works
+
+The `.github/workflows/sync-repos.yml` workflow automatically syncs changes:
+
+1. **On push to main/master**: If any files in the synced paths change, the workflow triggers
+2. **Manual dispatch**: Can be triggered manually from the Actions tab
+
+The workflow:
+- Detects which files changed
+- Clones the target repo
+- Copies updated files from the source path
+- Commits with a reference to the source commit
+- Pushes to the dedicated repo
+
+## Setup Requirements
+
+### REPO_SYNC_TOKEN Secret
+
+A Personal Access Token (PAT) with `repo` scope must be added as a repository secret named `REPO_SYNC_TOKEN`.
+
+To create the token:
+1. Go to GitHub Settings > Developer settings > Personal access tokens > Tokens (classic)
+2. Generate a new token with `repo` scope
+3. Add it as a repository secret in this repo's Settings > Secrets and variables > Actions
+
+### Target Repository Setup
+
+The dedicated repos should:
+1. Exist and be accessible with the REPO_SYNC_TOKEN
+2. Have a `main` or `master` branch
+3. Allow pushes from the token owner
+
+## Manual Sync
+
+To manually trigger a sync:
+1. Go to Actions > Sync to Dedicated Repos
+2. Click "Run workflow"
+3. Select which components to sync
+4. Click "Run workflow"
+
+## Adding New Synced Components
+
+To add a new component to sync:
+
+1. Add a new path filter in `sync-repos.yml`:
+   ```yaml
+   paths:
+     - 'parachord-extension/**'
+     - 'new-component/**'  # Add new path
+   ```
+
+2. Add a new job for the component (copy the `sync-browser-extension` job and modify paths/repo)
+
+3. Update this documentation
+
+## Troubleshooting
+
+### "REPO_SYNC_TOKEN secret is not set"
+Add the PAT secret as described in Setup Requirements.
+
+### "No changes to sync"
+The target repo already has the same content. This is normal if the sync already ran.
+
+### Push fails with 403
+The REPO_SYNC_TOKEN doesn't have permission to push to the target repo. Ensure the token has `repo` scope and the owner has write access to the target repo.


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically syncs changes from parachord-extension/ to the Parachord/parachord-browser-extension repo when changes are pushed to main/master.

Requires REPO_SYNC_TOKEN secret to be configured with repo scope.

https://claude.ai/code/session_018BRBt49JwVT1UZHSzCxZRc