### PR TITLE
feat: enable auto-updates by publishing releases as non-draft

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: artifacts/*
-          draft: true
+          draft: false
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ALPHA_GUIDE.md
+++ b/ALPHA_GUIDE.md
@@ -115,7 +115,7 @@ https://github.com/Parachord/parachord/discussions
 - **Apple Music**: Full playback and library sync on all platforms (macOS, Windows, Linux) via MusicKit
 - **Spotify**: Requires Spotify to be open on desktop (can be in background)
 - **YouTube**: Audio-only, quality varies - add the browser extension to improve the experience
-- **Auto-updates**: Not yet enabled - check releases manually
+- **Auto-updates**: Enabled - you'll be prompted when a new version is available
 
 ## Keyboard Shortcuts
 


### PR DESCRIPTION
Change the GitHub release job from draft: true to draft: false so that electron-updater can detect new versions. Update alpha guide to reflect auto-updates are now enabled.

https://claude.ai/code/session_01Xhja1UB3bTm1zLfAhcuupr