### PR TITLE
Fix data_collection_permissions format and min version

### DIFF
--- a/scripts/package-extension.js
+++ b/scripts/package-extension.js
@@ -106,14 +106,14 @@ function toFirefoxManifest(manifest) {
   }
 
   // Add Firefox-specific settings.
-  // strict_min_version bumped to 140 — required for data_collection_permissions.
+  // strict_min_version 142 — minimum for data_collection_permissions on Android.
   fx.browser_specific_settings = {
     gecko: {
       id: FIREFOX_EXTENSION_ID,
-      strict_min_version: '140.0',
+      strict_min_version: '142.0',
       data_collection_permissions: {
-        data_not_collected: true,
-        required: false
+        required: [],
+        optional: []
       }
     }
   };


### PR DESCRIPTION
- required/optional must be arrays of strings, not booleans
- Use empty arrays since we collect no data
- Bump strict_min_version to 142.0 for Android compat

https://claude.ai/code/session_016bTWmfob2jTKfDxWKF78SF