### PR TITLE
Fix universal build by enabling asar packaging

### DIFF
--- a/main.js
+++ b/main.js
@@ -1062,7 +1062,9 @@ function startNativeMessagingServer() {
 function registerNativeMessagingHost() {
   try {
     const { install } = require('./native-messaging/install');
-    install(process.execPath, app.getAppPath());
+    // In packaged builds, native-messaging/ is asarUnpacked so Chrome can spawn it
+    const hostAppPath = app.isPackaged ? app.getAppPath().replace('app.asar', 'app.asar.unpacked') : app.getAppPath();
+    install(process.execPath, hostAppPath);
   } catch (error) {
     console.error('Failed to register native messaging host:', error.message);
   }
@@ -4429,8 +4431,10 @@ ipcMain.handle('mcp-response', (event, { requestId, data }) => {
 
 // MCP server info - expose path for Claude Desktop config UI
 ipcMain.handle('mcp-get-info', () => {
+  // In packaged builds, mcp-stdio.js is asarUnpacked so external processes can access it
+  const basePath = app.isPackaged ? __dirname.replace('app.asar', 'app.asar.unpacked') : __dirname;
   return {
-    stdioPath: path.join(__dirname, 'mcp-stdio.js'),
+    stdioPath: path.join(basePath, 'mcp-stdio.js'),
     port: 9421
   };
 });

--- a/package.json
+++ b/package.json
@@ -76,7 +76,12 @@
       "!collection.json",
       "!native"
     ],
-    "asar": false,
+    "asar": true,
+    "asarUnpack": [
+      "**/*.node",
+      "mcp-stdio.js",
+      "native-messaging/**"
+    ],
     "extraResources": [
       {
         "from": "resources/keys/",
@@ -93,7 +98,7 @@
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
       "notarize": false,
-      "x64ArchFiles": "Contents/Resources/app/node_modules/**/*.node",
+      "x64ArchFiles": "Contents/Resources/app.asar.unpacked/node_modules/**/*.node",
       "extendInfo": {
         "NSAppleMusicUsageDescription": "Parachord needs access to Apple Music to play songs from your library and subscription."
       },


### PR DESCRIPTION
The @electron/universal merger creates a broken 2KB redirect stub app.asar when merging non-asar builds, causing "Not allowed to load local resource: app.asar/index.html" at launch. Enabling real asar packaging lets the merger produce a proper merged app.asar.

- Enable asar: true with asarUnpack for native .node modules, mcp-stdio.js, and native-messaging/ (needed by external processes)
- Update x64ArchFiles path to app.asar.unpacked/ for universal merge
- Fix MCP and native messaging host paths to use unpacked locations when running in packaged builds

https://claude.ai/code/session_01GwBAdHakMxG4iY2QysSTWe