### PR TITLE
fix(sync): restore playlistFilter when opening sync modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -8309,6 +8309,7 @@ const Parachord = () => {
       playlists: [],
       folders: [],
       selectedPlaylists: existingSettings?.selectedPlaylistIds || [],
+      playlistFilter: 'all',
       settings: {
         syncTracks: existingSettings?.syncTracks ?? true,
         syncAlbums: existingSettings?.syncAlbums ?? true,


### PR DESCRIPTION
The modal open handler replaced the entire state object without including playlistFilter, so it became undefined and no tab appeared selected. Add playlistFilter: 'all' to the reset state.

https://claude.ai/code/session_017QXJr63BB3YrtouVDujhz8