### PR TITLE
Refine share button styling and alignment

### DIFF
--- a/app.js
+++ b/app.js
@@ -3571,18 +3571,18 @@ const ReleasePage = ({
             }
           }, release.tracks ? `${release.tracks.length.toString().padStart(2, '0')} Songs` : 'Loading...'),
           // Share button
-          React.createElement('div', { className: 'relative mt-5 flex justify-center', style: { width: `${albumArtSize}px` } },
+          React.createElement('div', { className: 'relative mt-5 flex justify-start', style: { width: `${albumArtSize}px` } },
             React.createElement('button', {
               onClick: (e) => { e.stopPropagation(); setShareDropdownOpen(shareDropdownOpen === 'album' ? false : 'album'); },
-              className: 'px-3 py-1.5 bg-pink-600 hover:bg-pink-700 text-white rounded-lg text-sm font-medium transition-colors flex items-center gap-1.5 no-drag'
+              className: 'px-2 py-1 bg-pink-600 hover:bg-pink-700 text-white rounded-md text-xs font-medium transition-colors flex items-center gap-1 no-drag'
             },
-              React.createElement('svg', { className: 'w-4 h-4', fill: 'none', viewBox: '0 0 24 24', stroke: 'currentColor', strokeWidth: 2 },
+              React.createElement('svg', { className: 'w-3 h-3', fill: 'none', viewBox: '0 0 24 24', stroke: 'currentColor', strokeWidth: 2 },
                 React.createElement('path', { strokeLinecap: 'round', strokeLinejoin: 'round', d: 'M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z' })
               ),
               'Share'
             ),
             shareDropdownOpen === 'album' && React.createElement('div', {
-              className: 'absolute left-1/2 -translate-x-1/2 top-full mt-1 rounded-lg py-1 min-w-[160px] z-30',
+              className: 'absolute left-0 top-full mt-1 rounded-lg py-1 min-w-[160px] z-30',
               style: { backgroundColor: '#1f2937', boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)' },
               onClick: (e) => e.stopPropagation()
             },
@@ -35562,18 +35562,18 @@ useEffect(() => {
                 }, 'Delete Playlist')
               ),
               // Share button (outside space-y-1 metadata div for independent spacing)
-              React.createElement('div', { className: 'relative mt-3 flex justify-center', style: { width: '212px' } },
+              React.createElement('div', { className: 'relative mt-3 flex justify-start', style: { width: '212px' } },
                 React.createElement('button', {
                   onClick: (e) => { e.stopPropagation(); setShareDropdownOpen(shareDropdownOpen === 'playlist' ? false : 'playlist'); },
-                  className: 'px-3 py-1.5 bg-pink-600 hover:bg-pink-700 text-white rounded-lg text-sm font-medium transition-colors flex items-center gap-1.5 no-drag'
+                  className: 'px-2 py-1 bg-pink-600 hover:bg-pink-700 text-white rounded-md text-xs font-medium transition-colors flex items-center gap-1 no-drag'
                 },
-                  React.createElement('svg', { className: 'w-4 h-4', fill: 'none', viewBox: '0 0 24 24', stroke: 'currentColor', strokeWidth: 2 },
+                  React.createElement('svg', { className: 'w-3 h-3', fill: 'none', viewBox: '0 0 24 24', stroke: 'currentColor', strokeWidth: 2 },
                     React.createElement('path', { strokeLinecap: 'round', strokeLinejoin: 'round', d: 'M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z' })
                   ),
                   'Share'
                 ),
                 shareDropdownOpen === 'playlist' && React.createElement('div', {
-                  className: 'absolute left-1/2 -translate-x-1/2 top-full mt-1 rounded-lg py-1 min-w-[160px] z-30',
+                  className: 'absolute left-0 top-full mt-1 rounded-lg py-1 min-w-[160px] z-30',
                   style: { backgroundColor: '#1f2937', boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)' },
                   onClick: (e) => e.stopPropagation()
                 },


### PR DESCRIPTION
## Summary
Updated the share button styling and positioning across album and playlist pages to create a more compact, left-aligned appearance.

## Key Changes
- **Button alignment**: Changed from center-aligned (`justify-center`) to left-aligned (`justify-start`) for both album and playlist share buttons
- **Button sizing**: Reduced padding from `px-3 py-1.5` to `px-2 py-1` and text size from `text-sm` to `text-xs`
- **Icon sizing**: Decreased icon dimensions from `w-4 h-4` to `w-3 h-3`
- **Gap spacing**: Reduced gap between icon and text from `gap-1.5` to `gap-1`
- **Border radius**: Changed from `rounded-lg` to `rounded-md` for a slightly sharper appearance
- **Dropdown positioning**: Changed dropdown menu from center-aligned (`left-1/2 -translate-x-1/2`) to left-aligned (`left-0`) to match the button alignment

## Implementation Details
These changes were applied consistently to both the ReleasePage (album) and playlist share button components, ensuring a uniform user experience across the application. The modifications create a more compact button design while maintaining visual hierarchy and usability.

https://claude.ai/code/session_01Lz7WTSrEA5dAPkcXfQMsD8