### PR TITLE
Fix Apple Music auth failing when Music.app is not running

### DIFF
--- a/app.js
+++ b/app.js
@@ -26723,8 +26723,17 @@ ${tracks}
     checkMusicKitAvailable();
   }, []);
 
+  const appleMusicConnectingRef = useRef(false);
   const connectAppleMusic = async () => {
+    // Guard against multiple simultaneous connection attempts
+    if (appleMusicConnectingRef.current) {
+      console.log('[AppleMusic] Connection already in progress, ignoring click');
+      return;
+    }
+    appleMusicConnectingRef.current = true;
     console.log('=== Connect Apple Music Clicked ===');
+
+    try {
 
     // Try MusicKit JS first (works cross-platform, requires developer token)
     const musicKitWeb = window.getMusicKitWeb ? window.getMusicKitWeb() : null;
@@ -26847,6 +26856,10 @@ ${tracks}
         title: 'Authentication Failed',
         message: error.message || 'Apple Music authentication failed. Please try again.'
       });
+    }
+
+    } finally {
+      appleMusicConnectingRef.current = false;
     }
   };
 


### PR DESCRIPTION
The native MusicKit helper toggles NSApp activation policy to present the system authorization dialog, but the policy change hadn't propagated before MusicAuthorization.request() fired, so macOS couldn't present the dialog and it silently failed. Each click re-triggered the attempt, causing the dock icon to bounce repeatedly.

Two fixes:
- Swift helper: add 0.5s delay after activation policy change to let macOS bring the app to foreground, and retry once if auth returns notDetermined (dialog may not have appeared)
- JS side: guard against multiple simultaneous connection attempts so rapid clicks don't spawn competing authorization requests

https://claude.ai/code/session_01TpeZ9B7hL4wDmq4qYdB67t