### PR TITLE
Remove key field from manifest for Chrome Web Store submission

### DIFF
--- a/parachord-extension/manifest.json
+++ b/parachord-extension/manifest.json
@@ -3,7 +3,6 @@
   "name": "Parachord",
   "version": "0.3.0",
   "description": "Connect your browser to Parachord desktop for playback control and content discovery",
-  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnH3d205dKW4u0KLmU/8sjXnP/uAUb1BYXUPPSbnqmUMrck1MylNHx1E2gruONfuxCO+Q4c7KsfdHCvRIGpmVA0ME0FymJl+yLTsHfLhdXk2san7kdYcLVqO06f7QrLcXC+wu8uGs9rqNxzOZgkMbLBWq8ZN2as5eT7rmEA1BCpJ0+pMfQXY+/WOcrrWqUn9Zrdl0u19hk+lVTYzMHkqFtaHZ6kUoTxvtUXLvrW+c/5g0UWTqu8fZymR6Lne3aZLp3TBE6CXvjUjZfWtpqcSWWC1qUhEdBAfcczDNtS+nSdaDBSG1KfE4oGjGOoVLwiU4Sf6NEfGBQ6zvxTA6WtUnyQIDAQAB",
   "permissions": [
     "activeTab",
     "scripting",


### PR DESCRIPTION
The Chrome Web Store rejects uploads with the "key" field in manifest.json. This field was only needed during development to pin the extension ID.

https://claude.ai/code/session_016bTWmfob2jTKfDxWKF78SF