### PR TITLE
Fix auto-advance on track end and refresh MusicKit auth status

### DIFF
--- a/app.js
+++ b/app.js
@@ -9891,6 +9891,33 @@ ${trackListXml}
     };
   }, []);
 
+  // Listen for MusicKit JS track-ended and Apple Music preview-ended events
+  // to advance to the next track in the queue automatically
+  useEffect(() => {
+    const handleMusicKitTrackEnded = () => {
+      const track = currentTrackRef.current;
+      if (track?._activeResolver === 'applemusic') {
+        console.log('[MusicKit] Track ended, advancing to next');
+        if (handleNextRef.current) handleNextRef.current();
+      }
+    };
+
+    const handlePreviewEnded = () => {
+      const track = currentTrackRef.current;
+      if (track?._activeResolver === 'applemusic') {
+        console.log('[AppleMusic] Preview ended, advancing to next');
+        if (handleNextRef.current) handleNextRef.current();
+      }
+    };
+
+    window.addEventListener('musickit-track-ended', handleMusicKitTrackEnded);
+    window.addEventListener('applemusic-preview-ended', handlePreviewEnded);
+    return () => {
+      window.removeEventListener('musickit-track-ended', handleMusicKitTrackEnded);
+      window.removeEventListener('applemusic-preview-ended', handlePreviewEnded);
+    };
+  }, []);
+
   // Apple Music preview audio progress tracking
   // The preview audio element (window._appleMusicPreviewAudio) is created lazily in the
   // resolver's play method, separate from audioRef.current, so it needs its own timeupdate listener.

--- a/musickit-web.js
+++ b/musickit-web.js
@@ -196,6 +196,12 @@ class MusicKitWeb {
    * Check authorization status
    */
   getAuthStatus() {
+    // Query live MusicKit authorization state instead of relying on cached
+    // this.isAuthorized, which can become stale if the user's session expires
+    // or authorization is revoked externally (e.g. via System Settings).
+    if (this.musicKit) {
+      this.isAuthorized = this.musicKit.isAuthorized;
+    }
     return {
       configured: this.isConfigured,
       authorized: this.isAuthorized,


### PR DESCRIPTION
## Summary
This PR fixes two issues with Apple Music integration: automatic queue advancement when tracks end, and stale authorization status checks.

## Key Changes
- **Auto-advance on track end**: Added event listeners for `musickit-track-ended` and `applemusic-preview-ended` events that automatically advance to the next track in the queue when an Apple Music track finishes playing
- **Refresh MusicKit auth status**: Modified `getAuthStatus()` to query the live MusicKit authorization state instead of relying on potentially stale cached values, ensuring the authorization status reflects current session state

## Implementation Details
- The new `useEffect` hook in `app.js` listens for both MusicKit and Apple Music preview end events, checking that the current track is using the Apple Music resolver before advancing
- The auth status refresh in `musickit-web.js` queries `this.musicKit.isAuthorized` directly when available, preventing issues where cached authorization becomes invalid due to session expiration or external revocation (e.g., via System Settings)
- Both changes include proper cleanup (event listener removal) and logging for debugging

https://claude.ai/code/session_01E1u3eALJMBquLgdr1M2hEk