### PR TITLE
Fix Fresh Drops never auto-refreshing stale cached releases

### DIFF
--- a/app.js
+++ b/app.js
@@ -18031,7 +18031,12 @@ ${trackListXml}
         // Populate state immediately so Fresh Drops preview shows on Home
         if (hydratedReleases.length > 0) {
           setNewReleases(hydratedReleases);
-          setNewReleasesLoaded(true);
+          // Only mark as fully loaded if the cache is fresh. For stale caches,
+          // leave newReleasesLoaded=false so the background useEffect triggers
+          // an automatic refresh while the user sees the stale data instantly.
+          if (now - newReleasesData.timestamp < CACHE_TTL.newReleases) {
+            setNewReleasesLoaded(true);
+          }
           // Update the cache ref too so it has the hydrated art
           newReleasesCache.current.releases = hydratedReleases;
         }


### PR DESCRIPTION
On cache restore at startup, setNewReleasesLoaded(true) was called for both fresh and stale caches. This prevented the background useEffect from triggering loadNewReleases(), since it requires !newReleasesLoaded. As a result, once releases were cached, the data would never refresh automatically — users had to manually hit the refresh button to see new releases.

Now stale caches still populate state immediately (so the user sees data instantly) but leave newReleasesLoaded=false, allowing the background effect to trigger a full refresh automatically.

https://claude.ai/code/session_01XRvbPZ74tHKnSLymKZgr67