### PR TITLE
Always forward auto-updater errors to renderer

### DIFF
--- a/main.js
+++ b/main.js
@@ -1812,14 +1812,15 @@ app.whenReady().then(() => {
 
     autoUpdater.on('error', (err) => {
       console.error('❌ Auto-updater error:', err.message);
-      // Only forward to renderer if the user initiated the check
+      // Always forward errors to the renderer so download/install failures
+      // are visible. Only suppress the generic startup check errors.
       if (userInitiatedUpdateCheck) {
         userInitiatedUpdateCheck = false;
-        safeSendToRenderer('updater-status', {
-          status: 'error',
-          error: 'Could not check for updates. Please try again later.'
-        });
       }
+      safeSendToRenderer('updater-status', {
+        status: 'error',
+        error: err.message || 'An update error occurred.'
+      });
     });
 
     // Check for updates after a short delay (don't block startup)


### PR DESCRIPTION
The error handler only sent errors to the renderer when userInitiatedUpdateCheck was true. But download/install errors happen after that flag is already reset to false (in the update-available handler), so they were silently swallowed — the user clicked "Download" and nothing happened with no feedback.

Now all auto-updater errors are forwarded to the renderer, showing the actual error message (404, network, SHA mismatch, etc.) via toast so the user knows what went wrong.

https://claude.ai/code/session_01FvmjowGTpfbqmnANNcqY18