### PR TITLE
Exclude native build artifacts from package distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,9 @@
       "!npm-debug.log",
       "!dist",
       "!**/*.md",
-      "!collection.json"
+      "!collection.json",
+      "!native/**/.build",
+      "!native/**/.swiftpm"
     ],
     "asar": false,
     "afterSign": "scripts/notarize.js",


### PR DESCRIPTION
## Summary
Updated the package distribution configuration to exclude native build artifacts from the final package, reducing package size and preventing unnecessary files from being included.

## Changes
- Added `!native/**/.build` to exclude Swift build directories
- Added `!native/**/.swiftpm` to exclude Swift Package Manager cache directories

## Details
These exclusions prevent intermediate build artifacts and package manager caches from native modules from being included in the distributed package. This is consistent with the existing pattern of excluding build outputs and configuration files (like `dist`, `collection.json`, and markdown files).

https://claude.ai/code/session_015D3ToUBUy5FGYAz4v52wQ2