### PR TITLE
Fix 'damaged' app: verify and re-sign nested helper after electron-bu…

### DIFF
--- a/native/musickit-helper/build.sh
+++ b/native/musickit-helper/build.sh
@@ -107,15 +107,25 @@ fi
 
 if [ -n "$SIGNING_IDENTITY" ]; then
     echo "Signing with identity: $SIGNING_IDENTITY"
-    codesign --force --deep --sign "$SIGNING_IDENTITY" \
+    # Sign the inner binary first, then the bundle (Apple recommends against --deep)
+    codesign --force --sign "$SIGNING_IDENTITY" \
         --entitlements MusicKitHelper.entitlements \
         --options runtime \
+        --timestamp \
+        "$APP_DIR/Contents/MacOS/MusicKitHelper"
+    codesign --force --sign "$SIGNING_IDENTITY" \
+        --entitlements MusicKitHelper.entitlements \
+        --options runtime \
+        --timestamp \
         "$APP_DIR"
 else
     echo "Warning: No signing identity found, using ad-hoc signing"
     echo "  Ad-hoc signing won't work with MusicKit entitlement."
     echo "  Set APPLE_SIGNING_IDENTITY or install a Developer certificate."
-    codesign --force --deep --sign - \
+    codesign --force --sign - \
+        --entitlements MusicKitHelper.entitlements \
+        "$APP_DIR/Contents/MacOS/MusicKitHelper"
+    codesign --force --sign - \
         --entitlements MusicKitHelper.entitlements \
         "$APP_DIR"
 fi

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -1,29 +1,131 @@
 /**
- * Notarize the macOS app after signing
- * This script is called by electron-builder via the afterSign hook
+ * After-sign hook: verify nested bundle signatures and notarize.
+ *
+ * electron-builder's signing step can break nested .app bundles that live in
+ * extraResources (like MusicKitHelper.app).  It re-signs the inner Mach-O
+ * binary with entitlementsInherit but may not re-seal the nested .app bundle's
+ * CodeResources, leaving an internally-inconsistent signature that Gatekeeper
+ * rejects as "damaged."
+ *
+ * This hook runs after electron-builder's signing step.  It verifies the
+ * signature, re-signs if necessary (innermost → outermost), and then submits
+ * the app for notarization.
  */
 
 require('dotenv').config();
 const { notarize } = require('@electron/notarize');
+const { execSync } = require('child_process');
 const path = require('path');
+const fs = require('fs');
 
-exports.default = async function notarizing(context) {
+/**
+ * Find the Developer ID signing identity from the keychain.
+ */
+function findSigningIdentity() {
+  try {
+    const output = execSync('security find-identity -v -p codesigning', {
+      encoding: 'utf-8',
+      timeout: 10000,
+    });
+    const match = output.match(/"(Developer ID Application[^"]+)"/);
+    return match ? match[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Verify a code signature.  Returns true if valid, false otherwise.
+ */
+function verifySignature(targetPath) {
+  try {
+    execSync(
+      `/usr/bin/codesign --verify --deep --strict "${targetPath}" 2>&1`,
+      { encoding: 'utf-8', timeout: 30000 }
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+exports.default = async function afterSign(context) {
   const { electronPlatformName, appOutDir } = context;
 
-  // Only notarize macOS builds
+  // Only process macOS builds
   if (electronPlatformName !== 'darwin') {
-    console.log('Skipping notarization: not macOS');
+    console.log('Skipping post-sign tasks: not macOS');
     return;
   }
 
-  // Skip notarization for pull request builds
-  // electron-builder skips code signing for PRs, so notarization would fail
+  // Skip for pull request builds (code signing was skipped)
   if (process.env.GITHUB_EVENT_NAME === 'pull_request') {
-    console.log('Skipping notarization: pull request build (code signing was skipped)');
+    console.log('Skipping post-sign tasks: pull request build');
     return;
   }
 
-  // Check for required environment variables
+  const appName = context.packager.appInfo.productFilename;
+  const appPath = path.join(appOutDir, `${appName}.app`);
+
+  // ── Step 1: Verify and fix nested MusicKitHelper.app signature ──────
+  const helperAppPath = path.join(
+    appPath, 'Contents', 'Resources', 'bin', 'darwin', 'MusicKitHelper.app'
+  );
+
+  if (fs.existsSync(helperAppPath)) {
+    const helperValid = verifySignature(helperAppPath);
+
+    if (helperValid) {
+      console.log('✓ MusicKitHelper.app signature is valid');
+    } else {
+      console.log('⚠ MusicKitHelper.app signature is invalid — re-signing...');
+
+      const identity = findSigningIdentity();
+      if (!identity) {
+        console.error('✗ Cannot re-sign: no Developer ID identity found');
+        // Continue to notarization — it will fail, but at least we get
+        // Apple's error message about what's wrong with the signature.
+      } else {
+        const entitlements = path.join(__dirname, '..', 'build', 'entitlements.mac.plist');
+
+        // Re-sign the nested helper bundle (innermost first)
+        console.log(`  Signing MusicKitHelper.app with: ${identity}`);
+        execSync(
+          `/usr/bin/codesign --force --sign "${identity}" ` +
+          `--entitlements "${entitlements}" --options runtime ` +
+          `--timestamp "${helperAppPath}"`,
+          { stdio: 'inherit', timeout: 60000 }
+        );
+
+        // Re-sign the main app (outermost — seals the updated helper)
+        console.log(`  Re-signing ${appName}.app...`);
+        execSync(
+          `/usr/bin/codesign --force --sign "${identity}" ` +
+          `--entitlements "${entitlements}" --options runtime ` +
+          `--timestamp "${appPath}"`,
+          { stdio: 'inherit', timeout: 60000 }
+        );
+
+        // Final verification
+        if (verifySignature(appPath)) {
+          console.log('✓ Re-signed and verified successfully');
+        } else {
+          console.error('✗ Signature still invalid after re-signing');
+        }
+      }
+    }
+  } else {
+    console.log('ℹ No MusicKitHelper.app found (skipping nested bundle check)');
+  }
+
+  // ── Step 2: Verify the overall app signature ────────────────────────
+  if (verifySignature(appPath)) {
+    console.log(`✓ ${appName}.app signature is valid`);
+  } else {
+    console.error(`✗ ${appName}.app signature is INVALID — notarization will likely fail`);
+  }
+
+  // ── Step 3: Notarize ────────────────────────────────────────────────
   const appleId = process.env.APPLE_ID;
   const appleIdPassword = process.env.APPLE_APP_SPECIFIC_PASSWORD;
   const teamId = process.env.APPLE_TEAM_ID;
@@ -35,9 +137,6 @@ exports.default = async function notarizing(context) {
     console.log('  APPLE_TEAM_ID:', teamId ? '✓' : '✗');
     return;
   }
-
-  const appName = context.packager.appInfo.productFilename;
-  const appPath = path.join(appOutDir, `${appName}.app`);
 
   console.log(`Notarizing ${appPath}...`);
 


### PR DESCRIPTION
…ilder

electron-builder's signing step can break nested .app bundles in extraResources. It re-signs the inner Mach-O binary with entitlementsInherit but may not re-seal the nested .app bundle's CodeResources, leaving an internally-inconsistent signature that Gatekeeper rejects as "damaged and can't be opened."

Changes:
- notarize.js (afterSign hook): After electron-builder signs, verify the nested MusicKitHelper.app signature. If invalid, re-sign it (innermost → outermost) with the Developer ID identity, then verify the whole app before submitting for notarization.
- build.sh: Replace --deep with explicit inner-binary-then-bundle signing order, matching Apple's recommended practice. Also add --timestamp for RFC 3161 timestamping.

https://claude.ai/code/session_012tg5uTWFHDNvgbnrkwhyPL