### PR TITLE
Replace grep -oP with grep -oE for better portability

### DIFF
--- a/scripts/create-backlog-issues.sh
+++ b/scripts/create-backlog-issues.sh
@@ -37,7 +37,7 @@ create_issue_and_add() {
 
   # Extract issue number from URL
   local issue_number
-  issue_number=$(echo "$url" | grep -oP '\d+$')
+  issue_number=$(echo "$url" | grep -oE '[0-9]+$')
 
   # Add to project board as Backlog
   local item_id


### PR DESCRIPTION
## Summary
Updated the `create-backlog-issues.sh` script to use a more portable grep pattern matching syntax that works across different Unix-like systems.

## Key Changes
- Replaced `grep -oP` (Perl regex) with `grep -oE` (extended regex) in the issue number extraction logic
- This change improves compatibility with systems where Perl regex support in grep may not be available or enabled

## Implementation Details
The modification changes the regex pattern from `-oP '\d+$'` to `-oE '[0-9]+$'`. Both patterns match one or more digits at the end of a string, but:
- `-oP` requires Perl regex support (not always available on all systems)
- `-oE` uses extended regular expressions, which is more universally supported across different Unix-like systems and grep implementations

This is a compatibility improvement that maintains the same functionality while increasing portability.

https://claude.ai/code/session_01Kd5FNqQiWaQ7go3D318Z26