### PR TITLE
Add Claude Desktop setup section in General settings

### DIFF
--- a/app.js
+++ b/app.js
@@ -1759,6 +1759,88 @@ const ResolverCard = React.memo(({
   );
 });
 
+// MCP Settings Section - Claude Desktop integration setup
+const McpSettingsSection = () => {
+  const [mcpInfo, setMcpInfo] = useState(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (window.electron?.mcp?.getInfo) {
+      window.electron.mcp.getInfo().then(setMcpInfo);
+    }
+  }, []);
+
+  const configSnippet = mcpInfo ? JSON.stringify({
+    mcpServers: {
+      parachord: {
+        command: 'node',
+        args: [mcpInfo.stdioPath]
+      }
+    }
+  }, null, 2) : '';
+
+  const handleCopy = () => {
+    navigator.clipboard?.writeText(configSnippet).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return React.createElement('div', {
+    className: 'bg-white border border-gray-200 rounded-xl p-6 hover:shadow-sm hover:border-gray-300 transition-all'
+  },
+    React.createElement('div', { className: 'mb-5' },
+      React.createElement('h3', {
+        className: 'text-sm font-semibold text-gray-700 uppercase tracking-wider'
+      }, 'Claude Desktop'),
+      React.createElement('p', {
+        className: 'text-xs text-gray-500 mt-1'
+      }, 'Control Parachord from Claude Desktop using MCP')
+    ),
+    React.createElement('p', {
+      className: 'text-sm text-gray-600 mb-4 leading-relaxed'
+    }, 'Parachord runs an MCP server that lets Claude Desktop play music, search tracks, manage your queue, and control playback. Add the following to your Claude Desktop config:'),
+    mcpInfo && React.createElement('div', { className: 'relative' },
+      React.createElement('pre', {
+        style: {
+          backgroundColor: '#f8f9fa',
+          border: '1px solid #e5e7eb',
+          borderRadius: '8px',
+          padding: '12px 16px',
+          fontSize: '12px',
+          lineHeight: '1.6',
+          color: '#1f2937',
+          overflow: 'auto',
+          fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace',
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-all'
+        }
+      }, configSnippet),
+      React.createElement('button', {
+        onClick: handleCopy,
+        style: {
+          position: 'absolute',
+          top: '8px',
+          right: '8px',
+          padding: '4px 10px',
+          fontSize: '11px',
+          fontWeight: '500',
+          color: copied ? '#059669' : '#6b7280',
+          backgroundColor: copied ? '#ecfdf5' : '#f3f4f6',
+          border: '1px solid ' + (copied ? '#a7f3d0' : '#d1d5db'),
+          borderRadius: '6px',
+          cursor: 'pointer',
+          transition: 'all 0.15s'
+        }
+      }, copied ? 'Copied!' : 'Copy')
+    ),
+    React.createElement('p', {
+      className: 'text-xs text-gray-500 mt-3',
+      style: { lineHeight: '1.5' }
+    }, 'Parachord must be running for Claude Desktop to connect. The config file is typically located at ~/Library/Application Support/Claude/claude_desktop_config.json on macOS.')
+  );
+};
+
 // ScrobblerSettingsCard component - Settings card for individual scrobbler services
 const ScrobblerSettingsCard = React.memo(({ scrobbler, config, onConfigChange }) => {
   const [connecting, setConnecting] = useState(false);
@@ -39921,6 +40003,9 @@ useEffect(() => {
                     className: 'text-xs text-gray-500 mt-4 text-center'
                   }, 'Configure scrobbling services in their respective settings: Last.fm, ListenBrainz, and Libre.fm.')
                 ),
+
+                // Claude Desktop Integration Section
+                React.createElement(McpSettingsSection),
 
                 // Developer Settings Section
                 React.createElement('div', {

--- a/main.js
+++ b/main.js
@@ -3899,6 +3899,14 @@ ipcMain.handle('mcp-response', (event, { requestId, data }) => {
   handleRendererResponse(requestId, data);
 });
 
+// MCP server info - expose path for Claude Desktop config UI
+ipcMain.handle('mcp-get-info', () => {
+  return {
+    stdioPath: path.join(__dirname, 'mcp-stdio.js'),
+    port: 9421
+  };
+});
+
 // Local Files IPC handlers
 ipcMain.handle('localFiles:addWatchFolder', async () => {
   console.log('=== Add Watch Folder ===');

--- a/preload.js
+++ b/preload.js
@@ -246,6 +246,7 @@ contextBridge.exposeInMainWorld('electron', {
 
   // MCP server operations (Claude Desktop integration)
   mcp: {
+    getInfo: () => ipcRenderer.invoke('mcp-get-info'),
     respond: (requestId, data) => ipcRenderer.invoke('mcp-response', { requestId, data }),
     onToolCall: (callback) => {
       ipcRenderer.on('mcp-tool-call', (event, data) => {


### PR DESCRIPTION
Adds a "Claude Desktop" card in Settings > General that displays the MCP server config snippet with the correct mcp-stdio.js path pre-filled. Includes a copy button for easy setup. The path is resolved from the app's install location via a new mcp-get-info IPC handler.

https://claude.ai/code/session_01RgHRDYQoVgjcdwNmecYeTJ