### PR TITLE
Exclude native source directory from app bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,8 +74,7 @@
       "!dist",
       "!**/*.md",
       "!collection.json",
-      "!native/**/.build",
-      "!native/**/.swiftpm"
+      "!native"
     ],
     "asar": false,
     "extraResources": [


### PR DESCRIPTION
The native/musickit-helper/ directory contains an Info.plist that @electron/universal was picking up and trying to process as an embedded app bundle during the universal merge, causing an ENOENT error. The entire native/ directory is build-time source code only — the built MusicKitHelper.app is already included via extraResources from resources/bin/darwin/. Replace the granular .build/.swiftpm exclusions with a single exclusion of the whole native directory.

https://claude.ai/code/session_01TXFjY1JUNmFybzGioptx1T