### PR TITLE
Add MusicKitHelper to x64ArchFiles for universal build merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
       "notarize": false,
-      "x64ArchFiles": "Contents/Resources/app.asar.unpacked/node_modules/**/*.node",
+      "x64ArchFiles": "{Contents/Resources/app.asar.unpacked/node_modules/**/*.node,Contents/Resources/bin/darwin/**/*}",
       "extendInfo": {
         "NSAppleMusicUsageDescription": "Parachord needs access to Apple Music to play songs from your library and subscription."
       },


### PR DESCRIPTION
The @electron/universal merger errors when it finds arch-specific binaries not covered by x64ArchFiles. MusicKitHelper is in extraResources and needs to be included alongside .node modules.

https://claude.ai/code/session_01GwBAdHakMxG4iY2QysSTWe