### PR TITLE
Include entire MusicKitHelper.app in x64ArchFiles glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
       "notarize": false,
-      "x64ArchFiles": "{Contents/Resources/app.asar.unpacked/node_modules/**/*.node,Contents/Resources/bin/darwin/MusicKitHelper.app/Contents/MacOS/MusicKitHelper}",
+      "x64ArchFiles": "{Contents/Resources/app.asar.unpacked/node_modules/**/*.node,Contents/Resources/bin/darwin/MusicKitHelper.app/**}",
       "signIgnore": ["MusicKitHelper\\.app"],
       "extendInfo": {
         "NSAppleMusicUsageDescription": "Parachord needs access to Apple Music to play songs from your library and subscription."


### PR DESCRIPTION
The previous glob only matched the Mach-O binary, so @electron/universal handled _CodeSignature separately and corrupted the bundle seal (files=0, Info.plist=not bound). This forced the afterSign hook to re-sign both MusicKitHelper.app and the outer Parachord.app, replacing electron- builder's carefully-constructed signature with a bare codesign --force that Gatekeeper rejected as "damaged."

By matching the entire .app bundle, @electron/universal takes the pre-signed MusicKitHelper.app intact from the x64 build. The afterSign hook sees a valid signature, skips re-signing, and electron-builder's original Parachord.app signature is preserved.

https://claude.ai/code/session_012tg5uTWFHDNvgbnrkwhyPL