### PR TITLE
Fix black screen and 'Render frame was disposed' error

### DIFF
--- a/app.js
+++ b/app.js
@@ -16587,7 +16587,12 @@ const Parachord = () => {
 
   // Cache utility functions
   const loadCacheFromStore = async () => {
-    if (!window.electron?.store) return;
+    if (!window.electron?.store) {
+      console.warn('📦 electron.store not available, skipping cache load');
+      resolverSettingsLoaded.current = true;
+      setCacheLoaded(true);
+      return;
+    }
 
     try {
       // Load album art cache (keep full { url, timestamp } structure)


### PR DESCRIPTION
- Add safeSendToRenderer() helper that checks both window.isDestroyed() and webContents.isDestroyed() before sending IPC messages
- Convert all mainWindow.webContents.send() calls to use the safe helper, including protocol URL handlers, playback window events, context menus, embed handlers, extension WebSocket, and auth callbacks
- Update existing sendToRenderer helpers (spotifyPoller, appleMusicPoller) to also check webContents.isDestroyed()
- Change BrowserWindow backgroundColor from dark navy (#0f172a) to light gray (#f3f4f6) so flash-of-background matches the app theme
- Fix loadCacheFromStore early return when electron.store is unavailable: set cacheLoaded=true so the app doesn't get stuck on the loading screen

https://claude.ai/code/session_01TpeZ9B7hL4wDmq4qYdB67t