### PR TITLE
Improve HTML description parsing with entity decoding

### DIFF
--- a/app.js
+++ b/app.js
@@ -21569,8 +21569,9 @@ ${tracks}
         const spotifyMatch = descriptionRaw.match(/href="(https:\/\/open\.spotify\.com\/album\/[^"]+)"/);
         const spotifyUrl = spotifyMatch ? spotifyMatch[1] : null;
 
-        // Strip HTML tags and remove any remaining Spotify URLs from the synopsis
-        let description = descriptionRaw.replace(/<[^>]*>/g, '').trim();
+        // Strip HTML tags, decode HTML entities, and remove any remaining Spotify URLs from the synopsis
+        const descDoc = new DOMParser().parseFromString(descriptionRaw, 'text/html');
+        let description = (descDoc.body.textContent || '').trim();
         // Remove plain text Spotify URLs that might remain after HTML stripping
         description = description.replace(/https:\/\/open\.spotify\.com\/album\/\S+/g, '').trim();
 


### PR DESCRIPTION
## Summary
Updated the description parsing logic to properly decode HTML entities when stripping HTML tags from album descriptions.

## Key Changes
- Replaced regex-based HTML tag stripping with DOMParser for more robust HTML parsing
- Now properly decodes HTML entities (e.g., `&amp;`, `&quot;`, `&#39;`) that were previously left in the text
- Maintains existing functionality of removing Spotify URLs from descriptions

## Implementation Details
- Uses `DOMParser().parseFromString()` to parse the HTML string and extract clean text content via `textContent`
- The DOMParser approach automatically handles HTML entity decoding as part of the DOM parsing process
- Preserves the subsequent regex-based cleanup step to remove any remaining plain text Spotify URLs

https://claude.ai/code/session_017FM9NDDVNS2oj8BzfXKYV6