### PR TITLE
Add MusicKitHelper to x64ArchFiles for universal builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
       "notarize": false,
-      "x64ArchFiles": "Contents/Resources/app.asar.unpacked/node_modules/**/*.node",
+      "x64ArchFiles": "{Contents/Resources/app.asar.unpacked/node_modules/**/*.node,Contents/Resources/bin/darwin/MusicKitHelper.app/Contents/MacOS/MusicKitHelper}",
       "signIgnore": ["MusicKitHelper\\.app"],
       "extendInfo": {
         "NSAppleMusicUsageDescription": "Parachord needs access to Apple Music to play songs from your library and subscription."


### PR DESCRIPTION
The MusicKitHelper binary is already a universal (fat) binary built with lipo, but @electron/universal doesn't know that. It sees the identical file in both x64 and arm64 temp builds and errors out. Adding it to x64ArchFiles tells the merger to take the x64 copy (which is the same universal binary) and skip the conflict.

https://claude.ai/code/session_012tg5uTWFHDNvgbnrkwhyPL