### PR TITLE
Fix collection artist card height issue

### DIFF
--- a/app.js
+++ b/app.js
@@ -42091,7 +42091,7 @@ useEffect(() => {
 
               return React.createElement('div', {
                 className: 'grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-x-4 gap-y-5',
-                style: { minHeight: 'calc(100vh - 160px)' }  // Ensure enough scroll area to prevent header bounce
+                style: { minHeight: 'calc(100vh - 160px)', alignContent: 'start' }  // Ensure enough scroll area to prevent header bounce
               },
                 sorted.map((artist, index) =>
                   React.createElement(CollectionArtistCard, {


### PR DESCRIPTION
## Changes
- added alignContent: 'start' to pack the grid cards to the top
### Before
<img width="514" height="601" alt="Screenshot 2026-03-21 at 3 00 01 PM" src="https://github.com/user-attachments/assets/38e469bd-8736-4543-967d-4be9eeb5d61e" />

### After
<img width="392" height="537" alt="Screenshot 2026-03-21 at 3 12 26 PM" src="https://github.com/user-attachments/assets/18bc5ea0-b8d0-430b-a616-96a1c8f36e52" />
