### PR TITLE
Fix phantom "Install 1 more resolver" by removing non-existent Deezer

### DIFF
--- a/app.js
+++ b/app.js
@@ -32434,7 +32434,7 @@ useEffect(() => {
                 const suggestions = [];
 
                 // Check for uninstalled popular resolvers
-                const popularResolverIds = ['youtube', 'soundcloud', 'deezer'];
+                const popularResolverIds = ['youtube', 'soundcloud', 'bandcamp'];
                 const installedIds = allResolvers.map(r => r.id);
                 const uninstalledPopular = popularResolverIds.filter(id => !installedIds.includes(id));
 


### PR DESCRIPTION
The popularResolverIds list included 'deezer' but no Deezer resolver exists (it's only a TODO). This caused the Enhance section to always show "Install 1 more resolver" even with all available resolvers installed. Replaced with 'bandcamp' which is an actual available resolver.

https://claude.ai/code/session_014CAZeQ2RtCYSLfAcxNZjc1