### PR TITLE
fix: handle denied MusicKit auth, remove Spotify from default resolvers

### DIFF
--- a/app.js
+++ b/app.js
@@ -4643,8 +4643,8 @@ const Parachord = () => {
   const [homeHeaderCollapsed, setHomeHeaderCollapsed] = useState(false);
 
   const [trackSources, setTrackSources] = useState({}); // Resolved sources for each track: { trackId: { youtube: {...}, soundcloud: {...} } }
-  const [activeResolvers, setActiveResolvers] = useState(['spotify', 'bandcamp', 'localfiles']);
-  const [resolverOrder, setResolverOrder] = useState(['spotify', 'bandcamp', 'localfiles']);
+  const [activeResolvers, setActiveResolvers] = useState(['bandcamp', 'localfiles']);
+  const [resolverOrder, setResolverOrder] = useState(['bandcamp', 'localfiles']);
   const resolverSettingsLoaded = useRef(false);  // Track if we've loaded settings from storage
   const activeResolversRef = useRef(activeResolvers);  // Ref to avoid stale closure in save
   const resolverOrderRef = useRef(resolverOrder);  // Ref to avoid stale closure in save
@@ -26207,6 +26207,19 @@ ${tracks}
         }
 
         showToast('Apple Music connected successfully', 'success');
+      } else if (authResult.needsSystemSettings) {
+        // Previously denied — user must toggle permission in System Settings
+        showConfirmDialog({
+          type: 'info',
+          title: 'Apple Music Access Denied',
+          message: 'Apple Music access was previously denied. Please enable it in System Settings → Privacy & Security → Media & Apple Music, then try again.',
+          confirmLabel: 'Open System Settings',
+          onConfirm: () => {
+            if (window.electron?.shell?.openExternal) {
+              window.electron.shell.openExternal('x-apple.systempreferences:com.apple.preference.security?Privacy_MediaAppleMusic');
+            }
+          }
+        });
       } else {
         // User denied or other status
         showConfirmDialog({

--- a/native/musickit-helper/Sources/main.swift
+++ b/native/musickit-helper/Sources/main.swift
@@ -85,8 +85,30 @@ class MusicKitBridge {
 
     // Request authorization
     func authorize() async -> [String: Any] {
-        // Temporarily become a regular app so macOS shows the authorization dialog.
-        // Background/accessory apps can't present system auth prompts.
+        let currentStatus = MusicAuthorization.currentStatus
+
+        // If already authorized, return immediately
+        if currentStatus == .authorized {
+            isAuthorized = true
+            return [
+                "authorized": true,
+                "status": "authorized"
+            ]
+        }
+
+        // If previously denied, the system won't re-prompt — user must
+        // enable access in System Settings > Privacy & Security > Media & Apple Music
+        if currentStatus == .denied {
+            return [
+                "authorized": false,
+                "status": "denied",
+                "needsSystemSettings": true
+            ]
+        }
+
+        // Status is .notDetermined — we can request and macOS will show the dialog.
+        // Temporarily become a regular app so macOS presents the prompt.
+        // (Background/accessory apps can't present system auth prompts.)
         NSApp.setActivationPolicy(.regular)
         NSApp.activate(ignoringOtherApps: true)
 


### PR DESCRIPTION
Three fixes:

1. Swift helper now checks MusicAuthorization.currentStatus before calling request(). If already denied, returns needsSystemSettings flag instead of hanging. Only switches to .regular activation policy for the .notDetermined case where a dialog would actually appear.

2. App.js handles needsSystemSettings by showing a dialog with an "Open System Settings" button that opens Privacy & Security > Media & Apple Music directly.

3. Remove Spotify from default activeResolvers/resolverOrder. Spotify requires OAuth and shouldn't be in the resolve pipeline until the user authenticates. It's added back on successful auth and removed on disconnect.

https://claude.ai/code/session_01P5MCropTbvCL6cKW7ijM5x