### PR TITLE
Fix view navigation and history restoration after app relaunch

### DIFF
--- a/app.js
+++ b/app.js
@@ -30014,8 +30014,8 @@ Variety guidance: ${theme} Be creative and surprising — avoid defaulting to th
       // required data (e.g. after an app relaunch where only the last page
       // was fully restored), fall back to a safe parent view.
       if (previousView === 'artist' && !currentArtist) {
-        previousView = 'library';
-        newHistory[newHistory.length - 1] = 'library';
+        previousView = 'home';
+        newHistory[newHistory.length - 1] = 'home';
       } else if (previousView === 'playlist-view' && !selectedPlaylist) {
         previousView = 'playlists';
         newHistory[newHistory.length - 1] = 'playlists';


### PR DESCRIPTION
## Summary
This PR fixes navigation issues that occur when users navigate back to previous views after an app relaunch, particularly when the previous view requires specific data context (like an artist or playlist) that wasn't fully restored.

## Key Changes
- **Initialize view history on library view restoration**: When restoring the library view after app relaunch, explicitly initialize the view history stack to prevent navigation issues.
- **Add safety guards for data-dependent views**: Implemented fallback logic in the back navigation handler to detect when a previous view requires data that isn't available (e.g., `currentArtist` for artist view) and automatically fall back to a safe parent view instead of navigating to a broken state.
- **Handle corrupted history stack**: Added protection against empty or corrupted view history by resetting to the home view.

## Implementation Details
The back navigation now checks if the previous view in the history stack has its required data available:
- `artist` view requires `currentArtist` → falls back to `home`
- `playlist-view` requires `selectedPlaylist` → falls back to `playlists`
- `friendHistory` view requires `currentFriend` → falls back to `friends`
- If the history stack is empty or corrupted, it resets to `home`

This prevents the app from navigating to views with missing context after an app relaunch where only the last viewed page was restored.

https://claude.ai/code/session_012AT71MBs7UTHzi5GaSCV9L