### PR TITLE
Fix Local Files icon flashing when no local match is found

### DIFF
--- a/app.js
+++ b/app.js
@@ -18664,10 +18664,10 @@ const Parachord = () => {
         return;
       }
 
-      // Update state with combined sources
+      // Update state with combined sources (filter noMatch sentinels for UI)
       setTrackSources(prev => ({
         ...prev,
-        [trackKey]: sources
+        [trackKey]: filterNoMatch(sources)
       }));
 
       // Update cache with new sources
@@ -18805,14 +18805,16 @@ const Parachord = () => {
           console.log(`  ✅ ${resolver.name}: Found match (confidence: ${(sources[resolver.id].confidence * 100).toFixed(0)}%)`);
 
           // Flush to UI immediately so results appear as each resolver completes
+          // Filter noMatch sentinels so icons don't flash for resolvers with no match
           if (!signal?.aborted) {
+            const flushed = filterNoMatch(sources);
             setTrackSources(prev => ({
               ...prev,
-              [trackKey]: { ...prev[trackKey], ...sources }
+              [trackKey]: { ...prev[trackKey], ...flushed }
             }));
             if (isQueueResolution && track.id) {
               setCurrentQueue(prev => prev.map(t =>
-                t.id === track.id ? { ...t, sources: { ...t.sources, ...sources } } : t
+                t.id === track.id ? { ...t, sources: { ...t.sources, ...flushed } } : t
               ));
             }
           }


### PR DESCRIPTION
The intermediate flush in resolveTrack() spread the entire accumulated sources object into the UI state, including noMatch sentinels from resolvers that found nothing. This caused the Local Files icon to briefly appear (when another resolver's match triggered a flush) then disappear (when the final filterNoMatch update ran).

Fixed both intermediate flush locations to use filterNoMatch() before setting UI state, matching the final update behavior.

https://claude.ai/code/session_01TpeZ9B7hL4wDmq4qYdB67t