### PR TITLE
Improve release notes parsing for multi-level headings

### DIFF
--- a/main.js
+++ b/main.js
@@ -4122,20 +4122,25 @@ ipcMain.handle('release-notes-get', async () => {
   const currentVersion = app.getVersion();
 
   function parseHighlights(content) {
-    // Extract section highlights: each "## Title" with its first bullet or paragraph
-    const sections = content.split(/\n(?=## )/);
+    // Extract section highlights: each "##" or "###" heading with its first bullet or paragraph
+    const sections = content.split(/\n(?=#{2,3} )/);
     const highlights = [];
     for (const section of sections) {
-      const titleMatch = section.match(/^## (.+)/);
+      const titleMatch = section.match(/^#{2,3} (.+)/);
       if (!titleMatch) continue;
-      const title = titleMatch[1].trim();
+      const title = titleMatch[1].trim().replace(/\*\*([^*]+)\*\*/g, '$1');
 
       const lines = section.split('\n').slice(1);
       let text = '';
       for (const line of lines) {
         const trimmed = line.trim();
         if (!trimmed || trimmed === '---') continue;
-        text = trimmed.replace(/^- /, '').replace(/\*\*([^*]+)\*\*/g, '$1');
+        // Skip sub-headings within the section
+        if (/^#{1,6} /.test(trimmed)) continue;
+        text = trimmed
+          .replace(/^- /, '')
+          .replace(/\*\*([^*]+)\*\*/g, '$1')
+          .replace(/`([^`]+)`/g, '$1');
         break;
       }
       if (title && text) {


### PR DESCRIPTION
## Summary
Enhanced the release notes parser to better handle markdown formatting with support for multiple heading levels and improved text extraction.

## Key Changes
- **Multi-level heading support**: Updated regex patterns to recognize both `##` and `###` headings (previously only `##`)
- **Bold text removal**: Strip markdown bold formatting (`**text**`) from section titles for cleaner display
- **Sub-heading filtering**: Skip nested headings within sections to avoid including them as highlight text
- **Code formatting removal**: Strip backticks from inline code snippets (`` `code` ``) in extracted text for better readability

## Implementation Details
- Modified the section splitting regex from `/\n(?=## )/` to `/\n(?=#{2,3} )/` to match both heading levels
- Updated title extraction regex from `/^## (.+)/` to `/^#{2,3} (.+)/` for consistency
- Added a check to skip lines matching `/^#{1,6} /` pattern to filter out any heading levels within section content
- Applied three sequential text transformations: bullet point removal, bold formatting removal, and code backtick removal

https://claude.ai/code/session_013WfhtSs4Akoh51W52dfTsP