### PR TITLE
Skip macOS notarization for pull request builds

### DIFF
--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -16,6 +16,13 @@ exports.default = async function notarizing(context) {
     return;
   }
 
+  // Skip notarization for pull request builds
+  // electron-builder skips code signing for PRs, so notarization would fail
+  if (process.env.GITHUB_EVENT_NAME === 'pull_request') {
+    console.log('Skipping notarization: pull request build (code signing was skipped)');
+    return;
+  }
+
   // Check for required environment variables
   const appleId = process.env.APPLE_ID;
   const appleIdPassword = process.env.APPLE_APP_SPECIFIC_PASSWORD;


### PR DESCRIPTION
## Summary
Added a check to skip macOS notarization during pull request builds, preventing notarization failures when code signing is disabled for PRs.

## Changes
- Added early return in `scripts/notarize.js` when `GITHUB_EVENT_NAME` environment variable is set to `'pull_request'`
- Includes explanatory console log message indicating why notarization is being skipped
- Prevents notarization from attempting to process unsigned binaries in PR builds

## Details
Since electron-builder skips code signing for pull request builds (for security reasons), the subsequent notarization step would fail. This change detects PR builds via the GitHub Actions environment variable and gracefully exits the notarization process before attempting to notarize unsigned code.

https://claude.ai/code/session_017MvpQmFaW6FjngN44DCkEt