### PR TITLE
Bump GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,10 +48,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -111,7 +111,7 @@ jobs:
 
       - name: Cache node_modules
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -123,7 +123,7 @@ jobs:
       # Cache electron-builder binary downloads (NSIS, winCodeSign, electron zip)
       # to avoid transient GitHub download failures during the build step.
       - name: Cache electron-builder binaries
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~\AppData\Local\electron-builder\Cache
@@ -191,14 +191,14 @@ jobs:
       # overwrite each other when downloaded with merge-multiple.
       - name: Upload YAML manifest
         if: hashFiles('dist/*.yml') != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: manifest-${{ matrix.platform }}-${{ matrix.arch }}
           path: dist/*.yml
           retention-days: 30
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: parachord-${{ matrix.platform }}-${{ matrix.arch }}-v${{ steps.pkg.outputs.version }}
           path: |
@@ -219,7 +219,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: parachord-*
           path: artifacts
@@ -228,7 +228,7 @@ jobs:
       # Download all YAML manifests into separate subdirectories so
       # per-arch files with the same name don't overwrite each other.
       - name: Download manifests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: manifest-*
           path: manifests
@@ -267,7 +267,7 @@ jobs:
           fi
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: artifacts/*
           draft: false

--- a/.github/workflows/deploy-smart-links.yml
+++ b/.github/workflows/deploy-smart-links.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 

--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -30,10 +30,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -49,7 +49,7 @@ jobs:
         run: npm run package:extension
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: extension-v${{ steps.ext.outputs.version }}
           path: dist/parachord-extension-*.zip

--- a/.github/workflows/reverse-sync.yml
+++ b/.github/workflows/reverse-sync.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout monorepo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Clone browser extension repo
         env:
@@ -110,7 +110,7 @@ jobs:
 
     steps:
       - name: Checkout monorepo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Clone Raycast extension repo
         env:
@@ -183,10 +183,10 @@ jobs:
 
     steps:
       - name: Checkout monorepo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 

--- a/.github/workflows/sync-repos.yml
+++ b/.github/workflows/sync-repos.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout main repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -111,7 +111,7 @@ jobs:
 
     steps:
       - name: Checkout main repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -187,7 +187,7 @@ jobs:
 
     steps:
       - name: Checkout main repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
- actions/checkout v4 → v6
- actions/setup-node v4 → v6
- actions/cache v4 → v5
- actions/upload-artifact v4 → v7
- actions/download-artifact v4 → v8
- softprops/action-gh-release v1 → v2

Node.js 20 actions will be forced to Node.js 24 starting June 2, 2026.

https://claude.ai/code/session_01JGinUKagcjkx3F7LcE1RPH