### PR TITLE
Add MusicKit meta tags to fix Apple Music auth dialog showing "appName"

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="apple-music-app-name" content="Parachord">
+  <meta name="apple-music-app-build" content="1.0.0">
   <title>Parachord Desktop</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <style>


### PR DESCRIPTION
MusicKit JS v3 may read the app name from <meta> tags rather than the programmatic configure() call when displaying the authorization dialog. Added apple-music-app-name and apple-music-app-build meta tags so the dialog shows "Parachord" instead of the literal "appName".

https://claude.ai/code/session_014vyS6NfFmUKdigAFZdLNV7