### PR TITLE
fix: migrate search history calls from removed invoke() to dedicated …

### DIFF
--- a/app.js
+++ b/app.js
@@ -14250,7 +14250,7 @@ const Parachord = () => {
   // Load search history from electron-store
   const loadSearchHistory = async () => {
     try {
-      const history = await window.electron.invoke('search-history-load');
+      const history = await window.electron.searchHistory.load();
       setSearchHistory(history || []);
     } catch (error) {
       console.error('Failed to load search history:', error);
@@ -14273,7 +14273,7 @@ const Parachord = () => {
     };
 
     try {
-      await window.electron.invoke('search-history-save', entry);
+      await window.electron.searchHistory.save(entry);
       // Reload history to reflect update
       loadSearchHistory();
     } catch (error) {
@@ -14284,7 +14284,7 @@ const Parachord = () => {
   // Clear search history (single entry or all)
   const clearSearchHistory = async (entryQuery = null) => {
     try {
-      await window.electron.invoke('search-history-clear', entryQuery);
+      await window.electron.searchHistory.clear(entryQuery);
       loadSearchHistory();
     } catch (error) {
       console.error('Failed to clear search history:', error);


### PR DESCRIPTION
…IPC methods

The security fix (33483cd) removed the generic window.electron.invoke() bridge but app.js still used it for search history operations. This caused TypeError at runtime since invoke is now undefined. Migrated to use the existing window.electron.searchHistory.{load,save,clear} methods that were already defined in preload.js.

Also includes the CI artifact naming fix from the earlier commit.

679/679 tests pass.

https://claude.ai/code/session_01CL5oqNRy7GQQuxhy7iVRyn