### PR TITLE
Fix Apple Music playlist scraping and add scrape retry logic

### DIFF
--- a/parachord-extension/content-applemusic.js
+++ b/parachord-extension/content-applemusic.js
@@ -371,7 +371,12 @@
       }
     }
 
-    console.log(`[Parachord] Found ${trackRows.length} track rows`);
+    console.log(`[Parachord] Found ${trackRows.length} track rows (wrapperAsRow: ${usingWrapperAsRow})`);
+
+    // Log first row's structure for debugging
+    if (trackRows.length > 0) {
+      console.log('[Parachord] First row HTML (truncated):', trackRows[0].innerHTML.substring(0, 300));
+    }
 
     trackRows.forEach((row, index) => {
       try {
@@ -425,7 +430,13 @@
             }
           }
 
-          if (trackName && artist) {
+          // Log first few tracks for debugging
+          if (index < 3) {
+            console.log(`[Parachord] Track ${index + 1}: "${trackName}" by "${artist}" (has title el: ${!!trackNameEl}, has artist el: ${!!artistEl})`);
+          }
+
+          // Accept tracks even without artist (some playlist views don't show artist inline)
+          if (trackName) {
             tracks.push({
               title: trackName,
               artist: artist,
@@ -434,6 +445,9 @@
               position: index + 1
             });
           }
+        } else if (index < 3) {
+          // Log why first few rows failed to extract
+          console.log(`[Parachord] Track ${index + 1}: no title element found. Row text: "${row.textContent.trim().substring(0, 100)}"`);
         }
       } catch (e) {
         console.error('[Parachord] Error scraping track row:', e);

--- a/plugins/applemusic.axe
+++ b/plugins/applemusic.axe
@@ -18,9 +18,9 @@
     "urlLookup": true
   },
   "urlPatterns": [
-    "music.apple.com/*/album/*",
-    "music.apple.com/*/song/*",
-    "music.apple.com/*/playlist/*",
+    "music.apple.com/*/album/*/*",
+    "music.apple.com/*/song/*/*",
+    "music.apple.com/*/playlist/*/*",
     "itunes.apple.com/*"
   ],
   "settings": {


### PR DESCRIPTION
The Apple Music DOM scraper now uses data-testid selectors as the primary match (more stable than class names) and falls back to using song-name-wrapper elements as row proxies when the row container class changes. Also adds data-testid="track-title-by-line" for artist detection, which is the actual attribute Apple Music uses.

The popup now retries scraping up to 3 times with 1.5s delays for services where URL fallback cannot resolve playlists (Apple Music, Spotify). When all retries fail, shows a clear "Scrape failed" error instead of a false "Sent!" confirmation that silently drops the playlist.

https://claude.ai/code/session_016XPQS1YvjxrWUwRPUj17T4