### PR TITLE
Fix macOS 'damaged' error: notarize DMG, fix nested .app handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,16 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
+      # macOS: Notarize and staple the DMG so Gatekeeper on macOS Sequoia
+      # accepts the downloaded disk image (not just the .app inside it).
+      - name: Notarize DMG
+        if: matrix.platform == 'mac' && env.APPLE_ID != ''
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: node scripts/notarize-artifacts.js
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
       "notarize": false,
-      "x64ArchFiles": "{Contents/Resources/app.asar.unpacked/node_modules/**/*.node,Contents/Resources/bin/darwin/**/*}",
+      "x64ArchFiles": "Contents/Resources/app.asar.unpacked/node_modules/**/*.node",
+      "signIgnore": ["MusicKitHelper\\.app"],
       "extendInfo": {
         "NSAppleMusicUsageDescription": "Parachord needs access to Apple Music to play songs from your library and subscription."
       },

--- a/scripts/notarize-artifacts.js
+++ b/scripts/notarize-artifacts.js
@@ -1,0 +1,104 @@
+/**
+ * Post-build: notarize and staple distribution artifacts (DMG, ZIP).
+ *
+ * On macOS Sequoia (15+), Gatekeeper checks the downloaded artifact itself
+ * (DMG/ZIP), not just the .app inside.  If the DMG is not notarized,
+ * Gatekeeper shows "damaged and can't be opened" even though the .app
+ * inside is properly signed and notarized.
+ *
+ * This script runs AFTER electron-builder finishes creating the DMG/ZIP.
+ * The .app is already notarized by the afterSign hook (scripts/notarize.js).
+ * This script notarizes the outer DMG so Gatekeeper accepts it on Sequoia.
+ *
+ * Usage:
+ *   node scripts/notarize-artifacts.js
+ *
+ * Required environment variables:
+ *   APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, APPLE_TEAM_ID
+ */
+
+require('dotenv').config();
+const { execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+const DIST_DIR = path.join(__dirname, '..', 'dist');
+
+async function main() {
+  const appleId = process.env.APPLE_ID;
+  const appleIdPassword = process.env.APPLE_APP_SPECIFIC_PASSWORD;
+  const teamId = process.env.APPLE_TEAM_ID;
+
+  if (!appleId || !appleIdPassword || !teamId) {
+    console.log('Skipping artifact notarization: missing Apple credentials');
+    return;
+  }
+
+  // Find DMG files to notarize
+  const files = fs.readdirSync(DIST_DIR).filter(f => f.endsWith('.dmg'));
+
+  if (files.length === 0) {
+    console.log('No DMG files found in dist/ — nothing to notarize');
+    return;
+  }
+
+  for (const file of files) {
+    const filePath = path.join(DIST_DIR, file);
+    console.log(`Notarizing ${file}...`);
+
+    try {
+      // Submit for notarization and wait
+      execSync(
+        `xcrun notarytool submit "${filePath}" ` +
+        `--apple-id "${appleId}" ` +
+        `--password "${appleIdPassword}" ` +
+        `--team-id "${teamId}" ` +
+        `--wait`,
+        { stdio: 'inherit', timeout: 600000 }
+      );
+      console.log(`✓ ${file} notarization accepted`);
+
+      // Staple the ticket to the DMG
+      execSync(`xcrun stapler staple "${filePath}"`, {
+        stdio: 'inherit',
+        timeout: 60000,
+      });
+      console.log(`✓ ${file} stapled`);
+
+      // Validate
+      try {
+        execSync(`xcrun stapler validate "${filePath}" 2>&1`, {
+          encoding: 'utf-8',
+          timeout: 30000,
+        });
+        console.log(`✓ ${file} staple validation passed`);
+      } catch {
+        console.warn(`⚠ ${file} staple validation failed (non-fatal)`);
+      }
+    } catch (error) {
+      console.error(`✗ Failed to notarize ${file}:`, error.message);
+      // Log the notarization log for debugging
+      try {
+        // Get the submission ID from the error output to fetch the log
+        console.log('Fetching notarization log...');
+        execSync(
+          `xcrun notarytool log "${filePath}" ` +
+          `--apple-id "${appleId}" ` +
+          `--password "${appleIdPassword}" ` +
+          `--team-id "${teamId}" 2>&1`,
+          { stdio: 'inherit', timeout: 60000 }
+        );
+      } catch {
+        // log fetch failed — not critical
+      }
+      throw error;
+    }
+  }
+
+  console.log('✓ All artifacts notarized');
+}
+
+main().catch(err => {
+  console.error('Artifact notarization failed:', err.message);
+  process.exit(1);
+});

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -9,7 +9,8 @@
  *
  * This hook runs after electron-builder's signing step.  It verifies the
  * signature, re-signs if necessary (innermost → outermost), and then submits
- * the app for notarization.
+ * the .app for notarization.  The DMG is notarized separately in the CI
+ * workflow (see scripts/notarize-artifacts.js).
  */
 
 require('dotenv').config();
@@ -49,6 +50,37 @@ function verifySignature(targetPath) {
   }
 }
 
+/**
+ * Run spctl --assess to check Gatekeeper acceptance.
+ * Returns { accepted: bool, output: string }.
+ */
+function assessGatekeeper(targetPath) {
+  try {
+    const output = execSync(
+      `spctl --assess --type execute -vvv "${targetPath}" 2>&1`,
+      { encoding: 'utf-8', timeout: 30000 }
+    );
+    return { accepted: true, output };
+  } catch (err) {
+    return { accepted: false, output: err.stdout || err.stderr || err.message };
+  }
+}
+
+/**
+ * Print verbose signature info for debugging.
+ */
+function logSignatureInfo(targetPath, label) {
+  try {
+    const info = execSync(
+      `/usr/bin/codesign -dvv "${targetPath}" 2>&1`,
+      { encoding: 'utf-8', timeout: 10000 }
+    );
+    console.log(`  [${label}] codesign -dvv:\n${info.split('\n').map(l => '    ' + l).join('\n')}`);
+  } catch (err) {
+    console.log(`  [${label}] codesign -dvv failed: ${err.message}`);
+  }
+}
+
 exports.default = async function afterSign(context) {
   const { electronPlatformName, appOutDir } = context;
 
@@ -79,14 +111,22 @@ exports.default = async function afterSign(context) {
       console.log('✓ MusicKitHelper.app signature is valid');
     } else {
       console.log('⚠ MusicKitHelper.app signature is invalid — re-signing...');
+      logSignatureInfo(helperAppPath, 'MusicKitHelper (before fix)');
 
       const identity = findSigningIdentity();
       if (!identity) {
         console.error('✗ Cannot re-sign: no Developer ID identity found');
-        // Continue to notarization — it will fail, but at least we get
-        // Apple's error message about what's wrong with the signature.
       } else {
-        const entitlements = path.join(__dirname, '..', 'build', 'entitlements.mac.plist');
+        // Use the helper's own entitlements, not the main app's
+        const helperEntitlements = path.join(
+          __dirname, '..', 'native', 'musickit-helper', 'MusicKitHelper.entitlements'
+        );
+        // Fallback to main app entitlements if helper-specific ones don't exist
+        const entitlements = fs.existsSync(helperEntitlements)
+          ? helperEntitlements
+          : path.join(__dirname, '..', 'build', 'entitlements.mac.plist');
+
+        console.log(`  Entitlements: ${path.basename(entitlements)}`);
 
         // Re-sign the nested helper bundle (innermost first)
         console.log(`  Signing MusicKitHelper.app with: ${identity}`);
@@ -98,10 +138,11 @@ exports.default = async function afterSign(context) {
         );
 
         // Re-sign the main app (outermost — seals the updated helper)
+        const mainEntitlements = path.join(__dirname, '..', 'build', 'entitlements.mac.plist');
         console.log(`  Re-signing ${appName}.app...`);
         execSync(
           `/usr/bin/codesign --force --sign "${identity}" ` +
-          `--entitlements "${entitlements}" --options runtime ` +
+          `--entitlements "${mainEntitlements}" --options runtime ` +
           `--timestamp "${appPath}"`,
           { stdio: 'inherit', timeout: 60000 }
         );
@@ -111,6 +152,8 @@ exports.default = async function afterSign(context) {
           console.log('✓ Re-signed and verified successfully');
         } else {
           console.error('✗ Signature still invalid after re-signing');
+          logSignatureInfo(appPath, 'Parachord (after re-sign)');
+          logSignatureInfo(helperAppPath, 'MusicKitHelper (after re-sign)');
         }
       }
     }
@@ -123,9 +166,10 @@ exports.default = async function afterSign(context) {
     console.log(`✓ ${appName}.app signature is valid`);
   } else {
     console.error(`✗ ${appName}.app signature is INVALID — notarization will likely fail`);
+    logSignatureInfo(appPath, appName);
   }
 
-  // ── Step 3: Notarize ────────────────────────────────────────────────
+  // ── Step 3: Notarize the .app ───────────────────────────────────────
   const appleId = process.env.APPLE_ID;
   const appleIdPassword = process.env.APPLE_APP_SPECIFIC_PASSWORD;
   const teamId = process.env.APPLE_TEAM_ID;
@@ -151,5 +195,26 @@ exports.default = async function afterSign(context) {
   } catch (error) {
     console.error('✗ Notarization failed:', error.message);
     throw error;
+  }
+
+  // ── Step 4: Verify stapling ─────────────────────────────────────────
+  try {
+    execSync(`xcrun stapler validate "${appPath}" 2>&1`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    console.log('✓ Staple validation passed');
+  } catch (err) {
+    console.warn('⚠ Staple validation failed:', err.message);
+    // Not fatal — Gatekeeper can still check online
+  }
+
+  // ── Step 5: Gatekeeper assessment ───────────────────────────────────
+  const assessment = assessGatekeeper(appPath);
+  if (assessment.accepted) {
+    console.log(`✓ spctl assessment passed`);
+  } else {
+    console.warn(`⚠ spctl assessment failed (may be OK before DMG notarization):`);
+    console.warn(`  ${assessment.output.trim()}`);
   }
 };


### PR DESCRIPTION
Three root causes identified and fixed:

1. DMG not notarized — the afterSign hook notarized the .app, but on macOS Sequoia Gatekeeper checks the downloaded DMG itself.  Added scripts/notarize-artifacts.js and a CI step to notarize+staple the DMG after electron-builder creates it.

2. x64ArchFiles too broad — the glob caught everything inside MusicKitHelper.app (including Info.plist and CodeResources), which could cause @electron/universal to corrupt the pre-signed bundle during the merge.  Narrowed to only match .node files since MusicKitHelper is already a universal binary.

3. signIgnore missing — electron-builder re-signed the Mach-O inside MusicKitHelper.app without re-sealing the bundle.  Added signIgnore so electron-builder leaves the pre-signed helper untouched.

Also fixed: afterSign hook now uses the helper's own entitlements (MusicKitHelper.entitlements) instead of the main app's, and adds spctl/staple verification for better diagnostics.

https://claude.ai/code/session_012tg5uTWFHDNvgbnrkwhyPL