### PR TITLE
Allow inline buttons on Bandcamp, Pitchfork, Last.fm, and ListenBrain…

### DIFF
--- a/parachord-extension/manifest.json
+++ b/parachord-extension/manifest.json
@@ -88,13 +88,7 @@
         "*://music.apple.com/*",
         "*://www.youtube.com/*",
         "*://youtube.com/*",
-        "*://*.bandcamp.com/*",
-        "*://bandcamp.com/*",
-        "*://soundcloud.com/*",
-        "*://pitchfork.com/*",
-        "*://www.last.fm/*",
-        "*://last.fm/*",
-        "*://listenbrainz.org/*"
+        "*://soundcloud.com/*"
       ],
       "js": ["content-inline.js"],
       "run_at": "document_idle"


### PR DESCRIPTION
…z pages

These are traditional websites where injecting small buttons next to track links works well. Only exclude true web apps (Spotify, Apple Music, YouTube, SoundCloud) whose complex UIs would be flooded with buttons.

https://claude.ai/code/session_01TdPhQaSKjBsMg5262GPC4L