### PR TITLE
Fix crash in fetchArtistData when cached artist name doesn't match

### DIFF
--- a/app.js
+++ b/app.js
@@ -19212,7 +19212,7 @@ ${trackListXml}
     setArtistImagePosition('center 25%');
     navigateTo('artist');
 
-    if (cachedData && cachedData.resolverHash !== currentResolverHash) {
+    if (cachedData && cachedData.resolverHash !== getResolverSettingsHash()) {
       console.log('🔄 Resolver settings changed, invalidating cache for:', artistName);
     }
 


### PR DESCRIPTION
The cache name-match validation exposed a latent bug: when cachedData existed but was rejected (name mismatch), the code fell through to reference `currentResolverHash` which was never declared in fetchArtistData's scope, causing an uncaught ReferenceError. Replaced with direct call to getResolverSettingsHash().

This was the cause of the "Jack Jose" crash — a different artist was cached under that key, the new name validation correctly rejected it, but the code then hit the undeclared variable.

https://claude.ai/code/session_01Jg9rGAbA4k6BW7Jtc5nn2y