### PR TITLE
fix: add missing closing brace in delete-playlist handler (syntax error)

### DIFF
--- a/app.js
+++ b/app.js
@@ -9378,6 +9378,7 @@ const Parachord = () => {
               } else {
                 alert(`Failed to delete playlist: ${result.error}`);
               }
+            }
           }
         } else if (data.action === 'edit-id3-tags' && data.track) {
           // Open ID3 tag editor modal


### PR DESCRIPTION
PR #236 (commit a62ac93) added synced playlist handling to the delete-playlist context menu action but dropped a closing brace for the `else` branch. This caused `SyntaxError: Unexpected token 'else'` at line 9381, preventing app.js from parsing entirely — blank screen on launch.

https://claude.ai/code/session_01CL5oqNRy7GQQuxhy7iVRyn