### PR TITLE
fix: prevent resolvers from vanishing when in resolverOrder but not l…

### DIFF
--- a/app.js
+++ b/app.js
@@ -39657,7 +39657,9 @@ useEffect(() => {
 
                     // Then, add all other resolvers (loaded but not enabled + marketplace-only)
                     // User sees no distinction - they're all just "Available"
-                    const addedIds = new Set(resolverOrder);
+                    // Only track IDs actually added above (not all of resolverOrder) so that
+                    // resolvers in resolverOrder but not in allResolvers still appear from marketplace
+                    const addedIds = new Set(unifiedResolvers.map(r => r.id));
 
                     // Loaded but not enabled
                     allResolvers.forEach(resolver => {


### PR DESCRIPTION
…oaded

addedIds was initialized from the full resolverOrder array, which includes IDs of resolvers that may not have loaded into allResolvers (e.g. if they were added to uninstalled_resolvers or failed to load). These ghost IDs blocked the resolver from appearing via the marketplace fallback, making it completely invisible in Settings > Streaming.

Now addedIds only tracks IDs actually added to unifiedResolvers, so unloaded resolvers properly fall through to the marketplace display.

https://claude.ai/code/session_01P5MCropTbvCL6cKW7ijM5x