### PR TITLE
Simplify title bar handling to macOS only

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,12 +1,10 @@
 // Parachord Desktop App - Electron Version
 const { useState, useEffect, useRef, useCallback, useMemo } = React;
 
-// Platform detection: on macOS/Linux we use -webkit-app-region: drag for the title bar.
-// On Windows, titleBarOverlay handles dragging natively, so we skip the drag class
-// (which would block all mouse events including right-click context menus on Windows).
-// Linux has had the drag-region context menu fix since Electron 34+ (PR #45813).
-const isWindows = window.electron?.platform === 'win32';
-const useDragClass = !isWindows;
+// Platform detection: only macOS uses a hidden title bar (titleBarStyle: 'hidden'),
+// so only macOS needs the drag class and title bar spacer. Windows and Linux use the
+// native title bar with a visible menu bar.
+const isMac = window.electron?.platform === 'darwin';
 
 // Global rate limiter for iTunes API to prevent 403/429 errors
 // iTunes API has strict rate limits (~20 req/min)
@@ -30223,9 +30221,9 @@ useEffect(() => {
           }
         }
       },
-        // Title bar spacer (draggable on macOS for traffic lights; on Windows, titleBarOverlay handles dragging)
-        React.createElement('div', {
-          className: `h-8 flex-shrink-0${useDragClass ? ' drag' : ''}`
+        // Title bar spacer (macOS only — provides space for traffic lights and draggable area)
+        isMac && React.createElement('div', {
+          className: 'h-8 flex-shrink-0 drag'
         }),
         // Navigation arrows
         React.createElement('div', {
@@ -30841,10 +30839,10 @@ useEffect(() => {
         ref: mainContentRef,
         className: 'flex-1 flex flex-col overflow-hidden bg-white relative'
       },
-        // Title bar spacer (draggable on macOS; on Windows, titleBarOverlay handles dragging)
-        React.createElement('div', {
-          className: `h-8 flex-shrink-0 absolute top-0 left-0 right-0 z-10${useDragClass ? ' drag' : ''}`,
-          style: useDragClass ? { pointerEvents: 'auto' } : { pointerEvents: 'none' }
+        // Title bar spacer (macOS only — draggable area for traffic lights)
+        isMac && React.createElement('div', {
+          className: 'h-8 flex-shrink-0 absolute top-0 left-0 right-0 z-10 drag',
+          style: { pointerEvents: 'auto' }
         }),
 
     // External Track Prompt Modal - refined styling

--- a/main.js
+++ b/main.js
@@ -632,17 +632,10 @@ function createWindow() {
     height: 900,
     minWidth: 1000,
     minHeight: 600,
-    titleBarStyle: 'hidden',
-    // On Windows, titleBarOverlay provides native window controls and a draggable
-    // title bar area without needing -webkit-app-region: drag (which blocks all
-    // mouse events including right-click context menus on Windows).
-    ...(process.platform === 'win32' ? {
-      titleBarOverlay: {
-        color: '#f9fafb',
-        symbolColor: '#374151',
-        height: 32
-      }
-    } : {}),
+    // Hidden title bar on macOS only — macOS menus live in the system menu bar,
+    // so hiding the title bar is purely cosmetic. On Windows, the menu bar is part
+    // of the window frame, so we use the default title bar to keep menus accessible.
+    ...(process.platform === 'darwin' ? { titleBarStyle: 'hidden' } : {}),
     frame: true,
     backgroundColor: '#f3f4f6',
     icon: path.join(__dirname, 'assets/icons/icon512.png'),


### PR DESCRIPTION
## Summary
Refactored title bar and window frame handling to align with platform-specific requirements. The hidden title bar is now only applied to macOS, where it's needed for the custom drag region. Windows and Linux now use the native title bar with the standard menu bar.

## Key Changes
- Changed platform detection from `isWindows` to `isMac` to better reflect the actual requirement (only macOS needs special handling)
- Removed `titleBarOverlay` configuration from Windows, allowing the native title bar to display with the menu bar
- Updated `titleBarStyle: 'hidden'` to only apply on macOS via conditional spread operator
- Simplified title bar spacer elements to only render on macOS (`isMac &&`) instead of conditionally applying CSS classes
- Removed conditional `pointerEvents` styling since the spacer now only exists on macOS where it always needs interaction

## Implementation Details
- The title bar spacer in both the sidebar and main content areas now uses `isMac &&` to conditionally render, eliminating the need for platform-specific CSS class toggling
- Removed the `useDragClass` variable entirely in favor of direct `isMac` checks
- Simplified inline styles by removing conditional `pointerEvents` logic—the drag class and pointer events are now always applied when the element renders (macOS only)
- Updated comments to clarify that Windows and Linux rely on the native title bar for menu accessibility

https://claude.ai/code/session_019utDyCzyk1Xpjt51LmHFYu