### PR TITLE
End listen-along session when user manually plays a different track

### DIFF
--- a/app.js
+++ b/app.js
@@ -12303,6 +12303,21 @@ ${trackListXml}
   };
 
   const handlePlay = async (trackOrSource) => {
+    // If user manually plays something while listening along, end the listen-along session
+    // Listen-along tracks are tagged with _playbackContext.type === 'listenAlong'
+    const listenAlongFriendNow = listenAlongFriendRef.current;
+    if (listenAlongFriendNow && trackOrSource?._playbackContext?.type !== 'listenAlong') {
+      console.log(`🎧 User played a different track - ending listen-along with ${listenAlongFriendNow.displayName}`);
+      showToast(`Stopped listening along with ${listenAlongFriendNow.displayName}`);
+      abortSchedulerContext('listen-along');
+      setListenAlongFriend(null);
+      listenAlongLastTrackRef.current = null;
+      listenAlongPendingTrackRef.current = null;
+      listenAlongUserPausedRef.current = false;
+      listenAlongEndAfterSongRef.current = null;
+      setPlaybackContext(null);
+    }
+
     // Increment playback generation to mark this as the current play request
     // Any previously-started play request will detect this and abort
     playbackGenerationRef.current++;


### PR DESCRIPTION
When the user is listening along with a friend and manually chooses something else to play (from search, collection, queue, etc.), the listen-along session now automatically ends. This is detected at the top of handlePlay by checking if the track lacks the listenAlong playback context tag. All listen-along state is cleaned up and a toast notifies the user.

Previously, listen-along only ended on skip/previous/collection-station but not when the user directly played a different track.

https://claude.ai/code/session_011ycsM4CVur8EEuQvDzJvz2