### PR TITLE
Fix gray screen: use setCurrentQueue directly in onQueue handler

### DIFF
--- a/app.js
+++ b/app.js
@@ -8670,8 +8670,8 @@ const Parachord = () => {
     // Handle queue requests from embed (add track to end of queue)
     window.electron.embed.onQueue(({ track }) => {
       console.log('➕ Embed queue request:', track?.title);
-      if (track && setCurrentQueueRef.current) {
-        setCurrentQueueRef.current(prev => [...prev, track]);
+      if (track) {
+        setCurrentQueue(prev => [...prev, track]);
       }
     });
 


### PR DESCRIPTION
The onQueue embed handler referenced setCurrentQueueRef.current which doesn't exist, causing a crash on render.

https://claude.ai/code/session_01RzbHRU5TcNWPUve3wo3Xdg