### PR TITLE
Fix WebSocket connection from HTTPS pages, improve protocol fallback

### DIFF
--- a/parachord-button.js
+++ b/parachord-button.js
@@ -123,6 +123,19 @@
     return url;
   }
 
+  // Open a protocol URL without navigating the page away.  Uses a temporary
+  // hidden iframe so the browser triggers the OS protocol handler while the
+  // current page stays intact.
+  function openProtocolUrl(url) {
+    var iframe = document.createElement('iframe');
+    iframe.style.display = 'none';
+    iframe.src = url;
+    document.body.appendChild(iframe);
+    setTimeout(function () {
+      try { document.body.removeChild(iframe); } catch (e) { /* already gone */ }
+    }, 2000);
+  }
+
   // --- Core API ---
 
   function sendPlaylist(playlist) {
@@ -133,8 +146,8 @@
         tracks: playlist.tracks || []
       });
     }
-    // Fallback: open protocol URL
-    window.location.href = buildImportUrl(playlist);
+    // Fallback: open protocol URL via hidden iframe (keeps page intact)
+    openProtocolUrl(buildImportUrl(playlist));
     return Promise.resolve({ success: true, method: 'protocol' });
   }
 
@@ -142,7 +155,7 @@
     if (wsConnected) {
       return sendWsMessage('importPlaylist', { xspfUrl: url });
     }
-    window.location.href = PROTOCOL_SCHEME + '://import?url=' + encodeURIComponent(url);
+    openProtocolUrl(PROTOCOL_SCHEME + '://import?url=' + encodeURIComponent(url));
     return Promise.resolve({ success: true, method: 'protocol' });
   }
 

--- a/smart-links/public/button.js
+++ b/smart-links/public/button.js
@@ -123,6 +123,19 @@
     return url;
   }
 
+  // Open a protocol URL without navigating the page away.  Uses a temporary
+  // hidden iframe so the browser triggers the OS protocol handler while the
+  // current page stays intact.
+  function openProtocolUrl(url) {
+    var iframe = document.createElement('iframe');
+    iframe.style.display = 'none';
+    iframe.src = url;
+    document.body.appendChild(iframe);
+    setTimeout(function () {
+      try { document.body.removeChild(iframe); } catch (e) { /* already gone */ }
+    }, 2000);
+  }
+
   // --- Core API ---
 
   function sendPlaylist(playlist) {
@@ -133,8 +146,8 @@
         tracks: playlist.tracks || []
       });
     }
-    // Fallback: open protocol URL
-    window.location.href = buildImportUrl(playlist);
+    // Fallback: open protocol URL via hidden iframe (keeps page intact)
+    openProtocolUrl(buildImportUrl(playlist));
     return Promise.resolve({ success: true, method: 'protocol' });
   }
 
@@ -142,7 +155,7 @@
     if (wsConnected) {
       return sendWsMessage('importPlaylist', { xspfUrl: url });
     }
-    window.location.href = PROTOCOL_SCHEME + '://import?url=' + encodeURIComponent(url);
+    openProtocolUrl(PROTOCOL_SCHEME + '://import?url=' + encodeURIComponent(url));
     return Promise.resolve({ success: true, method: 'protocol' });
   }
 


### PR DESCRIPTION
The demos page at parachord.com loads over HTTPS but button.js connects to ws://127.0.0.1:9876.  Modern browsers enforce Private Network Access (PNA) for this — they send a CORS preflight OPTIONS request before the WebSocket upgrade.  The standalone ws server never answered that preflight, so the browser silently blocked the connection.

Fix: replace the standalone WebSocket.Server with one attached to an HTTP server that responds to PNA preflight requests with the required Access-Control-Allow-Private-Network header.

Also fix the protocol URL fallback in button.js: window.location.href navigated the entire page away to a parachord:// URL, losing the demos page.  Now uses a hidden iframe to trigger the OS protocol handler without disrupting the current page.

https://claude.ai/code/session_01RTg2AbU21MyduFLmwE3Wo7