### PR TITLE
Add MusicKitHelper binary back to x64ArchFiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
       "notarize": false,
-      "x64ArchFiles": "Contents/Resources/app.asar.unpacked/node_modules/**/*.node",
+      "x64ArchFiles": "{Contents/Resources/app.asar.unpacked/node_modules/**/*.node,Contents/Resources/bin/darwin/MusicKitHelper.app/Contents/MacOS/MusicKitHelper}",
       "extendInfo": {
         "NSAppleMusicUsageDescription": "Parachord needs access to Apple Music to play songs from your library and subscription."
       },


### PR DESCRIPTION
@electron/universal requires files identical in both arch builds to be listed in x64ArchFiles. The MusicKitHelper binary is already universal (built by prebuild), so it's the same in both x64 and arm64 temps.

Use the narrow pattern (just the binary, not the whole .app bundle) — this is the same pattern that produced working DMGs on main.

https://claude.ai/code/session_01Wu2aKp8wNLyRUP6MzMCMRJ