### PR TITLE
Fix AI chat auto-scroll behavior on window open and message arrival

### DIFF
--- a/app.js
+++ b/app.js
@@ -16860,8 +16860,21 @@ ${trackListXml}
   useEffect(() => { openAiChatRef.current = openAiChat; });
   useEffect(() => { handleAiChatSendRef.current = handleAiChatSend; });
 
+  // Scroll to bottom when chat window is opened (after slide-in animation completes)
+  useEffect(() => {
+    if (aiChatOpen && chatMessagesRef.current) {
+      const timer = setTimeout(() => {
+        if (chatMessagesRef.current) {
+          chatMessagesRef.current.scrollTop = chatMessagesRef.current.scrollHeight;
+        }
+      }, 220); // Wait for 200ms sidebar slide-in animation to finish
+      return () => clearTimeout(timer);
+    }
+  }, [aiChatOpen]);
+
   // Auto-scroll to keep messages visible when new messages arrive
   useEffect(() => {
+    if (!aiChatOpen) return;
     if (lastAssistantMessageRef.current) {
       // Scroll to show the assistant response from the top
       lastAssistantMessageRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });


### PR DESCRIPTION
## Summary
Improved the auto-scroll behavior of the AI chat window to ensure messages are properly visible both when the chat window is first opened and when new messages arrive.

## Key Changes
- Added a new effect that scrolls to the bottom of the chat when the chat window opens, with a 220ms delay to account for the sidebar slide-in animation
- Modified the existing auto-scroll effect to skip scrolling when the chat window is closed, preventing unnecessary scroll operations
- Implemented proper cleanup of the timer to avoid memory leaks

## Implementation Details
- The initial scroll uses a `setTimeout` with a 220ms delay to wait for the CSS slide-in animation to complete before scrolling
- The auto-scroll effect now checks `aiChatOpen` status before attempting to scroll to new messages
- Both effects properly manage their cleanup functions to prevent stale references and memory leaks

https://claude.ai/code/session_01EkBTJ2acS6pmEFtpgZv3Hk