### PR TITLE
Restore store-descriptions.md and fix reverse sync deleting monorepo-…

### DIFF
--- a/.github/workflows/reverse-sync.yml
+++ b/.github/workflows/reverse-sync.yml
@@ -49,7 +49,10 @@ jobs:
       - name: Copy changes into monorepo
         run: |
           # Copy everything except .git and .github from the dedicated repo
-          rsync -a --delete \
+          # NOTE: Do NOT use --delete here. The monorepo is the source of truth
+          # and may contain files (e.g. store-descriptions.md) that only live
+          # in the monorepo and were never synced to the dedicated repo.
+          rsync -a \
             --exclude '.git' \
             --exclude '.github' \
             /tmp/browser-ext/ parachord-extension/
@@ -121,7 +124,9 @@ jobs:
 
       - name: Copy changes into monorepo
         run: |
-          rsync -a --delete \
+          # Do NOT use --delete — the monorepo may contain files not in the
+          # dedicated repo (monorepo-only docs, scripts, etc.).
+          rsync -a \
             --exclude '.git' \
             --exclude '.github' \
             /tmp/raycast-ext/ raycast-extension/

--- a/parachord-extension/store-descriptions.md
+++ b/parachord-extension/store-descriptions.md
@@ -1,0 +1,102 @@
+# Parachord — Store Listing Descriptions
+
+## Chrome Web Store
+
+### Short Description (132 char max)
+
+Send songs, albums, and playlists from your browser to Parachord — your unified, privacy-first desktop music player.
+
+### Detailed Description
+
+Send songs, albums, and playlists to Parachord — a desktop music player that unifies Spotify, Apple Music, YouTube, Bandcamp, SoundCloud, and more into a single library.
+
+Browse any supported music site, click the Parachord icon, and instantly queue tracks or entire playlists for playback — all without leaving your browser.
+
+SUPPORTED SERVICES
+• YouTube — videos and music
+• Spotify — tracks, albums, and playlists
+• Apple Music — songs, albums, and playlists
+• Bandcamp — tracks and albums
+• SoundCloud — tracks and playlists
+• Pitchfork — album and track reviews
+• Last.fm — user profiles (add friends)
+• ListenBrainz — user profiles (add friends)
+
+FEATURES
+• One-click "Send to Parachord" from the popup or right-click context menu
+• Automatic playlist scraping — extracts full tracklists from Spotify, Apple Music, Bandcamp, YouTube, and SoundCloud
+• Smart page detection — badge indicator shows when you're viewing supported music content
+• Optional link interception — Spotify and Apple Music links open in Parachord instead of native apps
+• Real-time connection status so you always know the desktop app is ready
+
+PRIVACY FIRST
+• All data stays on your computer — communication uses Chrome's native messaging, a secure local-only channel
+• Zero analytics, zero tracking, zero telemetry
+• No user accounts or sign-up required
+• No ads
+
+REQUIREMENTS
+Parachord desktop app must be installed and running on your computer. Available for macOS, Windows, and Linux at https://parachord.com
+
+
+---
+
+## Firefox Add-ons (AMO)
+
+### Summary (250 char max)
+
+Send songs, albums, and playlists from your browser to Parachord — a desktop music player that unifies Spotify, Apple Music, YouTube, Bandcamp, SoundCloud, and more into a single library. Privacy-first: all data stays on your computer.
+
+### Description
+
+Send songs, albums, and playlists to Parachord — a desktop music player that unifies Spotify, Apple Music, YouTube, Bandcamp, SoundCloud, and more into a single library.
+
+Browse any supported music site, click the Parachord icon, and instantly queue tracks or entire playlists for playback — all without leaving your browser.
+
+<b>Supported Services</b>
+
+<ul>
+<li>YouTube — videos and music</li>
+<li>Spotify — tracks, albums, and playlists</li>
+<li>Apple Music — songs, albums, and playlists</li>
+<li>Bandcamp — tracks and albums</li>
+<li>SoundCloud — tracks and playlists</li>
+<li>Pitchfork — album and track reviews</li>
+<li>Last.fm — user profiles (add friends)</li>
+<li>ListenBrainz — user profiles (add friends)</li>
+</ul>
+
+<b>Features</b>
+
+<ul>
+<li>One-click "Send to Parachord" from the popup or right-click context menu</li>
+<li>Automatic playlist scraping — extracts full tracklists from Spotify, Apple Music, Bandcamp, YouTube, and SoundCloud</li>
+<li>Smart page detection — badge indicator shows when you're viewing supported music content</li>
+<li>Optional link interception — Spotify and Apple Music links open in Parachord instead of native apps</li>
+<li>Real-time connection status so you always know the desktop app is ready</li>
+</ul>
+
+<b>Privacy First</b>
+
+<ul>
+<li>All data stays on your computer — communication uses native messaging, a secure local-only channel</li>
+<li>Zero analytics, zero tracking, zero telemetry</li>
+<li>No user accounts or sign-up required</li>
+<li>No ads</li>
+</ul>
+
+<b>Requirements</b>
+
+Parachord desktop app must be installed and running on your computer. Available for macOS, Windows, and Linux at <a href="https://parachord.com">parachord.com</a>.
+
+
+---
+
+## Store Categories
+
+Chrome Web Store: Productivity (or Music, if available under Entertainment)
+Firefox Add-ons: Music & Video
+
+## Tags / Keywords
+
+music, player, spotify, youtube, bandcamp, apple music, soundcloud, playlist, queue, desktop, native messaging, privacy


### PR DESCRIPTION
…only files

The reverse sync workflow used `rsync --delete` which wiped files that only exist in the monorepo (like store-descriptions.md) whenever the dedicated repo didn't contain them. Removed --delete from the browser extension and Raycast reverse syncs so monorepo-only files are preserved.

https://claude.ai/code/session_016bTWmfob2jTKfDxWKF78SF