### PR TITLE
Add page support indicator with pulsing badge animation

### DIFF
--- a/parachord-extension/popup.html
+++ b/parachord-extension/popup.html
@@ -81,6 +81,55 @@
       color: #22c55e;
     }
 
+    .page-indicator {
+      display: none;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 14px;
+      background: #f0fdf4;
+      border: 1px solid #bbf7d0;
+      border-radius: 10px;
+      margin-bottom: 12px;
+    }
+
+    .page-indicator.visible {
+      display: flex;
+    }
+
+    .page-indicator.unsupported {
+      background: #fefce8;
+      border-color: #fde68a;
+    }
+
+    .page-indicator-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: #22c55e;
+      flex-shrink: 0;
+      animation: pulse-dot 2s ease-in-out infinite;
+    }
+
+    .page-indicator.unsupported .page-indicator-dot {
+      background: #f59e0b;
+      animation: none;
+    }
+
+    @keyframes pulse-dot {
+      0%, 100% { opacity: 1; box-shadow: 0 0 6px rgba(34, 197, 94, 0.6); }
+      50% { opacity: 0.5; box-shadow: 0 0 2px rgba(34, 197, 94, 0.2); }
+    }
+
+    .page-indicator-text {
+      font-size: 12px;
+      color: #15803d;
+      font-weight: 500;
+    }
+
+    .page-indicator.unsupported .page-indicator-text {
+      color: #92400e;
+    }
+
     .actions {
       display: flex;
       flex-direction: column;
@@ -273,6 +322,11 @@
   <div class="status">
     <div class="status-dot" id="status-dot"></div>
     <span class="status-text" id="status-text">Connecting...</span>
+  </div>
+
+  <div class="page-indicator" id="page-indicator">
+    <div class="page-indicator-dot"></div>
+    <span class="page-indicator-text" id="page-indicator-text"></span>
   </div>
 
   <div class="actions">

--- a/parachord-extension/popup.js
+++ b/parachord-extension/popup.js
@@ -6,6 +6,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   const sendUrlBtn = document.getElementById('send-url');
   const sendUrlBtnText = document.getElementById('send-url-text');
   const sendUrlBtnIcon = document.getElementById('send-url-icon');
+  const pageIndicator = document.getElementById('page-indicator');
+  const pageIndicatorText = document.getElementById('page-indicator-text');
   const spotifyInterceptToggle = document.getElementById('spotify-intercept');
   const appleMusicInterceptToggle = document.getElementById('applemusic-intercept');
 
@@ -137,6 +139,48 @@ document.addEventListener('DOMContentLoaded', async () => {
     return { text: 'Play Next', icon: 'playNext' };
   }
 
+  // Service name labels
+  const SERVICE_NAMES = {
+    spotify: 'Spotify',
+    apple: 'Apple Music',
+    youtube: 'YouTube',
+    bandcamp: 'Bandcamp',
+    lastfm: 'Last.fm',
+    listenbrainz: 'ListenBrainz',
+    pitchfork: 'Pitchfork',
+    soundcloud: 'SoundCloud'
+  };
+
+  // Type labels
+  const TYPE_NAMES = {
+    track: 'track',
+    album: 'album',
+    playlist: 'playlist',
+    video: 'video',
+    artist: 'artist',
+    user: 'user profile',
+    likes: 'likes'
+  };
+
+  // Update page support indicator
+  function updatePageIndicator(pageInfo) {
+    const { service, type } = pageInfo;
+
+    if (service && type && type !== 'unknown') {
+      const serviceName = SERVICE_NAMES[service] || service;
+      const typeName = TYPE_NAMES[type] || type;
+      pageIndicatorText.textContent = `${serviceName} ${typeName} detected`;
+      pageIndicator.classList.add('visible');
+      pageIndicator.classList.remove('unsupported');
+    } else if (service && type === 'unknown') {
+      const serviceName = SERVICE_NAMES[service] || service;
+      pageIndicatorText.textContent = `${serviceName} page (unsupported type)`;
+      pageIndicator.classList.add('visible', 'unsupported');
+    } else {
+      pageIndicator.classList.remove('visible');
+    }
+  }
+
   // Update button based on current tab
   async function updateButtonForCurrentTab() {
     try {
@@ -146,6 +190,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       const pageInfo = detectPageType(tab.url);
       const buttonConfig = getButtonConfig(pageInfo);
 
+      updatePageIndicator(pageInfo);
       sendUrlBtnText.textContent = buttonConfig.text;
 
       // Update icon


### PR DESCRIPTION
## Summary
This PR adds a visual indicator to show when the extension detects a supported music service page. The badge now pulses with a breathing green animation when on a supported page, and displays a red "!" when disconnected. A new page indicator UI element in the popup shows which service and content type was detected.

## Key Changes

- **Badge animation system**: Implemented a pulsing green badge that animates through a breathing cycle (bright → dim → bright) when on supported pages, providing visual feedback that the extension recognizes the current page
- **Page support detection**: Added `isSupportedPage()` function that comprehensively checks URLs against supported music services:
  - Spotify (tracks, albums, playlists, artists)
  - Apple Music (albums, playlists, songs, artists)
  - YouTube (watch pages, playlists)
  - Bandcamp (tracks, albums, playlists)
  - Last.fm (user profiles)
  - ListenBrainz (user profiles)
  - Pitchfork (album/track reviews)
  - SoundCloud (tracks, playlists, user profiles)
- **Unified badge management**: Refactored badge updates into `updateBadge()` function that handles both connection status and page support state
- **Tab monitoring**: Added listeners for tab activation, URL changes, and window focus to keep the page support indicator in sync
- **Popup UI indicator**: Added a styled page indicator element that displays the detected service name and content type (e.g., "Spotify track detected"), with visual distinction for unsupported pages
- **Service/type labels**: Implemented mapping system to display human-readable service and content type names in the popup

## Implementation Details

- The pulse animation uses a 4-frame color cycle with 400ms intervals, creating a smooth breathing effect
- Page detection handles various URL patterns including international Spotify URLs and different hostname variations
- The indicator gracefully handles edge cases like missing URLs or invalid tab states
- Popup indicator updates in real-time as users navigate between pages

https://claude.ai/code/session_016XPQS1YvjxrWUwRPUj17T4