### PR TITLE
Auto-select populated collection tab on library view entry

### DIFF
--- a/app.js
+++ b/app.js
@@ -5669,6 +5669,38 @@ const Parachord = () => {
     }
   }, [activeView]);
 
+  // Auto-select a populated collection tab when entering the library view
+  // This fixes the issue where sidebar navigation lands on an empty tab
+  // (e.g., 'artists' tab with no data) while other tabs have synced content
+  useEffect(() => {
+    if (activeView !== 'library' || collectionLoading) return;
+
+    const currentTabHasData = (() => {
+      switch (collectionTab) {
+        case 'artists': return collectionData.artists.length > 0;
+        case 'albums': return collectionData.albums.length > 0;
+        case 'tracks': return (library.length + collectionData.tracks.length) > 0;
+        case 'friends': return friends.length > 0;
+        default: return false;
+      }
+    })();
+
+    if (currentTabHasData) return;
+
+    // Current tab is empty - switch to the first tab that has data
+    const tabsWithData = [
+      { key: 'albums', hasData: collectionData.albums.length > 0 },
+      { key: 'tracks', hasData: (library.length + collectionData.tracks.length) > 0 },
+      { key: 'artists', hasData: collectionData.artists.length > 0 },
+      { key: 'friends', hasData: friends.length > 0 }
+    ];
+
+    const bestTab = tabsWithData.find(t => t.hasData);
+    if (bestTab) {
+      setCollectionTab(bestTab.key);
+    }
+  }, [activeView, collectionLoading, collectionTab, collectionData, library, friends]);
+
   // Reset playlists header collapse when leaving playlists view
   useEffect(() => {
     if (activeView !== 'playlists') {


### PR DESCRIPTION
## Summary
Added logic to automatically select a collection tab with data when entering the library view, preventing users from landing on empty tabs while other tabs contain synced content.

## Key Changes
- Added a new `useEffect` hook that monitors the library view state and collection data
- Implements tab validation that checks if the currently active collection tab has any data
- Automatically switches to the first populated tab (in priority order: albums → tracks → artists → friends) when the current tab is empty
- Includes guards to skip execution during collection loading or when the current tab already has data

## Implementation Details
- The effect runs whenever `activeView`, `collectionLoading`, `collectionTab`, `collectionData`, `library`, or `friends` changes
- Tab priority is determined by the order in the `tabsWithData` array, with albums checked first
- For the 'tracks' tab, data presence is determined by combining both `library` and `collectionData.tracks` arrays
- The solution gracefully handles cases where all tabs are empty by not switching tabs

https://claude.ai/code/session_01PEa8PAjTmTPL3VeEjpXcWo