### PR TITLE
Improve Last.fm API error handling and session validation

### DIFF
--- a/scrobbler-loader.js
+++ b/scrobbler-loader.js
@@ -498,19 +498,36 @@ class LastFmScrobbler extends BaseScrobbler {
       body: body.toString()
     });
 
-    if (!response.success) {
-      throw new Error(`Last.fm API request failed: ${response.error || response.status}`);
-    }
-
+    // Parse response body (Last.fm returns JSON with error details even on non-2xx status)
     let data;
+    const responseText = response.text || '';
     try {
-      data = JSON.parse(response.text);
+      data = JSON.parse(responseText);
     } catch (parseErr) {
-      throw new Error(`Failed to parse API response as JSON: ${(response.text || '').substring(0, 200)}`);
+      // If we can't parse JSON and the request failed, throw with HTTP status
+      if (!response.success) {
+        throw new Error(`Last.fm API request failed: ${response.error || `HTTP ${response.status}`}`);
+      }
+      throw new Error(`Failed to parse API response as JSON: ${responseText.substring(0, 200)}`);
     }
 
+    // Check for Last.fm API error in the parsed response
     if (data.error) {
-      throw new Error(`Last.fm API error ${data.error}: ${data.message}`);
+      const errorCode = data.error;
+      const errorMessage = data.message || 'Unknown error';
+      // Error 9: Invalid session key - user needs to re-authenticate
+      // Error 13: Invalid method signature
+      // Error 10: Invalid API key
+      // Error 26: Suspended API key
+      if (errorCode === 9) {
+        console.warn(`[LastFm] Session key is invalid or expired. Please re-authenticate in Settings > Scrobbling.`);
+      }
+      throw new Error(`Last.fm API error ${errorCode}: ${errorMessage}`);
+    }
+
+    // If HTTP request failed but no JSON error code, throw generic error
+    if (!response.success) {
+      throw new Error(`Last.fm API request failed: ${response.error || `HTTP ${response.status}`}`);
     }
 
     return data;


### PR DESCRIPTION
## Summary
Refactored the Last.fm API response handling to provide better error diagnostics and user guidance, particularly for session expiration scenarios.

## Key Changes
- **Reordered error checking logic**: Now attempts to parse JSON response before checking HTTP status, since Last.fm returns error details in JSON even on non-2xx responses
- **Enhanced error messages**: Improved error reporting to distinguish between HTTP failures, JSON parsing failures, and Last.fm API errors
- **Added session validation**: Detects invalid/expired session keys (error code 9) and logs a user-friendly warning directing users to re-authenticate
- **Better fallback handling**: If JSON parsing fails and the HTTP request failed, throws an HTTP status error; if JSON parsing fails but HTTP succeeded, throws a parse error
- **Improved error code handling**: Extracts error code and message separately for clearer error reporting

## Implementation Details
- The response parsing now captures the response text upfront to avoid multiple accesses
- Error checking follows a three-tier approach: JSON parse errors → Last.fm API errors → HTTP request failures
- Session expiration (error 9) is specifically handled with a console warning to guide users to the Settings > Scrobbling page for re-authentication
- Comments document the different Last.fm error codes for future reference

https://claude.ai/code/session_01Diw51nzpnKMjMJJHja8HpR