### PR TITLE
Add background color to progress slider track

### DIFF
--- a/index.html
+++ b/index.html
@@ -426,6 +426,7 @@
     .progress-slider::-webkit-slider-runnable-track {
       height: 4px;
       border-radius: 2px;
+      background: #4b5563;
     }
 
     .progress-slider::-webkit-slider-thumb {


### PR DESCRIPTION
## Summary
Added a background color to the webkit progress slider track to improve visual appearance and consistency.

## Changes
- Added `background: #4b5563;` to `.progress-slider::-webkit-slider-runnable-track` CSS rule
  - This applies a dark gray background color to the progress slider track in webkit browsers (Chrome, Safari, Edge)
  - Enhances the visual definition of the slider component

## Implementation Details
The background color (#4b5563) is a dark gray shade that complements the existing slider styling with the 4px height and 2px border-radius already defined for the track.

https://claude.ai/code/session_013CLDPUHGLMXKtqAfdLXXVH