### PR TITLE
Add exponential backoff retry logic for Spotify API server errors

### DIFF
--- a/sync-providers/spotify.js
+++ b/sync-providers/spotify.js
@@ -46,6 +46,15 @@ const spotifyRequest = async (endpoint, token, options = {}, _retryCount = 0) =>
       await new Promise(resolve => setTimeout(resolve, retryAfter * 1000));
       return spotifyRequest(endpoint, token, options, _retryCount + 1);
     }
+    // Retry on transient server errors (502, 503, 504) with exponential backoff
+    if ([502, 503, 504].includes(response.status)) {
+      if (_retryCount >= MAX_RETRIES) {
+        throw new Error(`Spotify API error: ${response.status} ${response.statusText} (after ${MAX_RETRIES} retries)`);
+      }
+      const delay = Math.min(1000 * Math.pow(2, _retryCount), 30000);
+      await new Promise(resolve => setTimeout(resolve, delay));
+      return spotifyRequest(endpoint, token, options, _retryCount + 1);
+    }
     // Only refresh on 401 (expired token). 403 means insufficient scopes —
     // refreshing gives the same scopes, so retrying would be wasteful.
     if (response.status === 401 && refreshToken) {
@@ -97,6 +106,15 @@ const spotifyFetch = async (endpoint, token, allItems = [], onProgress, refreshT
       // Rate limited - get retry-after header
       const retryAfter = parseInt(response.headers.get('Retry-After') || '5', 10);
       await new Promise(resolve => setTimeout(resolve, retryAfter * 1000));
+      return spotifyFetch(endpoint, token, allItems, onProgress, refreshToken, _retryCount + 1);
+    }
+    // Retry on transient server errors (502, 503, 504) with exponential backoff
+    if ([502, 503, 504].includes(response.status)) {
+      if (_retryCount >= MAX_RETRIES) {
+        throw new Error(`Spotify API error: ${response.status} ${response.statusText} (after ${MAX_RETRIES} retries)`);
+      }
+      const delay = Math.min(1000 * Math.pow(2, _retryCount), 30000);
+      await new Promise(resolve => setTimeout(resolve, delay));
       return spotifyFetch(endpoint, token, allItems, onProgress, refreshToken, _retryCount + 1);
     }
     // Only refresh on 401 (expired token). 403 means insufficient scopes —


### PR DESCRIPTION
## Summary
Added resilience handling for transient Spotify API server errors (502, 503, 504) by implementing exponential backoff retry logic in both the `spotifyRequest` and `spotifyFetch` functions.

## Key Changes
- Added retry handling for HTTP 502 (Bad Gateway), 503 (Service Unavailable), and 504 (Gateway Timeout) errors in `spotifyRequest` function
- Added identical retry handling for the same server errors in `spotifyFetch` function
- Implemented exponential backoff strategy with a maximum delay cap of 30 seconds
- Respects the existing `MAX_RETRIES` limit and throws an error after exhausting retries
- Provides clear error messages indicating the HTTP status and number of retry attempts

## Implementation Details
- Retry delay formula: `Math.min(1000 * Math.pow(2, _retryCount), 30000)` creates exponential backoff (1s, 2s, 4s, 8s, etc.) capped at 30 seconds
- Maintains consistency with existing retry patterns for rate limiting (429 status code)
- Placed before token refresh logic to handle transient server issues without unnecessary token refresh attempts
- Applied to both request functions to ensure comprehensive coverage of Spotify API interactions

https://claude.ai/code/session_01YL66B4kdupHRRXJQUedUP4