### PR TITLE
Fix Apple Music re-auth after app data reset

### DIFF
--- a/app.js
+++ b/app.js
@@ -39557,6 +39557,13 @@ useEffect(() => {
                             throw new Error('Store clear failed');
                           }
 
+                          // Persist the disconnect flag so native MusicKit (macOS keychain)
+                          // doesn't auto-reconnect after reset. store.clear() removes the
+                          // flag that disconnectAppleMusic() sets, so we must re-set it.
+                          if (window.electron?.store) {
+                            await window.electron.store.set('applemusic_authorized', false);
+                          }
+
                           // Clear localStorage tokens (MusicKit, etc.) that persist across resets
                           localStorage.removeItem('musickit_developer_token');
                           localStorage.removeItem('musickit_user_token');


### PR DESCRIPTION
store.clear() in the reset handler was deleting the applemusic_authorized flag that disconnectAppleMusic() sets to false. On reload, the startup code saw null (not false) for the flag and fell through to native MusicKit keychain detection, which auto-reconnected the user.

Re-set applemusic_authorized=false immediately after store.clear() so the startup guard at line 24959 correctly skips auto-reconnect.

https://claude.ai/code/session_01XSVdgoURAwbDBeg9jrML4o