### PR TITLE
Bump version to 0.8.0-alpha.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parachord-desktop",
-  "version": "0.8.0-alpha.3",
+  "version": "0.8.0-alpha.4",
   "description": "Parachord Desktop - Multi-source music player with cross-platform resolver support",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Summary
This release bumps the version number for the next alpha release of Parachord Desktop.

## Changes
- Updated version from `0.8.0-alpha.3` to `0.8.0-alpha.4` in package.json

This is a routine version bump for the alpha release cycle.

https://claude.ai/code/session_015SdkZYN1RrJkzLqZLGXddC