### PR TITLE
Fix missing previous weeks in Weekly Jams/Exploration playlists

### DIFF
--- a/app.js
+++ b/app.js
@@ -22566,8 +22566,9 @@ ${tracks}
 
     try {
       // Fetch playlists created for the user (includes Weekly Jams, Weekly Exploration, etc.)
+      // Request enough results to capture several weeks of both jams and exploration playlists
       const response = await fetch(
-        `https://api.listenbrainz.org/1/user/${encodeURIComponent(listenbrainzConfig.username)}/playlists/createdfor`
+        `https://api.listenbrainz.org/1/user/${encodeURIComponent(listenbrainzConfig.username)}/playlists/createdfor?count=100`
       );
 
       if (!response.ok) return { jams: null, exploration: null };


### PR DESCRIPTION
The ListenBrainz createdfor API was called without a count parameter, defaulting to ~25 results. Since the response includes all types of created-for playlists (not just weekly ones), older weekly playlists were often pushed off the first page. Increase count to 100 to ensure we capture several weeks of both Jams and Exploration playlists.

https://claude.ai/code/session_01Ax9Azy5aytKNDuuQbu4e3g