### PR TITLE
Use custom token for reverse sync pull request creation

### DIFF
--- a/.github/workflows/reverse-sync.yml
+++ b/.github/workflows/reverse-sync.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Create pull request
         if: steps.diff.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.REPO_SYNC_TOKEN }}
         run: |
           BRANCH="sync/browser-extension-$(date +%Y%m%d)"
 
@@ -142,7 +142,7 @@ jobs:
       - name: Create pull request
         if: steps.diff.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.REPO_SYNC_TOKEN }}
         run: |
           BRANCH="sync/raycast-extension-$(date +%Y%m%d)"
 
@@ -247,7 +247,7 @@ jobs:
       - name: Create pull request
         if: steps.diff.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.REPO_SYNC_TOKEN }}
         run: |
           BRANCH="sync/plugins-$(date +%Y%m%d)"
 


### PR DESCRIPTION
## Summary
Updated the reverse sync workflow to use a custom `REPO_SYNC_TOKEN` instead of the default `GITHUB_TOKEN` for creating pull requests across all three sync jobs.

## Changes
- Replaced `secrets.GITHUB_TOKEN` with `secrets.REPO_SYNC_TOKEN` in the "Create pull request" step for:
  - Browser extension sync job
  - Raycast extension sync job
  - Plugins sync job

## Rationale
Using a dedicated `REPO_SYNC_TOKEN` provides better security and permission management by:
- Limiting token scope to only what's needed for repository synchronization
- Allowing independent token rotation and revocation
- Enabling audit trails specific to sync operations
- Reducing exposure if the default token is compromised

This change applies consistently across all three reverse sync workflows to maintain uniform authentication practices.

https://claude.ai/code/session_01A6R7rPsP21bQxBw9AndUgV