### PR TITLE
Fix system volume being overridden and add system mute monitoring

### DIFF
--- a/native/musickit-helper/Sources/main.swift
+++ b/native/musickit-helper/Sources/main.swift
@@ -320,20 +320,14 @@ class MusicKitBridge {
         ]
     }
 
-    // Set volume via Music.app's AppleScript interface (non-blocking)
-    // Only sets volume if Music.app is already running to avoid launching it
+    // Set volume - no-op for native ApplicationMusicPlayer
+    // ApplicationMusicPlayer's audio output is controlled by macOS system volume,
+    // not by Music.app's "sound volume" AppleScript property. Setting Music.app's
+    // sound volume via AppleScript was interfering with system volume changes
+    // (user would hear brief change then volume would revert).
+    // Preview audio volume is handled separately via HTML5 Audio element.
     func setVolume(_ volume: Float) -> [String: Any] {
-        let volumePercent = Int(max(0, min(100, volume * 100)))
-        // Run AppleScript on background thread to avoid blocking command processing
-        DispatchQueue.global(qos: .userInitiated).async {
-            let script = NSAppleScript(source: """
-                if application "Music" is running then
-                    tell application "Music" to set sound volume to \(volumePercent)
-                end if
-            """)
-            script?.executeAndReturnError(nil)
-        }
-        return ["volume": volume, "appliedPercent": volumePercent]
+        return ["volume": volume, "note": "Native playback uses system volume"]
     }
 }
 

--- a/preload.js
+++ b/preload.js
@@ -423,5 +423,14 @@ contextBridge.exposeInMainWorld('electron', {
     check: () => ipcRenderer.invoke('ollama:check')
   },
 
+  // System volume monitoring (macOS)
+  system: {
+    onVolumeChanged: (callback) => {
+      ipcRenderer.on('system-volume-changed', (event, data) => {
+        callback(data);
+      });
+    }
+  },
+
   // Generic invoke removed for security — use specific API methods above
 });


### PR DESCRIPTION
Remove AppleScript volume control from Swift helper - it was setting Music.app's internal volume which interfered with system volume changes (user would hear brief change then volume reverted). ApplicationMusicPlayer audio is controlled by macOS system volume, not Music.app's sound volume.

Add system volume/mute monitoring (macOS) that polls via osascript and forwards changes to the renderer. When system is muted, pause Apple Music native playback and mute all audio elements. When unmuted, restore previous state (respecting Parachord's own mute state).

https://claude.ai/code/session_01E7HJbw7vLue1etUt7sBKej