### PR TITLE
Speed up app startup by parallelizing initialization

### DIFF
--- a/resolver-loader.js
+++ b/resolver-loader.js
@@ -54,17 +54,12 @@ class ResolverLoader {
    * Load multiple resolvers from an array of .axe contents
    */
   async loadResolvers(axeContents) {
-    const results = [];
-    for (const axeContent of axeContents) {
-      try {
-        const resolver = await this.loadResolver(axeContent);
-        results.push(resolver);
-      } catch (error) {
-        console.error('Failed to load resolver:', error);
-        // Continue loading other resolvers
-      }
-    }
-    return results;
+    const settled = await Promise.allSettled(
+      axeContents.map(axeContent => this.loadResolver(axeContent))
+    );
+    return settled
+      .filter(r => r.status === 'fulfilled')
+      .map(r => r.value);
   }
 
   /**


### PR DESCRIPTION
- Parallelize resolver loading: change sequential for...of loop to Promise.allSettled so resolvers load concurrently
- Parallelize initial IPC calls: API key, builtin resolvers, uninstalled list, and meta service configs now fetched via Promise.all instead of sequential awaits
- Parallelize meta service loading: URL lookup, AI generate, and chat services now load concurrently via Promise.all
- Defer AudioContext creation: create lazily on first playback instead of eagerly on mount, removing a synchronous browser API call from startup

https://claude.ai/code/session_014tEkEsRRPpt9HSfeiQTu8a