### PR TITLE
Add context menu support for collection albums

### DIFF
--- a/app.js
+++ b/app.js
@@ -2349,7 +2349,7 @@ const CollectionArtistCard = ({ artist, getArtistImage, onNavigate, onPlayTopTra
 };
 
 // CollectionAlbumCard component - Cinematic Light design
-const CollectionAlbumCard = ({ album, getAlbumArt, onNavigate, onAddToPlaylist, onPlay, onAddToQueue, animationDelay = 0 }) => {
+const CollectionAlbumCard = ({ album, getAlbumArt, onNavigate, onAddToPlaylist, onPlay, onAddToQueue, onContextMenu, animationDelay = 0 }) => {
   // States: undefined (fetching), null (no art found), string (URL)
   const [imageUrl, setImageUrl] = useState(album.art || undefined);
 
@@ -2374,6 +2374,7 @@ const CollectionAlbumCard = ({ album, getAlbumArt, onNavigate, onAddToPlaylist, 
 
   return React.createElement('button', {
     onClick: onNavigate,
+    onContextMenu: onContextMenu ? (e) => { e.preventDefault(); onContextMenu(e, album); } : undefined,
     className: 'group text-left release-card card-fade-up',
     style: {
       padding: '10px',
@@ -33495,6 +33496,12 @@ useEffect(() => {
                         addToQueue(albumTracks, { type: 'album', name: albumData.title, artist: albumData.artist });
                         showToast(`Added ${albumTracks.length} tracks from ${albumData.title}`, 'success');
                       }
+                    },
+                    onContextMenu: (e, albumData) => {
+                      window.electron?.contextMenu?.showTrackMenu({
+                        type: 'collection-album',
+                        album: albumData
+                      });
                     },
                     animationDelay: Math.min(index * 30, 300)
                   })

--- a/main.js
+++ b/main.js
@@ -2982,7 +2982,7 @@ ipcMain.handle('show-track-context-menu', async (event, data) => {
 
   // Only add queue/playlist options for types that have playable tracks
   // Exclude friend-track since it has its own specific menu items
-  if (data.type !== 'artist' && data.type !== 'friend' && data.type !== 'friend-track') {
+  if (data.type !== 'artist' && data.type !== 'friend' && data.type !== 'friend-track' && data.type !== 'collection-album') {
     menuItems.push({
       label: menuLabel,
       enabled: enabled,
@@ -3052,6 +3052,20 @@ ipcMain.handle('show-track-context-menu', async (event, data) => {
         mainWindow.webContents.send('track-context-menu-action', {
           action: 'edit-id3-tags',
           track: data.track
+        });
+      }
+    });
+  }
+
+  // Add "Remove from Collection" option for collection albums
+  if (data.type === 'collection-album') {
+    menuItems.push({
+      label: 'Remove from Collection',
+      click: () => {
+        mainWindow.webContents.send('track-context-menu-action', {
+          action: 'remove-from-collection',
+          type: 'album',
+          album: data.album
         });
       }
     });


### PR DESCRIPTION
## Summary
This PR adds right-click context menu functionality to album cards in the user's collection, allowing users to remove albums from their collection directly from the UI.

## Key Changes
- **app.js**: 
  - Added `onContextMenu` prop to `CollectionAlbumCard` component
  - Implemented context menu handler that prevents default behavior and triggers the custom menu
  - Passed `onContextMenu` callback when rendering album cards in the collection view

- **main.js**:
  - Updated context menu type filtering to exclude `'collection-album'` from standard queue/playlist options
  - Added new "Remove from Collection" menu item specifically for collection albums
  - Sends `'remove-from-collection'` action back to renderer with album data

## Implementation Details
- The context menu handler uses `e.preventDefault()` to suppress the browser's default context menu
- Collection albums are treated as a distinct menu type to provide album-specific actions rather than track-based options
- The removal action is sent via IPC to the main process, which then communicates back to the renderer for handling the actual removal logic

https://claude.ai/code/session_01Kkrt4KSKwVUDNKm7aUSfFo