### PR TITLE
Update compliance review: document resolved issues and remaining concerns

### DIFF
--- a/docs/setup/API_CREDENTIALS_SETUP.md
+++ b/docs/setup/API_CREDENTIALS_SETUP.md
@@ -112,17 +112,16 @@ YOUTUBE_API_KEY=your_api_key_here
 
 ---
 
-### 🟡 **SoundCloud** (Partial Implementation)
+### 🟢 **SoundCloud** (OAuth 2.1 + PKCE)
 
-**Status:** Browser extension scraping works; desktop search resolver not yet implemented
+**Status:** Fully implemented with OAuth 2.1 authentication (PKCE mandatory)
 
-**What Works Now:**
+**What Works:**
+- OAuth 2.1 login with PKCE (S256 code challenge)
+- Search SoundCloud catalog from within Parachord
+- URL resolution for SoundCloud track links
+- Audio streaming via official API
 - Browser extension can scrape tracks, playlists, and artist pages from SoundCloud
-- Scraped content can be queued in Parachord
-
-**What's Not Implemented:**
-- Desktop app search (cannot search SoundCloud from within Parachord)
-- Direct URL resolution
 
 **How to Get Credentials:**
 1. Go to: https://soundcloud.com/you/apps
@@ -135,7 +134,7 @@ SOUNDCLOUD_CLIENT_ID=your_client_id_here
 SOUNDCLOUD_CLIENT_SECRET=your_client_secret_here
 ```
 
-**Note:** SoundCloud's official API has been deprecated, so full resolver implementation may require alternative approaches.
+**Note:** SoundCloud migrated to [OAuth 2.1 with mandatory PKCE](https://developers.soundcloud.com/blog/oauth-migration). Parachord's integration is fully compliant. Fallback credentials are included for convenience, but users can provide their own via Settings or environment variables.
 
 ---
 


### PR DESCRIPTION
## Summary

This PR updates the Third-Party Compliance Review document to reflect significant progress made since the initial review on 2026-02-05. Multiple high-priority compliance and security issues have been resolved, and the document now provides a clear status of what has been fixed versus what remains.

## Key Changes

- **Reorganized document structure** to distinguish between resolved issues and remaining concerns, making it easier to track progress
- **Documented resolved issues:**
  - YouTube ad-skipping code removal from browser extension
  - Apple MusicKit private key removal from repository with `.gitignore` rule added
  - Spotify migration to PKCE flow (eliminating hardcoded client secret)
  - Removal of unnecessary Spotify OAuth scopes (`user-read-private`, `user-read-email`)
  - Browser extension C2 channel migration from unauthenticated WebSocket to Chrome native messaging with IPC sockets
  - SoundCloud OAuth 2.1 migration confirmation (API actively maintained, not deprecated)
  
- **Added new compliance artifacts:**
  - Privacy policy for desktop app and browser extension
  - Browser extension packaged for Chrome Web Store submission
  - Spotify URL lookup resolver (tracks, albums, playlists)
  - Smart Links enrichment using compliant APIs (iTunes, Spotify, YouTube)

- **Clarified remaining concerns:**
  - Bandcamp search scraping (MEDIUM RISK) — still requires oEmbed/iframe replacement
  - Qobuz shared demo App ID (MEDIUM RISK) — still requires production credentials
  - SoundCloud hardcoded fallback client secret (LOW-MEDIUM RISK) — new concern identified during OAuth 2.1 migration

- **Updated priority actions** to reflect completed work and remove obsolete recommendations

- **Updated API_CREDENTIALS_SETUP.md** to reflect SoundCloud's OAuth 2.1 status and remove deprecation language

## Notable Implementation Details

- The WebSocket server on port 9876 still exists but is now documented as being used exclusively for embedded player communication, not browser extension C2
- The browser extension's native messaging implementation uses OS-level socket permissions (Unix domain sockets on Linux/macOS, named pipes on Windows) for improved security
- SoundCloud's OAuth 2.1 with mandatory PKCE is now confirmed as the active authentication method, eliminating the "deprecated API" concern
- The document now includes a change log table showing what was fixed and when, providing clear audit trail for compliance purposes

https://claude.ai/code/session_01EQoQ45qSmeBzV1en9jioFZ