### PR TITLE
Fix double-encoded HTML entities in critics picks descriptions

### DIFF
--- a/app.js
+++ b/app.js
@@ -21569,9 +21569,15 @@ ${tracks}
         const spotifyMatch = descriptionRaw.match(/href="(https:\/\/open\.spotify\.com\/album\/[^"]+)"/);
         const spotifyUrl = spotifyMatch ? spotifyMatch[1] : null;
 
-        // Strip HTML tags, decode HTML entities, and remove any remaining Spotify URLs from the synopsis
-        const descDoc = new DOMParser().parseFromString(descriptionRaw, 'text/html');
-        let description = (descDoc.body.textContent || '').trim();
+        // Strip HTML tags and fully decode HTML entities (the RSS CDATA content may
+        // contain double-encoded entities like &amp;amp; so we decode in a loop until stable)
+        let description = descriptionRaw;
+        let prev;
+        do {
+          prev = description;
+          const descDoc = new DOMParser().parseFromString(description, 'text/html');
+          description = (descDoc.body.textContent || '').trim();
+        } while (description !== prev);
         // Remove plain text Spotify URLs that might remain after HTML stripping
         description = description.replace(/https:\/\/open\.spotify\.com\/album\/\S+/g, '').trim();
 


### PR DESCRIPTION
The RSS feed wraps descriptions in CDATA sections that contain double-encoded entities (e.g., &amp;amp; inside CDATA). Since CDATA content is treated as literal text, the XML parser doesn't decode anything, leaving multiple layers of HTML encoding. The previous single-pass DOMParser decode only stripped one layer. Decode in a loop until the text stabilizes to handle any depth of encoding.

https://claude.ai/code/session_017FM9NDDVNS2oj8BzfXKYV6