### PR TITLE
Fix Ollama chat provider visibility and Libre.fm auth

### DIFF
--- a/app.js
+++ b/app.js
@@ -14003,9 +14003,9 @@ const Parachord = () => {
     // Filter to only enabled services with required config
     const enabledServices = chatServices.filter(s => {
       const config = metaServiceConfigs[s.id] || {};
-      // Ollama doesn't need API key, others do
-      if (s.id === 'ollama') return config.enabled === true;
-      return !!config.apiKey;
+      // Services that don't require auth (e.g. Ollama) just need enabled toggle
+      const noKeyNeeded = s.requiresAuth === false || s.settings?.requiresAuth === false;
+      return noKeyNeeded ? config.enabled === true : !!config.apiKey;
     });
 
     if (enabledServices.length === 0) {
@@ -33326,8 +33326,8 @@ useEffect(() => {
                 const chatServices = getChatServices();
                 const hasEnabledChat = chatServices.some(s => {
                   const config = metaServiceConfigs[s.id] || {};
-                  if (s.id === 'ollama') return config.enabled === true;
-                  return !!config.apiKey;
+                  const noKeyNeeded = s.requiresAuth === false || s.settings?.requiresAuth === false;
+                  return noKeyNeeded ? config.enabled === true : !!config.apiKey;
                 });
 
                 return React.createElement('div', {
@@ -39874,9 +39874,8 @@ useEffect(() => {
             // Check if chat providers are enabled
             const hasEnabledChat = chatServices.some(s => {
               const config = metaServiceConfigs[s.id] || {};
-              // Ollama doesn't require API key
-              if (s.id === 'ollama') return config.enabled === true;
-              return !!config.apiKey;
+              const noKeyNeeded = s.requiresAuth === false || s.settings?.requiresAuth === false;
+              return noKeyNeeded ? config.enabled === true : !!config.apiKey;
             });
 
             // Check if generate providers are enabled (fallback)
@@ -41001,8 +41000,8 @@ useEffect(() => {
                 (() => {
                   const enabledServices = getChatServices().filter(s => {
                     const config = metaServiceConfigs[s.id] || {};
-                    if (s.id === 'ollama') return config.enabled === true;
-                    return !!config.apiKey;
+                    const noKeyNeeded = s.requiresAuth === false || s.settings?.requiresAuth === false;
+                    return noKeyNeeded ? config.enabled === true : !!config.apiKey;
                   });
                   const currentService = enabledServices.find(s => s.id === selectedChatProvider);
                   const currentLogo = currentService ? SERVICE_LOGOS[currentService.id] : null;

--- a/scrobblers/librefm-scrobbler.js
+++ b/scrobblers/librefm-scrobbler.js
@@ -16,13 +16,14 @@ class LibreFmScrobbler extends LastFmScrobbler {
 
   // Override to use username/password auth instead of OAuth
   async connectWithPassword(username, password) {
-    // MD5 hash the password
+    // Libre.fm uses authToken = md5(username + md5(password)) instead of password
     const passwordHash = await window.electron.crypto.md5(password);
+    const authToken = await window.electron.crypto.md5(username.toLowerCase() + passwordHash);
 
     const params = {
       method: 'auth.getMobileSession',
       username: username,
-      password: passwordHash,
+      authToken: authToken,
       api_key: this.apiKey
     };
     const sig = await this.generateSignature(params);
@@ -30,7 +31,7 @@ class LibreFmScrobbler extends LastFmScrobbler {
     const body = new URLSearchParams();
     body.append('method', 'auth.getMobileSession');
     body.append('username', username);
-    body.append('password', passwordHash);
+    body.append('authToken', authToken);
     body.append('api_key', this.apiKey);
     body.append('api_sig', sig);
     body.append('format', 'json');


### PR DESCRIPTION
Two fixes:

1. Ollama not showing in Shuffleupagus provider dropdown despite being enabled. Replaced fragile hardcoded `s.id === 'ollama'` checks in all 4 chat provider filter locations with a generic check using the service's own `requiresAuth` property. Services that don't require auth (like Ollama) check `config.enabled`; services that do require auth check `config.apiKey`.

2. Libre.fm auth failing with "Invalid parameters - Your request is missing a required parameter". Libre.fm (GNU FM) expects `authToken` = md5(username + md5(password)) for auth.getMobileSession, not the `password` parameter that Last.fm uses. Updated connectWithPassword to compute and send authToken instead.

https://claude.ai/code/session_014CAZeQ2RtCYSLfAcxNZjc1