### PR TITLE
Add auto-deploy workflow for smart-links to Cloudflare Pages

### DIFF
--- a/.github/workflows/deploy-smart-links.yml
+++ b/.github/workflows/deploy-smart-links.yml
@@ -1,0 +1,32 @@
+name: Deploy Smart Links
+
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - 'smart-links/**'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        working-directory: smart-links
+        run: npm ci
+
+      - name: Deploy to Cloudflare Pages
+        working-directory: smart-links
+        run: npx wrangler pages deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
Triggers on pushes to main/master that touch smart-links/ files, or manually via workflow_dispatch. Requires CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID secrets in the repo settings.

https://claude.ai/code/session_01BF2VFehb91zATnQcsDhV8W