### PR TITLE
Fix protocol volume handler using wrong scale (0-1 instead of 0-100)

### DIFF
--- a/app.js
+++ b/app.js
@@ -9272,7 +9272,7 @@ const Parachord = () => {
           case 'volume': {
             const vol = parseInt(segments[0], 10);
             if (!isNaN(vol) && vol >= 0 && vol <= 100) {
-              setVolume(vol / 100);
+              setVolume(vol);
             }
             break;
           }


### PR DESCRIPTION
The volume state uses a 0-100 scale but the protocol handler was dividing by 100, so setting volume to 20% resulted in 0.2 (effectively 0%).

https://claude.ai/code/session_01AoGC3Bi3TgBoLyfGK3EPuh