### PR TITLE
Build universal binaries for macOS (arm64 + x86_64)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Build for ${{ matrix.platform }}
-        run: npm run build:${{ matrix.platform }} -- --publish never
+        run: npm run build:${{ matrix.platform }} -- --${{ matrix.arch }} --publish never
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # macOS code signing and notarization

--- a/native/musickit-helper/build.sh
+++ b/native/musickit-helper/build.sh
@@ -10,8 +10,8 @@ cd "$SCRIPT_DIR"
 
 echo "Building MusicKit Helper App..."
 
-# Build release binary
-swift build -c release
+# Build universal (arm64 + x86_64) release binary
+swift build -c release --arch arm64 --arch x86_64
 
 # Get the built binary path
 BINARY_PATH=".build/release/musickit-helper"

--- a/package.json
+++ b/package.json
@@ -98,8 +98,14 @@
         "NSAppleMusicUsageDescription": "Parachord needs access to Apple Music to play songs from your library and subscription."
       },
       "target": [
-        "dmg",
-        "zip"
+        {
+          "target": "dmg",
+          "arch": ["universal"]
+        },
+        {
+          "target": "zip",
+          "arch": ["universal"]
+        }
       ],
       "extraResources": [
         {


### PR DESCRIPTION
## Summary
This PR updates the build configuration to generate universal macOS binaries that support both Apple Silicon (arm64) and Intel (x86_64) architectures.

## Key Changes
- **package.json**: Updated Electron Builder targets to explicitly specify `universal` architecture for both DMG and ZIP distribution formats
- **native/musickit-helper/build.sh**: Modified Swift build command to compile for both arm64 and x86_64 architectures using `--arch` flags
- **.github/workflows/build.yml**: Updated build workflow to pass architecture parameter to the build script via `--${{ matrix.arch }}`

## Implementation Details
The changes ensure that:
1. The native MusicKit Helper is built as a universal binary supporting both architectures
2. The Electron app distribution packages (DMG and ZIP) are configured to include universal binaries
3. The CI/CD pipeline properly passes architecture information during the build process

This enables the application to run natively on both Apple Silicon and Intel-based Mac systems without requiring Rosetta 2 translation.

https://claude.ai/code/session_01Pp4XLBiycF8dYLquoyxDcM