### PR TITLE
Auto-label PRs by changed files and categorize release notes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,42 @@
+# Auto-label PRs based on changed files (used by actions/labeler)
+
+extension:
+  - changed-files:
+      - any-glob-to-any-file: 'parachord-extension/**'
+
+smart-links:
+  - changed-files:
+      - any-glob-to-any-file: 'smart-links/**'
+
+native-messaging:
+  - changed-files:
+      - any-glob-to-any-file: 'native-messaging/**'
+
+resolvers:
+  - changed-files:
+      - any-glob-to-any-file: 'plugins/**'
+
+sync:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'sync-engine/**'
+          - 'sync-providers/**'
+
+scrobbling:
+  - changed-files:
+      - any-glob-to-any-file: 'scrobblers/**'
+
+playback:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'native/musickit-helper/**'
+          - 'resolution-scheduler.js'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/workflows/**'
+          - 'scripts/**'
+
+bug:
+  - head-branch: ['^fix/', '^claude/fix-']

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,21 @@
+changelog:
+  exclude:
+    labels:
+      - ci
+    authors:
+      - dependabot
+  categories:
+    - title: Browser Extension
+      labels: [extension]
+    - title: Smart Links
+      labels: [smart-links]
+    - title: Resolvers & Playback
+      labels: [resolvers, playback]
+    - title: Sync & Scrobbling
+      labels: [sync, scrobbling]
+    - title: Native Messaging
+      labels: [native-messaging]
+    - title: Bug Fixes
+      labels: [bug]
+    - title: Other Changes
+      labels: ['*']

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,17 @@
+name: Label PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yml


### PR DESCRIPTION
- .github/labeler.yml: maps file paths to labels (extension, smart-links, resolvers, sync, playback, etc.) and branch prefixes (fix/ → bug)
- .github/workflows/labeler.yml: runs actions/labeler on PR open/sync
- .github/release.yml: groups PRs into sections (Browser Extension, Smart Links, Bug Fixes, etc.) for GitHub's generate_release_notes

This means release notes are auto-generated from merged PRs when a tag is pushed, with no manual labeling needed — file paths determine labels, labels determine categories.

https://claude.ai/code/session_01XL4ox8D4RwJ2Bytr7R5HPf