### PR TITLE
Remove playlist library saving from web scrape import

### DIFF
--- a/app.js
+++ b/app.js
@@ -7910,7 +7910,6 @@ const Parachord = () => {
 
     const playlistName = playlist.name || 'Scraped Playlist';
     const playlistUrl = playlist.url || null;
-    const playlistOwner = playlist.owner || null;
     console.log(`📋 Processing scraped playlist: "${playlistName}" with ${playlist.tracks.length} tracks from ${playlistUrl}`);
 
     showToast(`Adding ${playlist.tracks.length} tracks from "${playlistName}"...`, 'info');
@@ -7943,32 +7942,6 @@ const Parachord = () => {
       setPlaybackContext(context);
       setCurrentTrack(firstTrack);
       setPlaybackSource(null);
-    }
-
-    // Save the playlist to the library
-    const playlistId = `web-${Date.now()}`;
-    const newPlaylist = {
-      id: playlistId,
-      title: playlistName,
-      creator: playlistOwner,
-      tracks: tracks,
-      source: 'web',
-      sourceUrl: playlistUrl,
-      createdAt: Date.now(),
-      addedAt: Date.now(),
-      lastModified: Date.now()
-    };
-
-    // Save to electron-store
-    const saveResult = await window.electron.playlists.save(newPlaylist);
-    if (saveResult.success) {
-      // Add to state (prepend so it appears at top)
-      setPlaylists(prev => [newPlaylist, ...prev]);
-      // Fetch covers for the 2x2 grid display
-      fetchPlaylistCovers(playlistId, tracks);
-      console.log(`✅ Saved web playlist: ${playlistName} (${tracks.length} tracks)`);
-    } else {
-      console.error(`❌ Failed to save web playlist: ${saveResult.error}`);
     }
 
     showToast(`Added ${tracks.length} tracks from "${playlistName}"`, 'success');


### PR DESCRIPTION
## Summary
Removed the functionality that automatically saved scraped web playlists to the local library after importing tracks. The import now only adds tracks to the current playback queue without persisting the playlist metadata.

## Key Changes
- Removed `playlistOwner` variable extraction from playlist metadata
- Removed entire playlist persistence logic including:
  - Playlist object creation with metadata (id, title, creator, source, timestamps)
  - `electron-store` save operation via `window.electron.playlists.save()`
  - State update to add the new playlist to the playlists list
  - Playlist cover fetching for grid display
  - Associated success/error logging

## Implementation Details
The web scrape import flow now:
1. Extracts playlist name and URL
2. Processes and adds tracks to the playback queue
3. Shows a success toast notification
4. **Does not** save the playlist as a persistent library item

This appears to be a simplification of the import flow, focusing on immediate track playback rather than library management.

https://claude.ai/code/session_011ciffL2TU1BB3qDhZ9sa1R