### PR TITLE
Add meta-service support and improve error handling for discovery

### DIFF
--- a/marketplace-manifest.json
+++ b/marketplace-manifest.json
@@ -155,6 +155,24 @@
       "tags": ["local", "files", "library", "offline", "free"]
     },
     {
+      "id": "claude",
+      "name": "Claude",
+      "type": "meta-service",
+      "version": "1.0.0",
+      "author": "Parachord Team",
+      "description": "Anthropic's Claude - thoughtful and capable AI assistant.",
+      "icon": "🧡",
+      "color": "#D97757",
+      "homepage": "https://anthropic.com",
+      "capabilities": {
+        "chat": true
+      },
+      "requiresAuth": true,
+      "downloadUrl": "https://raw.githubusercontent.com/Parachord/parachord-plugins/main/claude.axe",
+      "category": "ai",
+      "tags": ["ai", "chat", "anthropic", "claude"]
+    },
+    {
       "id": "chatgpt",
       "name": "ChatGPT",
       "type": "meta-service",
@@ -171,6 +189,24 @@
       "downloadUrl": "https://raw.githubusercontent.com/Parachord/parachord-plugins/main/chatgpt.axe",
       "category": "ai",
       "tags": ["ai", "playlist", "generation", "openai", "chatgpt"]
+    },
+    {
+      "id": "ollama",
+      "name": "Ollama (Local)",
+      "type": "meta-service",
+      "version": "1.0.0",
+      "author": "Parachord Team",
+      "description": "Run AI locally with Ollama. Free, private, works offline.",
+      "icon": "🦙",
+      "color": "#000000",
+      "homepage": "https://ollama.ai",
+      "capabilities": {
+        "chat": true
+      },
+      "requiresAuth": false,
+      "downloadUrl": "https://raw.githubusercontent.com/Parachord/parachord-plugins/main/ollama.axe",
+      "category": "ai",
+      "tags": ["ai", "chat", "local", "ollama", "free", "offline"]
     },
     {
       "id": "gemini",


### PR DESCRIPTION
## Summary
This PR adds support for meta-services (AI assistants and other non-music resolvers) as first-class entities in the resolver system, improves error handling for discovery features, and fixes a stale closure bug in volume offset persistence.

## Key Changes

### Meta-Service Support
- Added ability to distinguish between content resolvers and meta-services throughout the codebase
- Meta-services are now properly loaded, installed, updated, and uninstalled alongside content resolvers
- Added Claude and Ollama meta-services to the marketplace manifest
- Updated resolver installation/uninstallation logic to handle both resolver types

### Error Handling Improvements
- Added `criticsPicksError` and `chartsError` state variables to track loading failures
- Replaced modal dialogs with persistent error states in the UI for discovery features
- Added retry buttons to error states for better UX
- Error states are cleared when retrying or on successful loads

### Bug Fixes
- Fixed stale closure issue in volume offset persistence by:
  - Creating `resolverVolumeOffsetsRef` to maintain current values in callbacks
  - Added `useEffect` to keep the ref in sync with state changes
  - Updated save function to use the ref instead of potentially stale state
- Improved resolver lookup to check both content resolvers and meta-services

### UI Enhancements
- Added error state UI with warning icon and retry button for Charts tab
- Added error state UI with warning icon and retry button for Critic's Picks
- Improved loading state labels to distinguish between content resolvers and meta-services in logs

## Implementation Details
- Meta-services are identified by checking `manifest.type === 'meta-service'`
- Meta-service data is stored in a separate `metaServices` state array
- Both resolver types are checked when validating installations and uninstallations
- Error states persist until user retries or navigates away, providing better visibility into failures

https://claude.ai/code/session_012HieMCaWUW5arVso1J4rsC