### PR TITLE
Add album/playlist queue support for smart link embeds

### DIFF
--- a/app.js
+++ b/app.js
@@ -8526,9 +8526,16 @@ const Parachord = () => {
     });
 
     // Handle play requests from embed
-    window.electron.embed.onPlay(({ track }) => {
-      console.log('▶️ Embed play request:', track?.title);
+    window.electron.embed.onPlay(({ track, queue }) => {
+      console.log('▶️ Embed play request:', track?.title, queue ? `(+${queue.length} queued)` : '');
       if (track && handlePlayRef.current) {
+        if (queue && queue.length > 0) {
+          // Album/playlist: set queue with remaining tracks, then play first
+          const context = { type: 'smartlink', name: track.album || track.title };
+          const taggedTracks = queue.map(t => ({ ...t, _playbackContext: context }));
+          setCurrentQueue(taggedTracks);
+          setPlaybackContext(context);
+        }
         handlePlayRef.current(track);
       }
     });

--- a/main.js
+++ b/main.js
@@ -985,7 +985,7 @@ async function handleEmbedMessage(ws, message) {
 
     case 'play':
       if (mainWindow) {
-        safeSendToRenderer('embed-play', { track: payload?.track });
+        safeSendToRenderer('embed-play', { track: payload?.track, queue: payload?.queue });
         sendResponse({ success: true });
       } else {
         sendResponse({ success: false, error: 'App not ready' });


### PR DESCRIPTION
## Summary
Enhanced smart link embeds to properly handle albums and playlists by displaying service links as an icon row for collections and implementing queue-based playback that sends all tracks to Parachord.

## Key Changes

- **UI improvements for collections**: Service links now display as circular icon buttons in a row layout for albums/playlists, while single tracks retain the full button style
- **Queue support**: Albums and playlists now send all tracks as a queue to Parachord, with the first track playing immediately and remaining tracks queued
- **Track context enrichment**: Queued tracks include album context (title, artist, album art) for proper display in the player
- **IPC message updates**: Updated embed play messages to include optional `queue` parameter for multi-track playback
- **Playback context**: Sets smartlink context for queued tracks so the player knows they originated from a smart link

## Implementation Details

- Added new `.service-icon-link` CSS class with hover effects (border highlight, subtle lift animation)
- Modified `playInParachord()` to detect collections via `linkData.tracks` and format them as `{ track, queue }` payloads
- Updated Electron IPC handlers in both renderer and main process to pass queue data through the embed play flow
- Maintains backward compatibility with single-track playback

https://claude.ai/code/session_01CusHZZkge1x2w3bgJyah6e