### PR TITLE
Add Share button to album and playlist detail pages

### DIFF
--- a/app.js
+++ b/app.js
@@ -3557,7 +3557,73 @@ const ReleasePage = ({
               fontSize: isCompact ? '0.75rem' : '0.875rem',
               transition: 'font-size 300ms ease'
             }
-          }, release.tracks ? `${release.tracks.length.toString().padStart(2, '0')} Songs` : 'Loading...')
+          }, release.tracks ? `${release.tracks.length.toString().padStart(2, '0')} Songs` : 'Loading...'),
+          // Share button
+          React.createElement('div', { className: 'relative mt-2' },
+            React.createElement('button', {
+              onClick: (e) => { e.stopPropagation(); setShareDropdownOpen(shareDropdownOpen === 'album' ? false : 'album'); },
+              className: 'flex items-center gap-1.5 text-sm text-gray-400 hover:text-gray-600 transition-colors no-drag',
+              style: { fontSize: isCompact ? '0.75rem' : '0.8rem' }
+            },
+              React.createElement('svg', { className: 'w-3.5 h-3.5', fill: 'none', viewBox: '0 0 24 24', stroke: 'currentColor', strokeWidth: 2 },
+                React.createElement('path', { strokeLinecap: 'round', strokeLinejoin: 'round', d: 'M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z' })
+              ),
+              'Share'
+            ),
+            shareDropdownOpen === 'album' && React.createElement('div', {
+              className: 'absolute left-0 top-full mt-1 bg-white rounded-lg shadow-lg py-1 min-w-[160px] z-30 border border-gray-200',
+              onClick: (e) => e.stopPropagation()
+            },
+              React.createElement('button', {
+                onClick: () => {
+                  setShareDropdownOpen(false);
+                  const collectionData = {
+                    title: release.title,
+                    artist: release.artist?.name || release.artist,
+                    albumArt: release.albumArt,
+                    type: 'album',
+                    tracks: (release.tracks || []).map((t, i) => ({
+                      title: t.title || 'Unknown',
+                      artist: t.artist || release.artist?.name || null,
+                      duration: t.duration || null,
+                      trackNumber: t.trackNumber || (i + 1)
+                    }))
+                  };
+                  publishCollectionSmartLink(collectionData);
+                },
+                className: 'w-full px-4 py-2 text-left text-sm text-gray-600 hover:bg-gray-100 flex items-center gap-2 no-drag'
+              },
+                React.createElement('svg', { className: 'w-4 h-4', fill: 'none', viewBox: '0 0 24 24', stroke: 'currentColor', strokeWidth: 2 },
+                  React.createElement('path', { strokeLinecap: 'round', strokeLinejoin: 'round', d: 'M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1' })
+                ),
+                'Copy Link'
+              ),
+              React.createElement('button', {
+                onClick: () => {
+                  setShareDropdownOpen(false);
+                  const collectionData = {
+                    title: release.title,
+                    artist: release.artist?.name || release.artist,
+                    albumArt: release.albumArt,
+                    type: 'album',
+                    tracks: (release.tracks || []).map((t, i) => ({
+                      title: t.title || 'Unknown',
+                      artist: t.artist || release.artist?.name || null,
+                      duration: t.duration || null,
+                      trackNumber: t.trackNumber || (i + 1)
+                    }))
+                  };
+                  copyCollectionEmbedCode(collectionData);
+                },
+                className: 'w-full px-4 py-2 text-left text-sm text-gray-600 hover:bg-gray-100 flex items-center gap-2 no-drag'
+              },
+                React.createElement('svg', { className: 'w-4 h-4', fill: 'none', viewBox: '0 0 24 24', stroke: 'currentColor', strokeWidth: 2 },
+                  React.createElement('path', { strokeLinecap: 'round', strokeLinejoin: 'round', d: 'M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4' })
+                ),
+                'Copy Embed Code'
+              )
+            )
+          )
         )
       );
     })(),
@@ -4919,6 +4985,7 @@ const Parachord = () => {
   const [playlistDropTarget, setPlaylistDropTarget] = useState(null); // Index where track will be dropped
   const [playlistEditMode, setPlaylistEditMode] = useState(false); // Edit mode for playlist detail view
   const [editedPlaylistData, setEditedPlaylistData] = useState(null); // Buffered changes: { title, creator, tracks }
+  const [shareDropdownOpen, setShareDropdownOpen] = useState(false); // Share dropdown on album/playlist detail pages
   const [currentArtist, setCurrentArtist] = useState(null); // Artist page data
   const [artistImage, setArtistImage] = useState(null); // Artist image from Spotify
   const [artistImagePosition, setArtistImagePosition] = useState('center 25%'); // Face-centered position
@@ -5373,6 +5440,15 @@ const Parachord = () => {
       return () => document.removeEventListener('click', handleClickOutside);
     }
   }, [collectionSortDropdownOpen]);
+
+  // Close share dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = () => setShareDropdownOpen(false);
+    if (shareDropdownOpen) {
+      document.addEventListener('click', handleClickOutside);
+      return () => document.removeEventListener('click', handleClickOutside);
+    }
+  }, [shareDropdownOpen]);
 
   // Track main content width for responsive header buttons
   useEffect(() => {
@@ -34286,6 +34362,74 @@ useEffect(() => {
                 selectedPlaylist.lastModified && React.createElement('p', {
                   className: 'text-xs text-gray-400'
                 }, `Modified: ${new Date(selectedPlaylist.lastModified).toLocaleDateString()}`),
+                // Share button
+                React.createElement('div', { className: 'relative mt-2' },
+                  React.createElement('button', {
+                    onClick: (e) => { e.stopPropagation(); setShareDropdownOpen(shareDropdownOpen === 'playlist' ? false : 'playlist'); },
+                    className: 'flex items-center gap-1.5 text-sm text-gray-400 hover:text-gray-600 transition-colors no-drag',
+                    style: { fontSize: '0.8rem' }
+                  },
+                    React.createElement('svg', { className: 'w-3.5 h-3.5', fill: 'none', viewBox: '0 0 24 24', stroke: 'currentColor', strokeWidth: 2 },
+                      React.createElement('path', { strokeLinecap: 'round', strokeLinejoin: 'round', d: 'M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z' })
+                    ),
+                    'Share'
+                  ),
+                  shareDropdownOpen === 'playlist' && React.createElement('div', {
+                    className: 'absolute left-0 top-full mt-1 bg-white rounded-lg shadow-lg py-1 min-w-[160px] z-30 border border-gray-200',
+                    onClick: (e) => e.stopPropagation()
+                  },
+                    React.createElement('button', {
+                      onClick: () => {
+                        setShareDropdownOpen(false);
+                        const collectionData = {
+                          title: selectedPlaylist.title,
+                          artist: null,
+                          creator: selectedPlaylist.creator || null,
+                          albumArt: playlistCoverArt?.[0] || null,
+                          type: 'playlist',
+                          tracks: (playlistTracks || []).map((t, i) => ({
+                            title: t.title || 'Unknown',
+                            artist: t.artist || null,
+                            duration: t.duration || null,
+                            trackNumber: t.trackNumber || (i + 1)
+                          }))
+                        };
+                        publishCollectionSmartLink(collectionData);
+                      },
+                      className: 'w-full px-4 py-2 text-left text-sm text-gray-600 hover:bg-gray-100 flex items-center gap-2 no-drag'
+                    },
+                      React.createElement('svg', { className: 'w-4 h-4', fill: 'none', viewBox: '0 0 24 24', stroke: 'currentColor', strokeWidth: 2 },
+                        React.createElement('path', { strokeLinecap: 'round', strokeLinejoin: 'round', d: 'M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1' })
+                      ),
+                      'Copy Link'
+                    ),
+                    React.createElement('button', {
+                      onClick: () => {
+                        setShareDropdownOpen(false);
+                        const collectionData = {
+                          title: selectedPlaylist.title,
+                          artist: null,
+                          creator: selectedPlaylist.creator || null,
+                          albumArt: playlistCoverArt?.[0] || null,
+                          type: 'playlist',
+                          tracks: (playlistTracks || []).map((t, i) => ({
+                            title: t.title || 'Unknown',
+                            artist: t.artist || null,
+                            duration: t.duration || null,
+                            trackNumber: t.trackNumber || (i + 1)
+                          }))
+                        };
+                        copyCollectionEmbedCode(collectionData);
+                      },
+                      className: 'w-full px-4 py-2 text-left text-sm text-gray-600 hover:bg-gray-100 flex items-center gap-2 no-drag'
+                    },
+                      React.createElement('svg', { className: 'w-4 h-4', fill: 'none', viewBox: '0 0 24 24', stroke: 'currentColor', strokeWidth: 2 },
+                        React.createElement('path', { strokeLinecap: 'round', strokeLinejoin: 'round', d: 'M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4' })
+                      ),
+                      'Copy Embed Code'
+                    )
+                  )
+                ),
                 // Delete Playlist button (only in edit mode)
                 playlistEditMode && React.createElement('button', {
                   onClick: () => {


### PR DESCRIPTION
Adds a Share button in the left column metadata section of both album and playlist detail views. Clicking it reveals a dropdown with two options:
- Copy Link: calls publishCollectionSmartLink (same as context menu)
- Copy Embed Code: calls copyCollectionEmbedCode (same as context menu)

The dropdown closes on click-outside and uses the same styling patterns as existing sort dropdowns throughout the app.

https://claude.ai/code/session_01CusHZZkge1x2w3bgJyah6e