### PR TITLE
Strip manifest key from Chrome Web Store build

### DIFF
--- a/parachord-extension/manifest.json
+++ b/parachord-extension/manifest.json
@@ -3,6 +3,7 @@
   "name": "Parachord",
   "version": "0.3.0",
   "description": "Connect your browser to Parachord desktop for playback control and content discovery",
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnH3d205dKW4u0KLmU/8sjXnP/uAUb1BYXUPPSbnqmUMrck1MylNHx1E2gruONfuxCO+Q4c7KsfdHCvRIGpmVA0ME0FymJl+yLTsHfLhdXk2san7kdYcLVqO06f7QrLcXC+wu8uGs9rqNxzOZgkMbLBWq8ZN2as5eT7rmEA1BCpJ0+pMfQXY+/WOcrrWqUn9Zrdl0u19hk+lVTYzMHkqFtaHZ6kUoTxvtUXLvrW+c/5g0UWTqu8fZymR6Lne3aZLp3TBE6CXvjUjZfWtpqcSWWC1qUhEdBAfcczDNtS+nSdaDBSG1KfE4oGjGOoVLwiU4Sf6NEfGBQ6zvxTA6WtUnyQIDAQAB",
   "permissions": [
     "activeTab",
     "scripting",

--- a/scripts/package-extension.js
+++ b/scripts/package-extension.js
@@ -169,7 +169,11 @@ const manifest = validate();
 
 if (!target || target === 'chrome') {
   console.log('\n--- Chrome Web Store ---');
-  buildZip(manifest, '-chrome');
+  // Chrome Web Store rejects uploads with the "key" field — strip it for the store zip.
+  // The key is kept in the source manifest so unpacked dev installs get a stable extension ID.
+  const chromeManifest = JSON.parse(JSON.stringify(manifest));
+  delete chromeManifest.key;
+  buildZip(chromeManifest, '-chrome', chromeManifest);
 }
 
 if (!target || target === 'firefox') {


### PR DESCRIPTION
## Summary
This change ensures the extension can be uploaded to the Chrome Web Store by removing the `key` field from the packaged zip, while preserving it in the source manifest for stable extension IDs during development.

## Key Changes
- Added logic to `scripts/package-extension.js` to create a separate manifest for Chrome builds with the `key` field removed before packaging
- Added the extension's public key to `parachord-extension/manifest.json` to ensure unpacked dev installations maintain a stable extension ID

## Implementation Details
The Chrome Web Store rejects uploads containing the `key` field in manifest.json. To work around this:
- The source manifest now includes the `key` field, which allows local unpacked installations to use a consistent extension ID
- During the Chrome build process, a deep copy of the manifest is created and the `key` field is deleted before zipping
- The Firefox build continues to use the original manifest unchanged

https://claude.ai/code/session_01TdPhQaSKjBsMg5262GPC4L