### PR TITLE
Remove optional from data_collection_permissions

### DIFF
--- a/scripts/package-extension.js
+++ b/scripts/package-extension.js
@@ -112,8 +112,7 @@ function toFirefoxManifest(manifest) {
       id: FIREFOX_EXTENSION_ID,
       strict_min_version: '142.0',
       data_collection_permissions: {
-        required: ["none"],
-        optional: ["none"]
+        required: ["none"]
       }
     }
   };


### PR DESCRIPTION
"none" is only valid in the required array. The optional key should be omitted entirely when no optional data is collected.

https://claude.ai/code/session_016bTWmfob2jTKfDxWKF78SF