### PR TITLE
Fix Apple Music volume, system volume monitoring, and play/pause resume

### DIFF
--- a/main.js
+++ b/main.js
@@ -560,13 +560,15 @@ const systemVolumeMonitor = {
     const { execFile } = require('child_process');
 
     this.interval = setInterval(() => {
-      execFile('osascript', ['-e', 'set v to (get volume settings)', '-e', 'return (output volume of v) & "," & (output muted of v)'], { timeout: 2000 }, (error, stdout) => {
+      execFile('osascript', ['-e', 'get volume settings'], { timeout: 2000 }, (error, stdout) => {
         if (error) return;
-        const parts = stdout.trim().split(',');
-        if (parts.length !== 2) return;
+        // Output: "output volume:70, output muted:false, alert volume:100, input volume:50"
+        const volMatch = stdout.match(/output volume:(\d+)/);
+        const muteMatch = stdout.match(/output muted:(true|false)/);
+        if (!volMatch || !muteMatch) return;
 
-        const volume = parseInt(parts[0], 10);
-        const muted = parts[1].trim() === 'true';
+        const volume = parseInt(volMatch[1], 10);
+        const muted = muteMatch[1] === 'true';
 
         if (isNaN(volume)) return;
 


### PR DESCRIPTION
1. Restore AppleScript volume control for Apple Music - the no-op approach broke the in-app volume slider. Keep async background thread dispatch and Music.app running guard to avoid blocking and unwanted launches.

2. Fix system volume monitoring osascript command - the previous command used AppleScript & operator without text coercion, which fails for int/boolean concatenation. Now uses 'get volume settings' and parses the output with regex (output volume:N, output muted:true/false).

3. Fix Apple Music play/pause resume - restart playback polling after resume (was only stopped on pause, never restarted). Add error handling for preview audio resume. Update UI state even on error to prevent stuck play/pause button.

https://claude.ai/code/session_01E7HJbw7vLue1etUt7sBKej