### PR TITLE
Fix play button state when queue is exhausted or empty

### DIFF
--- a/app.js
+++ b/app.js
@@ -10238,6 +10238,9 @@ const Parachord = () => {
 
       if (queue.length === 0) {
         console.log('No queue set, cannot go to next track');
+        // Reset play button when queue is exhausted
+        setIsPlaying(false);
+        isPlayingRef.current = false;
         return;
       }
 
@@ -10249,6 +10252,9 @@ const Parachord = () => {
 
       if (nextTrackIndex === -1) {
         console.log('⚠️ No playable tracks in queue');
+        // Reset play button when no playable tracks remain
+        setIsPlaying(false);
+        isPlayingRef.current = false;
         return;
       }
 


### PR DESCRIPTION
## Summary
Fixed an issue where the play button remained in the "playing" state when the queue was exhausted or contained no playable tracks. The player now correctly resets the play state in these scenarios.

## Changes
- Reset `isPlaying` state and `isPlayingRef` reference when queue is empty and next track cannot be played
- Reset `isPlaying` state and `isPlayingRef` reference when no playable tracks remain in the queue
- Both state updates ensure UI and internal ref stay synchronized

## Implementation Details
The fix updates both the React state (`setIsPlaying(false)`) and the ref (`isPlayingRef.current = false`) to maintain consistency between the UI and the internal playback state. This prevents the play button from appearing active when playback has actually stopped due to queue exhaustion.

https://claude.ai/code/session_01WvPwrCTmXN7cndpwUWuWvC