### PR TITLE
Fix Apple Music seek silently failing due to Int/Double type coercion

### DIFF
--- a/app.js
+++ b/app.js
@@ -46212,11 +46212,16 @@ useEffect(() => {
                       if (window._appleMusicPreviewAudio && !window._appleMusicPreviewAudio.paused) {
                         window._appleMusicPreviewAudio.currentTime = newPosition;
                       }
+                      // Reset interpolation baseline to new position regardless of seek result,
+                      // so the progress bar stays at the dragged position until the next poll
+                      appleMusicProgressBaselineRef.current = { progress: newPosition, timestamp: Date.now(), isPlaying: true };
                       // Seek via native MusicKit (macOS)
                       if (window.electron?.musicKit?.seek) {
-                        await window.electron.musicKit.seek(newPosition);
-                        // Reset interpolation baseline to new position
-                        appleMusicProgressBaselineRef.current = { progress: newPosition, timestamp: Date.now(), isPlaying: true };
+                        try {
+                          await window.electron.musicKit.seek(newPosition);
+                        } catch (e) {
+                          console.warn('[Seek] Native MusicKit seek failed:', e);
+                        }
                       }
                       // Seek via MusicKit JS web (cross-platform)
                       if (window.getMusicKitWeb) {

--- a/musickit-bridge.js
+++ b/musickit-bridge.js
@@ -514,7 +514,12 @@ class MusicKitBridge extends EventEmitter {
   }
 
   async seek(position) {
-    return this.send('seek', { position });
+    // Ensure position serializes as a JSON float, not an integer.
+    // Swift's AnyCodable decodes "30" as Int, and `as? Double` fails,
+    // so whole-number positions silently fail.  Adding a tiny epsilon
+    // forces JSON.stringify to emit a decimal (e.g. "30.0000001").
+    const safePosition = Number.isInteger(position) ? position + 1e-7 : position;
+    return this.send('seek', { position: safePosition });
   }
 
   async getPlaybackState() {

--- a/native/musickit-helper/Sources/MusicKitHelperApp.swift
+++ b/native/musickit-helper/Sources/MusicKitHelperApp.swift
@@ -561,7 +561,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 result = try await bridge.skipToPrevious()
 
             case "seek":
-                guard let position = params["position"] as? Double else {
+                // Accept both Int and Double: JSON "30" decodes as Int via AnyCodable,
+                // but Swift's `as? Double` can't coerce Int, so we need to check both.
+                let position: Double
+                if let d = params["position"] as? Double {
+                    position = d
+                } else if let i = params["position"] as? Int {
+                    position = Double(i)
+                } else {
                     return Response(id: request.id, success: false, data: nil, error: "Missing position parameter")
                 }
                 result = bridge.seek(position: position)
@@ -579,7 +586,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 result = try await bridge.addToQueue(songId: songId)
 
             case "setVolume":
-                guard let volume = params["volume"] as? Double else {
+                let volume: Double
+                if let d = params["volume"] as? Double {
+                    volume = d
+                } else if let i = params["volume"] as? Int {
+                    volume = Double(i)
+                } else {
                     return Response(id: request.id, success: false, data: nil, error: "Missing volume parameter")
                 }
                 result = bridge.setVolume(Float(volume))


### PR DESCRIPTION
The Swift AnyCodable decoder tries Int before Double, so JSON integer values like "30" (from the slider's whole-number positions) are stored as Int. Swift's `as? Double` can't coerce Int, so the seek handler returned "Missing position parameter" every time — the seek silently failed and the progress bar snapped back after 1 second.

Fixes:
- Swift: accept both Int and Double for seek position and volume params
- JS bridge: add tiny epsilon to force JSON float serialization as a belt-and-suspenders workaround for pre-rebuilt binaries
- Slider onChange: move baseline reset before the seek call and add try-catch so the progress bar doesn't snap back even on seek failure

https://claude.ai/code/session_01DZy7JRsfQ65k2ZxV7X3YnG