### PR TITLE
Add Weekly Exploration playlists and AI recommendations to home

### DIFF
--- a/app.js
+++ b/app.js
@@ -1234,6 +1234,55 @@ const Tooltip = ({ children, content, position = 'top', variant = 'light', class
   );
 };
 
+// FixedTooltip - uses position:fixed to escape overflow:hidden containers
+// Shows tooltip below the trigger element, left-aligned to avoid sidebar clipping
+const FixedTooltip = ({ children, content }) => {
+  const [visible, setVisible] = useState(false);
+  const [coords, setCoords] = useState({ top: 0, left: 0 });
+  const triggerRef = useRef(null);
+
+  const show = () => {
+    if (triggerRef.current) {
+      const rect = triggerRef.current.getBoundingClientRect();
+      setCoords({ top: rect.bottom + 6, left: rect.left });
+    }
+    setVisible(true);
+  };
+  const hide = () => setVisible(false);
+
+  return React.createElement('div', {
+    ref: triggerRef,
+    onMouseEnter: show,
+    onMouseLeave: hide,
+    style: { position: 'relative' }
+  },
+    children,
+    visible && content && ReactDOM.createPortal(
+      React.createElement('div', {
+        style: {
+          position: 'fixed',
+          top: coords.top,
+          left: coords.left,
+          zIndex: 99999,
+          maxWidth: 280,
+          minWidth: 180,
+          backgroundColor: '#1f2937',
+          color: '#ffffff',
+          borderRadius: 8,
+          padding: '10px 14px',
+          fontSize: 12,
+          lineHeight: 1.5,
+          boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15), 0 2px 4px rgba(0, 0, 0, 0.1)',
+          pointerEvents: 'none',
+          opacity: visible ? 1 : 0,
+          transition: 'opacity 150ms ease'
+        }
+      }, content),
+      document.body
+    )
+  );
+};
+
 // TrackRow component - defined outside to prevent recreation on every render
 const TrackRow = React.memo(({ track, isPlaying, handlePlay, onArtistClick, onContextMenu, allResolvers, resolverOrder, activeResolvers }) => {
   // Get available sources (track.sources is an object with resolver IDs as keys)
@@ -36012,45 +36061,24 @@ useEffect(() => {
                               )
                             ),
                             // Album title + artist with reason tooltip
-                            album.reason
-                              ? React.createElement(Tooltip, {
-                                  content: album.reason,
-                                  position: 'bottom',
-                                  className: 'tooltip-bio'
-                                },
-                                  React.createElement('div', null,
-                                    React.createElement('h3', {
-                                      style: {
-                                        fontWeight: '500',
-                                        fontSize: '13px',
-                                        color: '#1f2937',
-                                        overflow: 'hidden',
-                                        textOverflow: 'ellipsis',
-                                        whiteSpace: 'nowrap',
-                                        marginBottom: '2px'
-                                      }
-                                    }, album.title),
-                                    React.createElement('p', {
-                                      style: { fontSize: '12px', color: '#6b7280', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }
-                                    }, album.artist)
-                                  )
-                                )
-                              : React.createElement('div', null,
-                                  React.createElement('h3', {
-                                    style: {
-                                      fontWeight: '500',
-                                      fontSize: '13px',
-                                      color: '#1f2937',
-                                      overflow: 'hidden',
-                                      textOverflow: 'ellipsis',
-                                      whiteSpace: 'nowrap',
-                                      marginBottom: '2px'
-                                    }
-                                  }, album.title),
-                                  React.createElement('p', {
-                                    style: { fontSize: '12px', color: '#6b7280', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }
-                                  }, album.artist)
-                                )
+                            React.createElement(FixedTooltip, { content: album.reason },
+                              React.createElement('div', null,
+                                React.createElement('h3', {
+                                  style: {
+                                    fontWeight: '500',
+                                    fontSize: '13px',
+                                    color: '#1f2937',
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    whiteSpace: 'nowrap',
+                                    marginBottom: '2px'
+                                  }
+                                }, album.title),
+                                React.createElement('p', {
+                                  style: { fontSize: '12px', color: '#6b7280', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }
+                                }, album.artist)
+                              )
+                            )
                           )
                         )
                       )
@@ -36070,7 +36098,7 @@ useEffect(() => {
                         aiRecs.artists.map((artist, index) =>
                           React.createElement('div', {
                             key: `ai-artist-${artist.name}`,
-                            className: 'bg-white rounded-lg overflow-hidden hover:shadow-lg transition-shadow cursor-pointer group release-card card-fade-up',
+                            className: 'bg-white rounded-lg hover:shadow-lg transition-shadow cursor-pointer group release-card card-fade-up',
                             style: {
                               animationDelay: `${index * 50}ms`
                             },
@@ -36166,23 +36194,13 @@ useEffect(() => {
                               )
                             ),
                             // Artist name section with reason tooltip
-                            artist.reason
-                              ? React.createElement(Tooltip, {
-                                  content: artist.reason,
-                                  position: 'bottom',
-                                  className: 'tooltip-bio'
-                                },
-                                  React.createElement('div', { className: 'p-3' },
-                                    React.createElement('p', {
-                                      className: 'font-medium text-gray-900 truncate text-sm'
-                                    }, artist.name)
-                                  )
-                                )
-                              : React.createElement('div', { className: 'p-3' },
-                                  React.createElement('p', {
-                                    className: 'font-medium text-gray-900 truncate text-sm'
-                                  }, artist.name)
-                                )
+                            React.createElement(FixedTooltip, { content: artist.reason },
+                              React.createElement('div', { className: 'p-3' },
+                                React.createElement('p', {
+                                  className: 'font-medium text-gray-900 truncate text-sm'
+                                }, artist.name)
+                              )
+                            )
                           )
                         )
                       )


### PR DESCRIPTION
## Summary
Extends the home page with support for ListenBrainz Weekly Exploration playlists alongside existing Weekly Jams, and adds AI-generated music recommendations powered by enabled chat services.

## Key Changes

### ListenBrainz Weekly Playlists
- Renamed `loadWeeklyJams()` to `loadWeeklyPlaylists()` to handle both Weekly Jams and Weekly Exploration playlists
- Added `weeklyExploration` state field to `homeData` to store exploration playlists separately
- Updated playlist loading logic to fetch and categorize both playlist types from ListenBrainz API
- Modified UI to display both playlist types side-by-side when both are available, or in a 4-column grid when only one type exists
- Updated cover loading and track management to work with both playlist types
- Fixed pending playlist restoration to check both `weeklyJams` and `weeklyExploration` arrays

### AI-Generated Recommendations
- Added `aiRecommendations` state field to `homeData` with structure: `{ albums: [], artists: [], loading: false }`
- Implemented `loadAiRecommendations()` function that:
  - Uses enabled chat service providers to generate recommendations
  - Builds listening context from user's history (recent listens, top artists/albums) and collection data
  - Sends structured prompt to AI requesting 5 albums and 5 artists with reasoning
  - Parses JSON response and handles markdown code block formatting
- Added `useEffect` hook to load recommendations when home view is active and chat services are enabled
- Asynchronously loads album art and artist images for recommendations
- Displays recommendations in a 5-column grid layout with loading skeleton state
- Added "Refresh" button to reload recommendations
- Falls back to original "Surprise Me" card if no AI recommendations are available

### UI/UX Improvements
- Weekly playlists now display in a responsive grid that adapts based on available content
- AI recommendations section appears before the fallback "Surprise Me" card
- Added visual distinction with "Shuffleupagus" branding for AI recommendations
- Improved loading states with skeleton screens for recommendations
- Updated playback context handling to support both weekly-jam and weekly-exploration types

## Implementation Details
- Refactored weekly playlist rendering into a reusable `renderWeeklyColumn()` function
- Maintained backward compatibility with existing Weekly Jams functionality
- AI recommendations respect user's data sharing preferences via `aiIncludeHistoryRef`
- Graceful fallback when AI services are unavailable or recommendations fail to load

https://claude.ai/code/session_01Ax9Azy5aytKNDuuQbu4e3g