### PR TITLE
Fix auto-update on Apple Silicon by preserving arm64 in filenames

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,42 +163,28 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: node scripts/notarize-artifacts.js
 
-      - name: Rename Mac artifacts with friendly arch labels
+      # Rename Mac DMGs with friendly arch labels for human-facing download links.
+      # IMPORTANT: Only rename the DMG (the manual download artifact). Do NOT
+      # rename the .zip or .blockmap files, and do NOT touch the YAML manifests —
+      # electron-updater identifies arm64 builds by checking for "arm64" in the
+      # filename/URL, so renaming those breaks auto-update on Apple Silicon.
+      - name: Rename Mac DMG with friendly arch label
         if: matrix.platform == 'mac'
         shell: bash
         run: |
           cd dist
           label="${{ matrix.arch_label }}"
-          # Rename binary artifacts only (not the YAML manifests electron-updater needs)
-          for f in *.dmg *.zip *.blockmap; do
+          for f in *.dmg; do
             [ -e "$f" ] || continue
-            newname="$f"
             if [ "${{ matrix.arch }}" = "arm64" ]; then
-              newname=$(echo "$f" | sed "s/-arm64/-${label}/g")
+              newname=$(echo "$f" | sed "s/-arm64/-arm64-${label}/")
             elif [ "${{ matrix.arch }}" = "x64" ]; then
-              newname=$(echo "$f" | sed \
-                "s/\.dmg\.blockmap$/-${label}.dmg.blockmap/
-                 s/\.dmg$/-${label}.dmg/
-                 s/-mac\.zip$/-${label}-mac.zip/")
+              newname=$(echo "$f" | sed "s/\.dmg$/-${label}.dmg/")
             fi
-            if [ "$f" != "$newname" ]; then
+            if [ -n "$newname" ] && [ "$f" != "$newname" ]; then
               mv "$f" "$newname"
               echo "Renamed $f -> $newname"
             fi
-          done
-          # Update filenames inside the YAML manifests so electron-updater
-          # downloads the renamed artifacts instead of 404ing.
-          for yml in latest-mac*.yml; do
-            [ -e "$yml" ] || continue
-            if [ "${{ matrix.arch }}" = "arm64" ]; then
-              sed -i '' "s/-arm64/-${label}/g" "$yml"
-            elif [ "${{ matrix.arch }}" = "x64" ]; then
-              sed -i '' \
-                -e "s/\.dmg\.blockmap/-${label}.dmg.blockmap/g" \
-                -e "s/\.dmg/-${label}.dmg/g" \
-                -e "s/-mac\.zip/-${label}-mac.zip/g" "$yml"
-            fi
-            echo "Updated references in $yml"
           done
 
       - name: Upload artifacts

--- a/main.js
+++ b/main.js
@@ -17,21 +17,6 @@ console.log('SPOTIFY_CLIENT_ID:', process.env.SPOTIFY_CLIENT_ID ? '✅ .env' : '
 console.log('MUSICKIT_DEVELOPER_TOKEN:', process.env.MUSICKIT_DEVELOPER_TOKEN ? '✅ .env' : '⚪ Will generate from .p8 key');
 console.log('=========================');
 
-// Fix Rosetta 2 auto-update trap: when an x64 Electron build runs on Apple
-// Silicon via Rosetta 2, process.arch reports 'x64', causing electron-updater
-// to fetch latest-mac.yml (Intel) instead of latest-mac-arm64.yml. Override
-// process.arch to the native hardware architecture so the next auto-update
-// downloads the correct Apple Silicon build, permanently breaking the cycle.
-if (process.platform === 'darwin' && process.arch === 'x64') {
-  try {
-    const nativeArch = require('child_process')
-      .execFileSync('uname', ['-m'], { encoding: 'utf-8' }).trim();
-    if (nativeArch === 'arm64') {
-      Object.defineProperty(process, 'arch', { value: 'arm64' });
-      console.log('Detected Apple Silicon — auto-updater will fetch arm64 updates');
-    }
-  } catch { /* ignore — worst case, updater uses x64 manifest */ }
-}
 
 const { app, BrowserWindow, ipcMain, globalShortcut, shell, protocol, Menu, nativeTheme } = require('electron');
 const path = require('path');


### PR DESCRIPTION
## Summary
This PR fixes the auto-update mechanism for Apple Silicon Macs by ensuring that the `arm64` identifier is preserved in build artifact filenames, allowing electron-updater to correctly identify and download arm64 builds.

## Key Changes

- **Simplified DMG renaming logic** in the build workflow to only rename `.dmg` files (not `.zip` or `.blockmap` files) and preserve the `arm64` identifier in filenames for arm64 builds
- **Removed YAML manifest rewriting** that was previously updating filenames inside `latest-mac*.yml` files, since electron-updater uses the original filenames to identify architecture
- **Removed the Rosetta 2 workaround** from `main.js` that was attempting to override `process.arch` at runtime, as it's no longer needed with the corrected filename strategy

## Implementation Details

The core issue was that electron-updater identifies arm64 builds by checking for "arm64" in the filename/URL. The previous approach of:
1. Renaming all artifacts (including `.zip` and `.blockmap`)
2. Updating YAML manifests with the new names

...broke auto-updates because the manifest references no longer matched what electron-updater expected.

The new approach:
- Only renames the DMG file (the manual download artifact) with a friendly label
- For arm64: appends the label after `arm64` (e.g., `app-arm64-apple-silicon.dmg`)
- For x64: replaces the extension with the label (e.g., `app-intel.dmg`)
- Leaves `.zip`, `.blockmap`, and YAML manifests untouched so electron-updater can find them by their original names

This allows both human-friendly download links and correct auto-update behavior on Apple Silicon.

https://claude.ai/code/session_01JGinUKagcjkx3F7LcE1RPH