### PR TITLE
chore: bump version to 0.6.0-alpha.1 and update alpha guide

### DIFF
--- a/ALPHA_GUIDE.md
+++ b/ALPHA_GUIDE.md
@@ -112,7 +112,7 @@ https://github.com/Parachord/parachord/discussions
 
 ## Known Limitations (Alpha)
 
-- **Apple Music**: Playback support (no library sync yet)
+- **Apple Music**: Full playback and library sync on all platforms (macOS, Windows, Linux) via MusicKit
 - **Spotify**: Requires Spotify to be open on desktop (can be in background)
 - **YouTube**: Audio-only, quality varies - add the browser extension to improve the experience
 - **Auto-updates**: Not yet enabled - check releases manually

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parachord-desktop",
-  "version": "0.5.0-alpha.1",
+  "version": "0.6.0-alpha.1",
   "description": "Parachord Desktop - Multi-source music player with cross-platform resolver support",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
- Bump version from 0.5.0-alpha.1 to 0.6.0-alpha.1
- Update Apple Music known limitations to reflect cross-platform support and library sync now available on all platforms

https://claude.ai/code/session_01Xhja1UB3bTm1zLfAhcuupr