### PR TITLE
Change status dot to white on green Play button for visibility

### DIFF
--- a/smart-links/lib/html.js
+++ b/smart-links/lib/html.js
@@ -792,7 +792,7 @@ export function generateLargeEmbedHtml(data, linkId, baseUrl) {
       width: 8px;
       height: 8px;
       border-radius: 50%;
-      background: #22c55e;
+      background: #fff;
       display: inline-block;
       margin-right: 6px;
       animation: pulse 2s infinite;
@@ -1185,7 +1185,7 @@ export function generateEmbedHtml(data, linkId, baseUrl) {
       width: 8px;
       height: 8px;
       border-radius: 50%;
-      background: #22c55e;
+      background: #fff;
       display: inline-block;
       margin-right: 6px;
       animation: pulse 2s infinite;


### PR DESCRIPTION
The green pulsing dot was invisible against the green primary button background. Changed to white so users can see Parachord is connected.

https://claude.ai/code/session_01DtsdYLqc9rJU4GLbrF72xm