### PR TITLE
Add Ticketmaster concert service integration

### DIFF
--- a/app.js
+++ b/app.js
@@ -44319,7 +44319,7 @@ useEffect(() => {
               }, 'No Concert Services Configured'),
               React.createElement('p', {
                 className: 'text-sm text-gray-500 text-center max-w-md mb-4'
-              }, 'Enable a concert service plugin (Bandsintown, Songkick, or SeatGeek) in Settings to see upcoming shows for artists you love.'),
+              }, 'Enable a concert service plugin (Bandsintown, Songkick, SeatGeek, or Ticketmaster) in Settings to see upcoming shows for artists you love.'),
               React.createElement('button', {
                 onClick: () => { navigateTo('settings'); },
                 className: 'px-4 py-2 bg-teal-500 text-white rounded-lg text-sm hover:bg-teal-600 transition-colors'

--- a/marketplace-manifest.json
+++ b/marketplace-manifest.json
@@ -461,6 +461,30 @@
         "events",
         "festivals"
       ]
+    },
+    {
+      "id": "ticketmaster",
+      "name": "Ticketmaster",
+      "type": "meta-service",
+      "version": "1.0.0",
+      "author": "Parachord Team",
+      "description": "Find concerts and live events via the Ticketmaster Discovery API.",
+      "icon": "🎟️",
+      "color": "#026CDF",
+      "homepage": "https://www.ticketmaster.com",
+      "capabilities": {
+        "concerts": true
+      },
+      "requiresAuth": true,
+      "downloadUrl": "https://raw.githubusercontent.com/Parachord/parachord-plugins/main/ticketmaster.axe",
+      "category": "concerts",
+      "tags": [
+        "concerts",
+        "tickets",
+        "live-music",
+        "events",
+        "tours"
+      ]
     }
   ],
   "categories": [


### PR DESCRIPTION
## Summary
This PR adds Ticketmaster as a new concert service plugin to the marketplace, enabling users to discover concerts and live events through the Ticketmaster Discovery API.

## Key Changes
- **Marketplace Manifest**: Added Ticketmaster service entry with complete metadata including:
  - Service configuration (id, name, version, author)
  - API integration details (requires authentication, download URL)
  - Categorization (concerts category with relevant tags: concerts, tickets, live-music, events, tours)
  - Visual branding (Ticketmaster blue color #026CDF and ticket emoji icon)
  
- **User-Facing Documentation**: Updated the concert services configuration prompt in app.js to include Ticketmaster alongside existing services (Bandsintown, Songkick, and SeatGeek)

## Implementation Details
- Ticketmaster is configured as a "meta-service" type with version 1.0.0
- Authentication is required to use the service
- The plugin is hosted on the Parachord plugins repository
- Service is properly tagged for discoverability with concert-related keywords

https://claude.ai/code/session_01CwTUzrLxYXm6MxvAkfLWc3