### PR TITLE
Cache electron-builder binaries to reduce build failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,19 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Cache electron-builder binary downloads (NSIS, winCodeSign, electron zip)
+      # to avoid transient GitHub download failures during the build step.
+      - name: Cache electron-builder binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~\AppData\Local\electron-builder\Cache
+            ~/Library/Caches/electron-builder
+            ~/.cache/electron-builder
+          key: electron-builder-cache-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            electron-builder-cache-${{ runner.os }}-
+
       # Wrap codesign with retry logic for transient Apple timestamp server failures
       - name: Setup codesign retry wrapper
         if: matrix.platform == 'mac'


### PR DESCRIPTION
## Summary
Added caching for electron-builder binary downloads to improve build reliability and reduce transient download failures from GitHub.

## Key Changes
- Implemented GitHub Actions cache for electron-builder binaries across all platforms:
  - Windows: `~\AppData\Local\electron-builder\Cache`
  - macOS: `~/Library/Caches/electron-builder`
  - Linux: `~/.cache/electron-builder`
- Cache key includes runner OS and `package-lock.json` hash to invalidate when dependencies change
- Fallback restore key allows cache hits across patch versions of the same OS

## Implementation Details
The cache step is positioned before the codesign retry wrapper setup, ensuring binaries (NSIS, winCodeSign, electron zip) are available early in the build process. This reduces the likelihood of transient network failures during the build step by reusing previously downloaded binaries when available.

https://claude.ai/code/session_012Af5vvNbkGfRmVhKFvS3mV