### PR TITLE
Fix share button container width on release and playlist pages

### DIFF
--- a/app.js
+++ b/app.js
@@ -3567,7 +3567,7 @@ const ReleasePage = ({
             }
           }, release.tracks ? `${release.tracks.length.toString().padStart(2, '0')} Songs` : 'Loading...'),
           // Share button
-          React.createElement('div', { className: 'relative mt-5 flex justify-center' },
+          React.createElement('div', { className: 'relative mt-5 flex justify-center', style: { width: `${albumArtSize}px` } },
             React.createElement('button', {
               onClick: (e) => { e.stopPropagation(); setShareDropdownOpen(shareDropdownOpen === 'album' ? false : 'album'); },
               className: 'px-3 py-1.5 bg-pink-600 hover:bg-pink-700 text-white rounded-lg text-sm font-medium transition-colors flex items-center gap-1.5 no-drag'
@@ -34995,7 +34995,7 @@ useEffect(() => {
                 }, 'Delete Playlist')
               ),
               // Share button (outside space-y-1 metadata div for independent spacing)
-              React.createElement('div', { className: 'relative mt-3 flex justify-center' },
+              React.createElement('div', { className: 'relative mt-3 flex justify-center', style: { width: '212px' } },
                 React.createElement('button', {
                   onClick: (e) => { e.stopPropagation(); setShareDropdownOpen(shareDropdownOpen === 'playlist' ? false : 'playlist'); },
                   className: 'px-3 py-1.5 bg-pink-600 hover:bg-pink-700 text-white rounded-lg text-sm font-medium transition-colors flex items-center gap-1.5 no-drag'


### PR DESCRIPTION
## Summary
Fixed layout issues with share button containers on the release and playlist pages by adding explicit width constraints to their parent divs.

## Key Changes
- **Release page**: Added dynamic width styling to the share button container, matching the album art size (`${albumArtSize}px`)
- **Playlist page**: Added fixed width styling (212px) to the share button container

## Implementation Details
Both changes apply inline styles to the `div` elements that wrap the share buttons, ensuring the containers have consistent widths that align with their respective content areas. This prevents layout shifts and ensures proper button alignment on both pages.

https://claude.ai/code/session_01R44iW8xosXH3FdUvY1Ym61