### PR TITLE
Configure x64 architecture files for macOS notarization

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
       "notarize": false,
+      "x64ArchFiles": "Contents/Resources/app/node_modules/**/*.node",
       "extendInfo": {
         "NSAppleMusicUsageDescription": "Parachord needs access to Apple Music to play songs from your library and subscription."
       },


### PR DESCRIPTION
## Summary
Added configuration for x64 architecture files in the macOS build settings to ensure proper handling of native Node.js modules during the notarization process.

## Changes
- Added `x64ArchFiles` configuration pointing to native `.node` modules in the app's node_modules directory
- This ensures that native binaries are correctly identified and processed during macOS code signing and notarization

## Details
The `x64ArchFiles` setting specifies the glob pattern `Contents/Resources/app/node_modules/**/*.node` to target all native Node.js modules within the application bundle. This is necessary for proper macOS notarization compliance when the application includes native dependencies.

https://claude.ai/code/session_01TXFjY1JUNmFybzGioptx1T