### PR TITLE
Add Firefox support to extension packaging and native messaging insta…

### DIFF
--- a/scripts/package-extension.js
+++ b/scripts/package-extension.js
@@ -8,12 +8,16 @@ const ROOT = path.resolve(__dirname, '..');
 const EXT_DIR = path.join(ROOT, 'parachord-extension');
 const OUT_DIR = path.join(ROOT, 'dist');
 
-// Files that should not be included in the Chrome Web Store package
+// Files that should not be included in the store packages
 const EXCLUDE = [
   'README.md',
   '.DS_Store',
   '*.map',
 ];
+
+// Firefox extension ID — must match what's registered with AMO and used in
+// the native messaging host manifest's allowed_extensions.
+const FIREFOX_EXTENSION_ID = 'parachord@parachord.com';
 
 function fatal(msg) {
   console.error(`ERROR: ${msg}`);
@@ -86,36 +90,80 @@ function validate() {
   return manifest;
 }
 
-function build(manifest) {
+// Transform the base manifest into a Firefox-compatible one
+function toFirefoxManifest(manifest) {
+  const fx = JSON.parse(JSON.stringify(manifest));
+
+  // Remove Chrome-specific key
+  delete fx.key;
+
+  // Add Firefox-specific settings
+  fx.browser_specific_settings = {
+    gecko: {
+      id: FIREFOX_EXTENSION_ID,
+      strict_min_version: '127.0'
+    }
+  };
+
+  return fx;
+}
+
+function buildZip(manifest, suffix, tempManifest) {
   fs.mkdirSync(OUT_DIR, { recursive: true });
 
-  const zipName = `parachord-extension-v${manifest.version}.zip`;
+  const zipName = `parachord-extension-v${manifest.version}${suffix}.zip`;
   const zipPath = path.join(OUT_DIR, zipName);
 
-  // Remove previous build if it exists
   if (fs.existsSync(zipPath)) {
     fs.unlinkSync(zipPath);
   }
 
-  // Build the exclude flags for zip
   const excludeFlags = EXCLUDE.map(p => `-x '${p}'`).join(' ');
 
-  execSync(
-    `cd "${EXT_DIR}" && zip -r "${zipPath}" . ${excludeFlags}`,
-    { stdio: 'inherit' }
-  );
+  if (tempManifest) {
+    // Write a temporary manifest, build zip, then restore original
+    const originalManifest = path.join(EXT_DIR, 'manifest.json');
+    const backup = fs.readFileSync(originalManifest);
+    fs.writeFileSync(originalManifest, JSON.stringify(tempManifest, null, 2) + '\n');
+    try {
+      execSync(
+        `cd "${EXT_DIR}" && zip -r "${zipPath}" . ${excludeFlags}`,
+        { stdio: 'inherit' }
+      );
+    } finally {
+      fs.writeFileSync(originalManifest, backup);
+    }
+  } else {
+    execSync(
+      `cd "${EXT_DIR}" && zip -r "${zipPath}" . ${excludeFlags}`,
+      { stdio: 'inherit' }
+    );
+  }
 
   const stats = fs.statSync(zipPath);
   const sizeKB = (stats.size / 1024).toFixed(1);
-
-  console.log(`\n  Output:   dist/${zipName} (${sizeKB} KB)`);
+  console.log(`  Output:   dist/${zipName} (${sizeKB} KB)`);
 
   return zipPath;
 }
 
+// --- Main ---
+
+const target = process.argv[2]; // 'chrome', 'firefox', or omit for both
+
 console.log('\nPackaging Parachord browser extension...\n');
 
 const manifest = validate();
-const zipPath = build(manifest);
 
-console.log('\nDone. Upload this file to the Chrome Web Store Developer Dashboard.\n');
+if (!target || target === 'chrome') {
+  console.log('\n--- Chrome Web Store ---');
+  buildZip(manifest, '-chrome');
+}
+
+if (!target || target === 'firefox') {
+  console.log('\n--- Firefox Add-ons (AMO) ---');
+  const fxManifest = toFirefoxManifest(manifest);
+  buildZip(fxManifest, '-firefox', fxManifest);
+}
+
+console.log('\nDone.\n');


### PR DESCRIPTION
…ller

Packaging script now produces two zips:
  - dist/parachord-extension-v0.3.0-chrome.zip (with key field)
  - dist/parachord-extension-v0.3.0-firefox.zip (gecko settings, no key)

Run with: node scripts/package-extension.js [chrome|firefox] Omit argument to build both.

Native messaging installer now registers host manifests for both Chromium browsers (allowed_origins) and Firefox (allowed_extensions) with the correct platform-specific directories and registry keys.

https://claude.ai/code/session_016bTWmfob2jTKfDxWKF78SF