### PR TITLE
Fix MusicKit helper build and update bundle identifier

### DIFF
--- a/native/musickit-helper/Info.plist
+++ b/native/musickit-helper/Info.plist
@@ -7,7 +7,7 @@
     <key>CFBundleExecutable</key>
     <string>MusicKitHelper</string>
     <key>CFBundleIdentifier</key>
-    <string>dev.parachord.app</string>
+    <string>com.parachord.desktop.musickit-helper</string>
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundleName</key>

--- a/native/musickit-helper/Sources/MusicKitHelperApp.swift
+++ b/native/musickit-helper/Sources/MusicKitHelperApp.swift
@@ -331,7 +331,7 @@ class MusicKitBridge {
         // We need to get the song's catalog ID from the underlying item
         if let entry = player.queue.currentEntry {
             // Try to get the song's catalog ID and duration from the entry's item
-            if let song = entry.item as? Song {
+            if case .song(let song) = entry.item {
                 result["songId"] = song.id.rawValue
                 result["songTitle"] = song.title
                 // Include duration if available (in seconds)
@@ -632,7 +632,7 @@ struct MusicKitHelperApp {
                 .replacingOccurrences(of: "\"", with: "\\\"")
                 .replacingOccurrences(of: "\n", with: " ")
             let msg = "{\"id\":\"\(reqId)\",\"success\":false,\"data\":null,\"error\":\"MusicKit internal error: \(exception.name.rawValue) — \(reason)\"}\n"
-            msg.withCString { ptr in
+            _ = msg.withCString { ptr in
                 write(STDOUT_FILENO, ptr, strlen(ptr))
             }
         }

--- a/scripts/build-native.js
+++ b/scripts/build-native.js
@@ -28,7 +28,7 @@ function buildMusicKitHelper() {
   }
 
   // Check if already built (skip if up to date)
-  const sourceFile = path.join(helperDir, 'Sources', 'main.swift');
+  const sourceFile = path.join(helperDir, 'Sources', 'MusicKitHelperApp.swift');
   if (fs.existsSync(outputApp)) {
     const sourceStats = fs.statSync(sourceFile);
     const outputStats = fs.statSync(outputApp);


### PR DESCRIPTION
## Summary
This PR addresses several issues in the MusicKit helper implementation, including fixing a type casting pattern, suppressing an unused return value warning, updating the bundle identifier, and correcting the build script source file reference.

## Key Changes
- **Type casting pattern**: Changed from `as? Song` to `case .song(let song)` pattern matching for more idiomatic Swift enum handling
- **Compiler warning**: Added underscore prefix to suppress unused return value warning from `withCString` call
- **Bundle identifier**: Updated from `dev.parachord.app` to `com.parachord.desktop.musickit-helper` to follow proper naming conventions
- **Build script**: Fixed source file reference from `main.swift` to `MusicKitHelperApp.swift` to match the actual renamed file

## Implementation Details
The type casting change improves code quality by using Swift's pattern matching for enum types rather than force-casting. The bundle identifier update aligns with standard macOS app naming conventions (reverse domain notation). The build script fix ensures the dependency tracking works correctly with the renamed source file.

https://claude.ai/code/session_012tg5uTWFHDNvgbnrkwhyPL