### PR TITLE
Add tooltip-top-end positioning to prevent right edge overflow

### DIFF
--- a/app.js
+++ b/app.js
@@ -46029,7 +46029,7 @@ useEffect(() => {
             },
               React.createElement(Tooltip, {
                 content: getTooltip(),
-                position: 'top',
+                position: 'top-end',
                 variant: 'dark'
               },
                 React.createElement('button', {
@@ -46051,7 +46051,7 @@ useEffect(() => {
               ),
               React.createElement(Tooltip, {
                 content: getTooltip(),
-                position: 'top',
+                position: 'top-end',
                 variant: 'dark'
               },
                 React.createElement('input', {

--- a/index.html
+++ b/index.html
@@ -321,6 +321,23 @@
       transform: translateX(-50%) translateY(0);
     }
 
+    /* Top-end: right-aligned to prevent overflow at right edge of window */
+    .tooltip-top-end {
+      bottom: calc(100% + 8px);
+      right: 0;
+      transform: translateY(4px);
+    }
+
+    .tooltip-top-end::before {
+      bottom: -4px;
+      right: 12px;
+      transform: rotate(45deg);
+    }
+
+    .tooltip-container:hover .tooltip-top-end {
+      transform: translateY(0);
+    }
+
     .tooltip-bottom {
       top: calc(100% + 8px);
       left: 50%;


### PR DESCRIPTION
## Summary
Added a new `tooltip-top-end` positioning variant for tooltips that aligns them to the right to prevent overflow at the window's right edge. Updated two tooltip instances to use this new positioning.

## Key Changes
- **CSS**: Added `.tooltip-top-end` styles with right-aligned positioning and corresponding arrow styling
  - Positions tooltip above the trigger element with `bottom: calc(100% + 8px)`
  - Right-aligns the tooltip with `right: 0` to prevent overflow
  - Arrow positioned 12px from the right edge
  - Includes hover animation that translates from 4px to 0 on the Y-axis
  
- **JavaScript**: Updated two Tooltip components to use `position: 'top-end'` instead of `position: 'top'`
  - First tooltip instance (around line 46032)
  - Second tooltip instance (around line 46054)

## Implementation Details
The new positioning follows the existing tooltip pattern with a pseudo-element arrow (`::before`) that rotates 45 degrees. The right-alignment strategy ensures tooltips don't overflow the viewport when positioned near the right edge of the window.

https://claude.ai/code/session_01Cek4YJZsgGsY45pAbKJcVw