### PR TITLE
Include package version in build artifacts and set retention

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,11 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
+      - name: Get package version
+        id: pkg
+        shell: bash
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
       # macOS: Import code signing certificate
       - name: Import Code Signing Certificate
         if: matrix.platform == 'mac' && env.CSC_LINK != ''
@@ -66,7 +71,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: parachord-${{ matrix.platform }}-${{ matrix.arch }}
+          name: parachord-${{ matrix.platform }}-${{ matrix.arch }}-v${{ steps.pkg.outputs.version }}
           path: |
             dist/*.dmg
             dist/*.zip
@@ -75,6 +80,7 @@ jobs:
             dist/*.deb
             dist/*.rpm
           if-no-files-found: ignore
+          retention-days: 30
 
   release:
     needs: build


### PR DESCRIPTION
## Summary
Updated the GitHub Actions build workflow to include the package version in artifact names and configure artifact retention policy.

## Key Changes
- Added a step to extract the package version from `package.json` and store it as a workflow output
- Updated artifact naming to include the version: `parachord-{platform}-{arch}-v{version}`
- Set artifact retention period to 30 days to manage storage and cleanup

## Implementation Details
- The package version is extracted using Node.js and the `require()` function, making it a dynamic value that automatically stays in sync with `package.json`
- The version is captured in the `steps.pkg.outputs.version` output variable and referenced in the artifact upload step
- This change improves artifact organization and makes it easier to identify which version of the application each build artifact corresponds to

https://claude.ai/code/session_01CL5oqNRy7GQQuxhy7iVRyn