### PR TITLE
Update Shuffleupagus feature UI and add Songs stat to dashboard

### DIFF
--- a/app.js
+++ b/app.js
@@ -33571,15 +33571,15 @@ useEffect(() => {
                   }
                 },
                   React.createElement('div', { className: 'inline-flex items-center justify-center w-16 h-16 rounded-full bg-white/10 mb-4' },
-                    React.createElement('svg', { className: 'w-8 h-8 text-white', fill: 'none', viewBox: '0 0 24 24', stroke: 'currentColor' },
-                      React.createElement('path', { strokeLinecap: 'round', strokeLinejoin: 'round', strokeWidth: 2, d: 'M13 10V3L4 14h7v7l9-11h-7z' })
+                    React.createElement('svg', { className: 'w-8 h-8 text-white', viewBox: '0 0 56 56', fill: 'currentColor' },
+                      React.createElement('path', { d: 'M 26.6875 12.6602 C 26.9687 12.6602 27.1094 12.4961 27.1797 12.2383 C 27.9062 8.3242 27.8594 8.2305 31.9375 7.4570 C 32.2187 7.4102 32.3828 7.2461 32.3828 6.9648 C 32.3828 6.6836 32.2187 6.5195 31.9375 6.4726 C 27.8828 5.6524 28.0000 5.5586 27.1797 1.6914 C 27.1094 1.4336 26.9687 1.2695 26.6875 1.2695 C 26.4062 1.2695 26.2656 1.4336 26.1953 1.6914 C 25.3750 5.5586 25.5156 5.6524 21.4375 6.4726 C 21.1797 6.5195 20.9922 6.6836 20.9922 6.9648 C 20.9922 7.2461 21.1797 7.4102 21.4375 7.4570 C 25.5156 8.2774 25.4687 8.3242 26.1953 12.2383 C 26.2656 12.4961 26.4062 12.6602 26.6875 12.6602 Z M 15.3438 28.7852 C 15.7891 28.7852 16.0938 28.5039 16.1406 28.0821 C 16.9844 21.8242 17.1953 21.8242 23.6641 20.5821 C 24.0860 20.5117 24.3906 20.2305 24.3906 19.7852 C 24.3906 19.3633 24.0860 19.0586 23.6641 18.9883 C 17.1953 18.0977 16.9609 17.8867 16.1406 11.5117 C 16.0938 11.0899 15.7891 10.7852 15.3438 10.7852 C 14.9219 10.7852 14.6172 11.0899 14.5703 11.5352 C 13.7969 17.8164 13.4687 17.7930 7.0469 18.9883 C 6.6250 19.0821 6.3203 19.3633 6.3203 19.7852 C 6.3203 20.2539 6.6250 20.5117 7.1406 20.5821 C 13.5156 21.6133 13.7969 21.7774 14.5703 28.0352 C 14.6172 28.5039 14.9219 28.7852 15.3438 28.7852 Z M 31.2344 54.7305 C 31.8438 54.7305 32.2891 54.2852 32.4062 53.6524 C 34.0703 40.8086 35.8750 38.8633 48.5781 37.4570 C 49.2344 37.3867 49.6797 36.8945 49.6797 36.2852 C 49.6797 35.6758 49.2344 35.2070 48.5781 35.1133 C 35.8750 33.7070 34.0703 31.7617 32.4062 18.9180 C 32.2891 18.2852 31.8438 17.8633 31.2344 17.8633 C 30.6250 17.8633 30.1797 18.2852 30.0860 18.9180 C 28.4219 31.7617 26.5938 33.7070 13.9140 35.1133 C 13.2344 35.2070 12.7891 35.6758 12.7891 36.2852 C 12.7891 36.8945 13.2344 37.3867 13.9140 37.4570 C 26.5703 39.1211 28.3281 40.8321 30.0860 53.6524 C 30.1797 54.2852 30.6250 54.7305 31.2344 54.7305 Z' })
                     )
                   ),
                   React.createElement('h3', { className: 'text-xl font-bold text-white mb-2' }, 'Surprise Me'),
                   React.createElement('p', { className: 'text-white/70 text-sm mb-4 max-w-md mx-auto' },
                     hasEnabledChat
-                      ? 'Let Shuffleupagus, your AI DJ, create a personalized playlist based on your listening history'
-                      : 'Shuffleupagus is your AI DJ that creates personalized playlists. Enable at least one AI plug-in (like ChatGPT, Gemini, or Claude) to get started.'
+                      ? 'Shuffleupagus, your AI companion, can recommend music, provide insights, control your playback experience and integrates with other AI agents so they can control it too.'
+                      : 'Shuffleupagus, your AI companion, can recommend music, provide insights, control your playback experience and integrates with other AI agents so they can control it too. Enable at least one AI plug-in (like ChatGPT, Gemini, or Claude) to get started.'
                   ),
                   hasEnabledChat
                     ? React.createElement('button', {
@@ -33601,8 +33601,9 @@ useEffect(() => {
               // SECTION: Collection Stats & Sync
               (() => {
                 const hasSyncEnabled = Object.values(resolverSyncSettings).some(s => s?.enabled);
-                const statsGrid = React.createElement('div', { className: 'grid grid-cols-2 md:grid-cols-4 gap-4' },
+                const statsGrid = React.createElement('div', { className: 'grid grid-cols-2 md:grid-cols-5 gap-4' },
                   [
+                    { label: 'Songs', value: library.length + collectionData.tracks.length, icon: 'M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2z', color: '#3b82f6', onClick: () => { navigateTo('library'); setCollectionTab('tracks'); } },
                     { label: 'Albums', value: collectionData.albums.length, icon: 'M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3', color: '#8b5cf6', onClick: () => { navigateTo('library'); setCollectionTab('albums'); } },
                     { label: 'Artists', value: collectionData.artists.length, icon: 'M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z', color: '#ec4899', onClick: () => { navigateTo('library'); setCollectionTab('artists'); } },
                     { label: 'Playlists', value: playlists.length, icon: 'M4 6h16M4 10h16M4 14h16M4 18h16', color: '#f59e0b', onClick: () => navigateTo('playlists') },


### PR DESCRIPTION
## Summary
This PR updates the "Surprise Me" feature presentation and enhances the collection statistics dashboard with improved messaging and a new Songs counter.

## Key Changes
- **Updated SVG Icon**: Replaced the lightning bolt icon with a new sparkle/star icon for the "Surprise Me" feature, changing from a stroke-based design to a filled path-based design with updated viewBox dimensions
- **Revised Feature Description**: Updated the "Surprise Me" feature messaging to emphasize Shuffleupagus as an AI companion that can recommend music, provide insights, control playback, and integrate with other AI agents
- **Added Songs Stat**: Introduced a new "Songs" card to the collection statistics grid that displays the total count of songs in the library and collection
- **Updated Grid Layout**: Changed the stats grid from 4 columns on medium screens (`md:grid-cols-4`) to 5 columns (`md:grid-cols-5`) to accommodate the new Songs stat card
- **Added Navigation**: The new Songs stat card includes click functionality to navigate to the library and filter by tracks

## Implementation Details
- The Songs count combines `library.length` and `collectionData.tracks.length` to show the complete song inventory
- The new stat card maintains consistent styling with existing stat cards (blue color theme with `#3b82f6`)
- All stat cards remain interactive with their respective navigation handlers

https://claude.ai/code/session_017nrB1vV2G3F4NjHV4BaNeB