### PR TITLE
Fix Ollama plugin loading and Libre.fm auth

### DIFF
--- a/main.js
+++ b/main.js
@@ -2844,14 +2844,15 @@ ipcMain.handle('resolvers-load-builtin', async () => {
               axe._filename = filename;
               axe._source = source;
               console.log(`  🔄 Upgraded: ${axe.manifest.name} v${existing.manifest.version} → v${axe.manifest.version} (${source})`);
-            } else if (versionCmp === 0 && source === 'cache') {
-              // Same version from cache - prefer cache (may have user customizations)
+            } else if (versionCmp === 0 && existing._source === 'cache' && source === 'app') {
+              // Same version but shipped app plugin is more authoritative than cache
+              // (cache may have stale format from old marketplace downloads)
               plugins[existingIdx] = axe;
               axe._filename = filename;
               axe._source = source;
-              console.log(`  🔄 Using cached: ${axe.manifest.name} v${axe.manifest.version}`);
+              console.log(`  🔄 Preferring shipped: ${axe.manifest.name} v${axe.manifest.version} over cached`);
             } else {
-              console.log(`  ⚠️  Skipping ${axe.manifest.name} v${axe.manifest.version} (already have v${existing.manifest.version} from ${existing._source})`);
+              console.log(`  ⚠️  Skipping ${axe.manifest.name} v${axe.manifest.version} from ${source} (already have v${existing.manifest.version} from ${existing._source})`);
             }
             continue;
           }

--- a/scrobbler-loader.js
+++ b/scrobbler-loader.js
@@ -715,13 +715,14 @@ class LibreFmScrobbler extends LastFmScrobbler {
 
   // Override to use username/password auth instead of OAuth
   async connectWithPassword(username, password) {
-    // MD5 hash the password
+    // Libre.fm (GNU FM) uses authToken = md5(username + md5(password))
     const passwordHash = await window.electron.crypto.md5(password);
+    const authToken = await window.electron.crypto.md5(username.toLowerCase() + passwordHash);
 
     const params = {
       method: 'auth.getMobileSession',
       username: username,
-      password: passwordHash,
+      authToken: authToken,
       api_key: this.apiKey
     };
     const sig = await this.generateSignature(params);
@@ -729,7 +730,7 @@ class LibreFmScrobbler extends LastFmScrobbler {
     const body = new URLSearchParams();
     body.append('method', 'auth.getMobileSession');
     body.append('username', username);
-    body.append('password', passwordHash);
+    body.append('authToken', authToken);
     body.append('api_key', this.apiKey);
     body.append('api_sig', sig);
     body.append('format', 'json');


### PR DESCRIPTION
Two root causes identified and fixed:

1. Ollama (and other AI plugins) not showing in chat dropdown: Commit a7d6b68 added version-aware plugin loading but still let cache override shipped plugins at the same version. Cached v1.0.0 plugins (from old marketplace downloads) lacked the `chat: true` capability that shipped v1.0.0 plugins have. Fix: at equal versions, prefer shipped (app) plugins over cached ones.

2. Libre.fm auth failing with "missing required parameter": The auth code was sending `password` (md5 of password) but Libre.fm (GNU FM) expects `authToken` = md5(username + md5(password)) for auth.getMobileSession. Applied the fix to scrobbler-loader.js which is the actual runtime file loaded by index.html, not the standalone scrobblers/librefm-scrobbler.js which is dead code at runtime. Also synced the standalone file to match (fixed response.json() → JSON.parse(response.text) to match proxyFetch return format).

https://claude.ai/code/session_014CAZeQ2RtCYSLfAcxNZjc1