### PR TITLE
Fix crash when sync skips data types: null check on results

### DIFF
--- a/main.js
+++ b/main.js
@@ -5235,7 +5235,7 @@ ipcMain.handle('sync:start', async (event, providerId, options = {}) => {
     // everything is unchanged, skip the expensive IPC serialisation of
     // the entire collection — the data is already saved to disk above.
     const hasChanges = Object.values(results).some(r =>
-      (r.added || 0) > 0 || (r.removed || 0) > 0 || (r.updated || 0) > 0
+      r && ((r.added || 0) > 0 || (r.removed || 0) > 0 || (r.updated || 0) > 0)
     );
 
     return { success: true, results, collection: hasChanges ? collection : null };


### PR DESCRIPTION
When a sync type is skipped (e.g., provider doesn't support it or user disabled it), its entry in the results object stays null. The hasChanges check iterated Object.values(results) and accessed .added on null entries, causing "Cannot read properties of null (reading 'added')".

https://claude.ai/code/session_01FXaUE1r4XpU7w1CDeLgodd