### PR TITLE
Add codesign retry wrapper for Apple timestamp server failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Wrap codesign with retry logic for transient Apple timestamp server failures
+      - name: Setup codesign retry wrapper
+        if: matrix.platform == 'mac'
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          cp scripts/codesign-retry.sh "$HOME/.local/bin/codesign"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Build for ${{ matrix.platform }}
         run: npm run build:${{ matrix.platform }} -- --publish never
         env:

--- a/scripts/codesign-retry.sh
+++ b/scripts/codesign-retry.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Wrapper around macOS codesign that retries on timestamp service failures.
+# Apple's timestamp server can be transiently unavailable, causing CI builds
+# to fail. This wrapper detects that specific error and retries with backoff.
+
+REAL_CODESIGN=/usr/bin/codesign
+MAX_RETRIES=5
+INITIAL_DELAY=3
+
+delay=$INITIAL_DELAY
+
+for attempt in $(seq 1 $MAX_RETRIES); do
+  output=$("$REAL_CODESIGN" "$@" 2>&1)
+  exit_code=$?
+
+  if [ $exit_code -eq 0 ]; then
+    [ -n "$output" ] && echo "$output"
+    exit 0
+  fi
+
+  if echo "$output" | grep -qi "timestamp service is not available\|timestamp server is not available\|unable to communicate with the timestamp server"; then
+    echo "codesign-retry: timestamp service unavailable (attempt $attempt/$MAX_RETRIES), retrying in ${delay}s..." >&2
+    sleep $delay
+    delay=$((delay * 2))
+  else
+    # Not a timestamp error — fail immediately
+    echo "$output" >&2
+    exit $exit_code
+  fi
+done
+
+# Final attempt
+exec "$REAL_CODESIGN" "$@"


### PR DESCRIPTION
## Summary
This PR adds resilience to macOS code signing in CI by implementing a retry wrapper that handles transient Apple timestamp server failures. These failures are a known issue that can cause otherwise successful builds to fail unexpectedly.

## Changes
- **New script**: `scripts/codesign-retry.sh` - A bash wrapper around `/usr/bin/codesign` that:
  - Detects timestamp service unavailability errors
  - Retries up to 5 times with exponential backoff (3s, 6s, 12s, 24s, 48s)
  - Fails immediately on non-timestamp errors to avoid masking real issues
  - Passes through all arguments and output transparently

- **Updated workflow**: `.github/workflows/build.yml` - Modified macOS build job to:
  - Create `$HOME/.local/bin` directory
  - Copy the retry wrapper script as `codesign`
  - Prepend this directory to `$PATH` so it intercepts codesign calls

## Implementation Details
- The wrapper uses grep to detect common timestamp server error messages (case-insensitive)
- Exponential backoff prevents overwhelming the timestamp service during recovery
- Non-timestamp errors bypass retry logic entirely, preserving fast failure for actual code signing issues
- The solution is transparent to the build process—no changes needed to build scripts

https://claude.ai/code/session_01BS5FmXKFHJdyNzN66nBLVh