### PR TITLE
Remove unsupported 'concerts' capability from all plugins

### DIFF
--- a/plugins/chatgpt.axe
+++ b/plugins/chatgpt.axe
@@ -12,8 +12,7 @@
   },
   "capabilities": {
     "generate": true,
-    "chat": true,
-    "concerts": true
+    "chat": true
   },
   "settings": {
     "requiresAuth": true,

--- a/plugins/claude.axe
+++ b/plugins/claude.axe
@@ -11,8 +11,7 @@
     "homepage": "https://anthropic.com"
   },
   "capabilities": {
-    "chat": true,
-    "concerts": true
+    "chat": true
   },
   "settings": {
     "requiresAuth": true,

--- a/plugins/gemini.axe
+++ b/plugins/gemini.axe
@@ -12,8 +12,7 @@
   },
   "capabilities": {
     "generate": true,
-    "chat": true,
-    "concerts": true
+    "chat": true
   },
   "settings": {
     "requiresAuth": true,

--- a/plugins/ollama.axe
+++ b/plugins/ollama.axe
@@ -11,8 +11,7 @@
     "homepage": "https://ollama.ai"
   },
   "capabilities": {
-    "chat": true,
-    "concerts": true
+    "chat": true
   },
   "settings": {
     "requiresAuth": false,


### PR DESCRIPTION
## Summary
Removed the `"concerts": true` capability declaration from all AI plugin configurations. This capability appears to have been incorrectly included and is not actually supported by any of the plugins.

## Changes
- **chatgpt.axe**: Removed `"concerts": true` from capabilities
- **claude.axe**: Removed `"concerts": true` from capabilities
- **gemini.axe**: Removed `"concerts": true` from capabilities
- **ollama.axe**: Removed `"concerts": true` from capabilities

All plugins now accurately declare only their supported capabilities (`generate` and/or `chat`).

## Details
This cleanup ensures that the plugin manifests accurately reflect the actual capabilities available to users, preventing confusion or failed feature requests related to concert-related functionality.

https://claude.ai/code/session_01NnYtZfvpyoKtBzzWqoS7Ns