### PR TITLE
Replace deprecated macos-13 runner with macos-latest for x64 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
           - os: macos-latest
             platform: mac
             arch: arm64
-          - os: macos-13
+          - os: macos-latest
             platform: mac
             arch: x64
           - os: ubuntu-latest


### PR DESCRIPTION
GitHub has retired the macos-13 Intel runners. Use macos-latest (ARM64) and let electron-builder cross-compile x64 via the --x64 flag.

https://claude.ai/code/session_01Wu2aKp8wNLyRUP6MzMCMRJ