### PR TITLE
Fix build: remove duplicate extraResources for .p8 key

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,13 +112,6 @@
           "filter": [
             "**/*"
           ]
-        },
-        {
-          "from": "resources/keys/",
-          "to": "keys/",
-          "filter": [
-            "*.p8"
-          ]
         }
       ],
       "entitlements": "build/entitlements.mac.plist",


### PR DESCRIPTION
The keys/ extraResources was defined both at the top level (all platforms) and in the mac section, causing an EEXIST hard-link error during electron-builder packaging. Remove the mac-specific duplicate.

https://claude.ai/code/session_01Wu2aKp8wNLyRUP6MzMCMRJ