### PR TITLE
Fix Libre.fm auth (use authToken), add Spotify disconnect handler

### DIFF
--- a/app.js
+++ b/app.js
@@ -24768,9 +24768,7 @@ ${tracks}
 
   const disconnectSpotify = async () => {
     if (window.electron?.spotify) {
-      await window.electron.store.delete('spotify_token');
-      await window.electron.store.delete('spotify_refresh_token');
-      await window.electron.store.delete('spotify_token_expiry');
+      await window.electron.spotify.disconnect();
       setSpotifyToken(null);
       setSpotifyConnected(false);
       // Remove Spotify sources from all tracks and remove from active resolvers

--- a/main.js
+++ b/main.js
@@ -2287,6 +2287,15 @@ ipcMain.handle('soundcloud-check-token', async () => {
 });
 
 // Disconnect SoundCloud (clear tokens)
+ipcMain.handle('spotify-disconnect', async () => {
+  console.log('=== Spotify Disconnect ===');
+  store.delete('spotify_token');
+  store.delete('spotify_refresh_token');
+  store.delete('spotify_token_expiry');
+  console.log('Spotify tokens cleared');
+  return { success: true };
+});
+
 ipcMain.handle('soundcloud-disconnect', async () => {
   console.log('=== SoundCloud Disconnect ===');
   store.delete('soundcloud_token');

--- a/preload.js
+++ b/preload.js
@@ -17,6 +17,7 @@ contextBridge.exposeInMainWorld('electron', {
   spotify: {
     authenticate: () => ipcRenderer.invoke('spotify-auth'),
     checkToken: () => ipcRenderer.invoke('spotify-check-token'),
+    disconnect: () => ipcRenderer.invoke('spotify-disconnect'),
     launchInBackground: () => ipcRenderer.invoke('spotify-launch-background'),
     getCredentials: () => ipcRenderer.invoke('spotify-get-credentials'),
     setCredentials: (credentials) => ipcRenderer.invoke('spotify-set-credentials', credentials),

--- a/scrobbler-loader.js
+++ b/scrobbler-loader.js
@@ -715,13 +715,14 @@ class LibreFmScrobbler extends LastFmScrobbler {
 
   // Override to use username/password auth instead of OAuth
   async connectWithPassword(username, password) {
-    // MD5 hash the password for auth.getMobileSession
+    // Libre.fm uses authToken = md5(lowercased_username + md5(password))
     const passwordHash = await window.electron.crypto.md5(password);
+    const authToken = await window.electron.crypto.md5(username.toLowerCase() + passwordHash);
 
     const params = {
       method: 'auth.getMobileSession',
       username: username,
-      password: passwordHash,
+      authToken: authToken,
       api_key: this.apiKey
     };
     const sig = await this.generateSignature(params);
@@ -729,7 +730,7 @@ class LibreFmScrobbler extends LastFmScrobbler {
     const body = new URLSearchParams();
     body.append('method', 'auth.getMobileSession');
     body.append('username', username);
-    body.append('password', passwordHash);
+    body.append('authToken', authToken);
     body.append('api_key', this.apiKey);
     body.append('api_sig', sig);
     body.append('format', 'json');

--- a/scrobblers/librefm-scrobbler.js
+++ b/scrobblers/librefm-scrobbler.js
@@ -16,13 +16,14 @@ class LibreFmScrobbler extends LastFmScrobbler {
 
   // Override to use username/password auth instead of OAuth
   async connectWithPassword(username, password) {
-    // MD5 hash the password for auth.getMobileSession
+    // Libre.fm uses authToken = md5(lowercased_username + md5(password))
     const passwordHash = await window.electron.crypto.md5(password);
+    const authToken = await window.electron.crypto.md5(username.toLowerCase() + passwordHash);
 
     const params = {
       method: 'auth.getMobileSession',
       username: username,
-      password: passwordHash,
+      authToken: authToken,
       api_key: this.apiKey
     };
     const sig = await this.generateSignature(params);
@@ -30,7 +31,7 @@ class LibreFmScrobbler extends LastFmScrobbler {
     const body = new URLSearchParams();
     body.append('method', 'auth.getMobileSession');
     body.append('username', username);
-    body.append('password', passwordHash);
+    body.append('authToken', authToken);
     body.append('api_key', this.apiKey);
     body.append('api_sig', sig);
     body.append('format', 'json');


### PR DESCRIPTION
Three fixes for security commit regressions:

1. Libre.fm auth: API test confirmed Libre.fm rejects `password` param (error 6: missing parameter) but accepts `authToken` param (error 4: invalid token = param recognized). Changed to authToken = md5( lowercased_username + md5(password)) in both scrobbler-loader.js (runtime) and standalone scrobblers/librefm-scrobbler.js.

2. Spotify disconnect: The security commit's store key whitelist correctly blocks renderer access to spotify_token, but this also broke disconnectSpotify() which used store.delete() from renderer. Added dedicated spotify-disconnect IPC handler (matching the existing soundcloud-disconnect pattern) so token cleanup happens in main process without exposing sensitive keys to the renderer.

3. Previous commit already added scrobbler-config-* keys to the store whitelist to fix scrobbler getConfig/setConfig.

https://claude.ai/code/session_014CAZeQ2RtCYSLfAcxNZjc1