### PR TITLE
Fix album-level enrichment matching against track name instead of alb…

### DIFF
--- a/smart-links/lib/enrich.js
+++ b/smart-links/lib/enrich.js
@@ -206,8 +206,21 @@ async function enrichAlbumUrls(albumObj, title, artist, spotifyToken) {
 
   const resolved = await Promise.all(searches);
 
+  const normTitle = normalize(title);
+  const normArtist = normalize(artist);
+
   for (const { service, results } of resolved) {
-    const match = findBestMatch(results, title, artist || '');
+    // Match by album name (not track name) since we're looking for the album
+    const match = results.find(r => {
+      const normAlbum = normalize(r.album);
+      const normResultArtist = normalize(r.artist);
+      return normAlbum === normTitle && normResultArtist.includes(normArtist);
+    }) || results.find(r => {
+      const normAlbum = normalize(r.album);
+      const normResultArtist = normalize(r.artist);
+      return (normAlbum.includes(normTitle) || normTitle.includes(normAlbum)) &&
+             (normResultArtist.includes(normArtist) || normArtist.includes(normResultArtist));
+    });
     if (match && match.albumUrl) {
       albumObj.urls[service] = match.albumUrl;
       changed = true;


### PR DESCRIPTION
…um name

enrichAlbumUrls was passing the album title to findBestMatch, which compares against r.title (the track name). Since no track is named the same as the album, the match always failed and album-level service URLs (Apple Music, Spotify) were never set.

Now matches against r.album from search results instead, so any track result from the correct album will provide the albumUrl.

https://claude.ai/code/session_01CusHZZkge1x2w3bgJyah6e