### PR TITLE
Fix smart-links deploy to use pages_build_output_dir from wrangler.toml

### DIFF
--- a/smart-links/package.json
+++ b/smart-links/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "description": "Shareable smart links for Parachord - like feature.fm/linkfire",
   "scripts": {
-    "dev": "wrangler pages dev . --kv=LINKS",
-    "deploy": "wrangler pages deploy .",
+    "dev": "wrangler pages dev --kv=LINKS",
+    "deploy": "wrangler pages deploy",
     "kv:create": "wrangler kv:namespace create LINKS",
     "kv:create:preview": "wrangler kv:namespace create LINKS --preview"
   },


### PR DESCRIPTION
The explicit '.' argument in 'wrangler pages deploy .' was overriding pages_build_output_dir = "public", causing static assets in public/ to be nested under /public/ instead of served at the root. This made the SoundCloud PNG (and any other static assets) 404 because the HTML referenced /assets/icons/... but the file was at /public/assets/icons/...

https://claude.ai/code/session_01BF2VFehb91zATnQcsDhV8W