### PR TITLE
Increase playlist display limit from 3 to 4 items

### DIFF
--- a/app.js
+++ b/app.js
@@ -37506,7 +37506,7 @@ useEffect(() => {
                     React.createElement('div', { className: 'space-y-2 flex-1' },
                       [...playlists]
                         .sort((a, b) => (b.lastModified || b.addedAt || 0) - (a.lastModified || a.addedAt || 0))
-                        .slice(0, 3)
+                        .slice(0, 4)
                         .map((playlist, index) =>
                           React.createElement('button', {
                             key: playlist.id,


### PR DESCRIPTION
## Summary
Updated the playlist display limit to show one additional playlist in the UI.

## Changes
- Increased the slice limit for displaying playlists from 3 to 4 items
- This allows users to see more recently modified or added playlists at a glance

## Implementation Details
The change modifies the `.slice(0, 3)` call to `.slice(0, 4)` in the playlist rendering logic. Playlists are sorted by `lastModified` or `addedAt` timestamp in descending order before being sliced, so the 4 most recent playlists will now be displayed instead of 3.

https://claude.ai/code/session_01LiWRpYqPV8QKrqe5PTCrJb