### PR TITLE
Fix Rosetta 2 auto-update trap and optimize CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,12 @@ on:
 permissions:
   contents: write
 
+# Cancel in-progress runs when a new push arrives for the same branch/PR.
+# Tagged releases are never cancelled so release builds always complete.
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   build:
     env:
@@ -103,7 +109,15 @@ jobs:
           mkdir -p resources/keys
           echo "$MUSICKIT_PRIVATE_KEY" > resources/keys/AuthKey_437JVHZMMK.p8
 
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
       - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
       # Cache electron-builder binary downloads (NSIS, winCodeSign, electron zip)

--- a/main.js
+++ b/main.js
@@ -17,6 +17,22 @@ console.log('SPOTIFY_CLIENT_ID:', process.env.SPOTIFY_CLIENT_ID ? '✅ .env' : '
 console.log('MUSICKIT_DEVELOPER_TOKEN:', process.env.MUSICKIT_DEVELOPER_TOKEN ? '✅ .env' : '⚪ Will generate from .p8 key');
 console.log('=========================');
 
+// Fix Rosetta 2 auto-update trap: when an x64 Electron build runs on Apple
+// Silicon via Rosetta 2, process.arch reports 'x64', causing electron-updater
+// to fetch latest-mac.yml (Intel) instead of latest-mac-arm64.yml. Override
+// process.arch to the native hardware architecture so the next auto-update
+// downloads the correct Apple Silicon build, permanently breaking the cycle.
+if (process.platform === 'darwin' && process.arch === 'x64') {
+  try {
+    const nativeArch = require('child_process')
+      .execFileSync('uname', ['-m'], { encoding: 'utf-8' }).trim();
+    if (nativeArch === 'arm64') {
+      Object.defineProperty(process, 'arch', { value: 'arm64' });
+      console.log('Detected Apple Silicon — auto-updater will fetch arm64 updates');
+    }
+  } catch { /* ignore — worst case, updater uses x64 manifest */ }
+}
+
 const { app, BrowserWindow, ipcMain, globalShortcut, shell, protocol, Menu } = require('electron');
 const path = require('path');
 


### PR DESCRIPTION
## Summary
This PR addresses a critical issue where Electron builds running on Apple Silicon via Rosetta 2 get stuck in an update loop, plus optimizes CI/CD performance through build concurrency and dependency caching.

## Key Changes

- **Fix Rosetta 2 auto-update trap**: Added logic to detect when an x64 Electron build runs on Apple Silicon via Rosetta 2 and override `process.arch` to `arm64`. This ensures `electron-updater` fetches the correct ARM64 manifest (`latest-mac-arm64.yml`) instead of the Intel manifest, breaking the update cycle where users would repeatedly download the x64 build.

- **Optimize GitHub Actions workflow**:
  - Added concurrency configuration to cancel in-progress builds when new commits arrive on the same branch/PR, while preserving tagged release builds
  - Implemented `node_modules` caching using `package-lock.json` hash to skip redundant dependency installations
  - Made `npm ci` conditional, only running when cache miss occurs

## Implementation Details

The Rosetta 2 fix uses `uname -m` to detect native hardware architecture and safely handles any errors by falling back to the original behavior. The solution is non-invasive and logs when Apple Silicon is detected for transparency.

The CI optimizations reduce build times by avoiding redundant work while ensuring release builds always complete without interruption.

https://claude.ai/code/session_01QEexCdBf82zb2Q9tckBmsg