### PR TITLE
Fix Play All button alignment in large embed

### DIFF
--- a/smart-links/lib/html.js
+++ b/smart-links/lib/html.js
@@ -747,14 +747,17 @@ export function generateLargeEmbedHtml(data, linkId, baseUrl) {
     .header-actions {
       display: flex;
       justify-content: center;
+      align-items: center;
       gap: 8px;
       margin-bottom: 16px;
     }
     .btn {
       padding: 8px 16px;
       border-radius: 20px;
+      font-family: inherit;
       font-size: 13px;
       font-weight: 500;
+      line-height: 1;
       text-decoration: none;
       transition: all 0.2s;
       cursor: pointer;


### PR DESCRIPTION
The <button> element doesn't inherit font-family by default and has a different default line-height than <a>, causing it to render taller than the adjacent Open link. Added font-family: inherit and line-height: 1 to .btn, and align-items: center to .header-actions.

https://claude.ai/code/session_01DtsdYLqc9rJU4GLbrF72xm