### PR TITLE
Fix sync workflow to include dotfiles like .eslintrc.json

### DIFF
--- a/.github/workflows/sync-repos.yml
+++ b/.github/workflows/sync-repos.yml
@@ -84,7 +84,8 @@ jobs:
           cd target-repo
           find . -mindepth 1 -maxdepth 1 ! -name '.git' ! -name '.github' -exec rm -rf {} +
 
-          # Copy extension files to target
+          # Copy extension files to target (including dotfiles like .eslintrc.json)
+          shopt -s dotglob
           cp -r ../parachord-extension/* .
 
           # Check if there are changes to commit
@@ -159,7 +160,8 @@ jobs:
           cd target-repo
           find . -mindepth 1 -maxdepth 1 ! -name '.git' ! -name '.github' -exec rm -rf {} +
 
-          # Copy Raycast extension files to target
+          # Copy Raycast extension files to target (including dotfiles like .eslintrc.json)
+          shopt -s dotglob
           cp -r ../raycast-extension/* .
 
           # Check if there are changes to commit


### PR DESCRIPTION
The cp -r glob * doesn't match dotfiles by default, so files like .eslintrc.json were never synced to dedicated repos. Enable dotglob before copying for both browser and Raycast extension syncs.

https://claude.ai/code/session_01AoGC3Bi3TgBoLyfGK3EPuh