### PR TITLE
Fix data_collection_permissions: use ["none"] instead of empty arrays

### DIFF
--- a/scripts/package-extension.js
+++ b/scripts/package-extension.js
@@ -112,8 +112,8 @@ function toFirefoxManifest(manifest) {
       id: FIREFOX_EXTENSION_ID,
       strict_min_version: '142.0',
       data_collection_permissions: {
-        required: [],
-        optional: []
+        required: ["none"],
+        optional: ["none"]
       }
     }
   };


### PR DESCRIPTION
AMO requires at least one item in required/optional arrays. "none" explicitly declares no data is collected.

https://claude.ai/code/session_016bTWmfob2jTKfDxWKF78SF