### PR TITLE
Bump version to 0.8.0-alpha.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parachord-desktop",
-  "version": "0.8.0-alpha.4",
+  "version": "0.8.0-alpha.5",
   "description": "Parachord Desktop - Multi-source music player with cross-platform resolver support",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bumps version from `0.8.0-alpha.4` to `0.8.0-alpha.5`

## Changes since alpha.4
- Inline "Send to Parachord" buttons on supported music pages (Bandcamp, Pitchfork, Last.fm, ListenBrainz)
- Automated browser extension publishing to AMO and Chrome Web Store
- Fixed Spotify sync OAuth redirect, Bandcamp buy buttons, artist extraction, and YouTube URL matching
- Native title bar on Windows/Linux for menu access
- GitHub workflows for release-to-discussions and blog RSS-to-discussions
- Fixed Chrome extension connection (stable extension ID, dual CWS/dev ID support)
- Fixed hardcoded version on About page

🤖 Generated with [Claude Code](https://claude.com/claude-code)