### PR TITLE
Replace custom window.open with standard target="_blank" for service links

### DIFF
--- a/smart-links/lib/html.js
+++ b/smart-links/lib/html.js
@@ -40,7 +40,7 @@ export function generateLinkPageHtml(data, linkId, baseUrl) {
     const url = urls?.[s.id];
     if (!url) return '';
     return `
-      <a href="${escapeHtml(url)}" onclick="window.open(this.href, '${s.id}', 'width=1024,height=768,menubar=no,toolbar=no,location=yes,status=no'); return false;" class="service-link" style="--service-color: ${s.color}">
+      <a href="${escapeHtml(url)}" target="_blank" rel="noopener noreferrer" class="service-link" style="--service-color: ${s.color}">
         <span class="service-icon">${SERVICE_ICONS[s.id]}</span>
         <span class="service-name">${s.name}</span>
       </a>`;


### PR DESCRIPTION
## Summary
Simplified the service link implementation by replacing custom `window.open()` behavior with standard HTML attributes for opening links in new tabs.

## Key Changes
- Removed `onclick` handler that used `window.open()` with custom window dimensions (1024x768)
- Replaced with standard `target="_blank"` attribute to open links in new tabs
- Added `rel="noopener noreferrer"` for security best practices when opening external links
- Maintains the same visual styling with the `service-link` class and color variable

## Benefits
- Improved security by preventing the opened window from accessing the `window.opener` property
- Better user experience by respecting browser/OS default window behavior instead of forcing specific dimensions
- Cleaner, more maintainable code using standard HTML attributes
- Better accessibility and compatibility with browser extensions and user preferences

https://claude.ai/code/session_01BF2VFehb91zATnQcsDhV8W