### PR TITLE
Fix TDZ crash: remove fetchAlbumTracksFromMusicBrainz from useCallbac…

### DIFF
--- a/app.js
+++ b/app.js
@@ -10918,7 +10918,8 @@ ${trackListXml}
       console.error('[PublishCollectionSmartLink] Error:', error);
       showToast('Failed to publish link. Is the backend running?', 'error');
     }
-  }, [showToast, resolveTrackUrls, resolveAlbumUrls, fetchAlbumTracksFromMusicBrainz]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showToast, resolveTrackUrls, resolveAlbumUrls]);
 
   // Copy embed code for an album or playlist
   const copyCollectionEmbedCode = useCallback(async (collection) => {


### PR DESCRIPTION
…k deps

fetchAlbumTracksFromMusicBrainz is defined at line ~23874 but referenced in publishCollectionSmartLink's dependency array at line ~10921, causing a "Cannot access before initialization" error. It's a plain async function (not a useCallback), so it doesn't need to be in the deps array.

https://claude.ai/code/session_01RzbHRU5TcNWPUve3wo3Xdg