### PR TITLE
Always show Friends section in sidebar for discoverability

### DIFF
--- a/app.js
+++ b/app.js
@@ -27308,8 +27308,8 @@ useEffect(() => {
             )
           ),
 
-          // FRIENDS section (only show if there are pinned friends OR dragging a friend over)
-          (pinnedFriendIds.length > 0 || friendDragOverSidebar) && React.createElement('div', {
+          // FRIENDS section (always visible so new users can discover and add friends)
+          React.createElement('div', {
             className: 'rounded-lg transition-colors',
             style: friendDragOverSidebar ? {
               backgroundColor: 'rgba(124, 58, 237, 0.05)',


### PR DESCRIPTION
Previously the Friends section (with the + button to add friends) was hidden when the user had no pinned friends, making it invisible to new users who hadn't added anyone yet.

https://claude.ai/code/session_014tEkEsRRPpt9HSfeiQTu8a