### PR TITLE
Configure NSIS installer artifact naming for Windows builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,6 +167,9 @@
         "portable"
       ]
     },
+    "nsis": {
+      "artifactName": "${productName}-Setup-${version}.${ext}"
+    },
     "linux": {
       "icon": "assets/icons",
       "target": [


### PR DESCRIPTION
## Summary
Added NSIS configuration to customize the artifact name for Windows installer builds.

## Changes
- Added `nsis` configuration block to `package.json` electron-builder settings
- Set custom `artifactName` pattern to `${productName}-Setup-${version}.${ext}` for NSIS installers
  - This ensures Windows installers follow a consistent naming convention with "Setup" in the filename
  - Makes the installer name more user-friendly and descriptive

## Details
This configuration change affects the Windows NSIS installer output filename during the build process. Instead of using the default naming scheme, installers will now be named in the format `[ProductName]-Setup-[Version].exe`, providing better clarity for end users downloading the installer.

https://claude.ai/code/session_01W61Y4ZYVCe1LrBs1Ne6VRo