### PR TITLE
Switch from universal to separate arch-specific Mac builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,10 @@ jobs:
         include:
           - os: macos-latest
             platform: mac
-            arch: universal
+            arch: arm64
+          - os: macos-13
+            platform: mac
+            arch: x64
           - os: ubuntu-latest
             platform: linux
             arch: x64

--- a/package.json
+++ b/package.json
@@ -98,19 +98,12 @@
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
       "notarize": false,
-      "x64ArchFiles": "{Contents/Resources/app.asar.unpacked/node_modules/**/*.node,Contents/Resources/bin/darwin/MusicKitHelper.app/Contents/MacOS/MusicKitHelper}",
       "extendInfo": {
         "NSAppleMusicUsageDescription": "Parachord needs access to Apple Music to play songs from your library and subscription."
       },
       "target": [
-        {
-          "target": "dmg",
-          "arch": ["universal"]
-        },
-        {
-          "target": "zip",
-          "arch": ["universal"]
-        }
+        "dmg",
+        "zip"
       ],
       "extraResources": [
         {


### PR DESCRIPTION
Gatekeeper on macOS Sequoia rejects universal Electron apps created by @electron/universal, even when codesign and spctl both say the app is valid. This is confirmed by testing: the .app passes all checks but still shows "damaged" with quarantine set. Removing quarantine lets it open fine. Previous working releases (0.6.0, 0.7.0) were arm64-only.

Switch to separate arm64 + x64 builds:
- package.json: Remove x64ArchFiles (no longer needed without universal merge), simplify targets to ["dmg", "zip"] without explicit arch
- build.yml: Replace single universal job with arm64 (macos-latest) and x64 (macos-13) jobs. Both get code signing, notarization, and artifact upload.

This also fixes MusicKit playback — the universal merge was breaking MusicKitHelper.app's signature in ways that prevented developer token generation. With single-arch builds, electron-builder signs everything correctly end-to-end.

https://claude.ai/code/session_01Wu2aKp8wNLyRUP6MzMCMRJ