### PR TITLE
Fix Apple Music playlist deletion: use DELETE endpoint with token ref…

### DIFF
--- a/main.js
+++ b/main.js
@@ -4583,7 +4583,29 @@ ipcMain.handle('playlists-delete-from-source', async (event, providerId, externa
       return { success: false, error: 'Not authenticated with provider' };
     }
 
-    await provider.deletePlaylist(externalId, token);
+    // Provide a token refresh callback for Apple Music 401 recovery
+    let refreshTokenCb = null;
+    if (providerId === 'applemusic') {
+      refreshTokenCb = async () => {
+        try {
+          const bridge = getMusicKitBridge();
+          const freshDevToken = generatedMusicKitToken || process.env.MUSICKIT_DEVELOPER_TOKEN || store.get('applemusic_developer_token');
+          if (!freshDevToken) return null;
+          const result = await bridge.fetchUserToken(freshDevToken);
+          if (result && result.userToken) {
+            store.set('applemusic_user_token', result.userToken);
+            const newToken = JSON.stringify({ developerToken: freshDevToken, userToken: result.userToken });
+            token = newToken;
+            return newToken;
+          }
+        } catch (err) {
+          console.warn('[AppleMusic] Failed to refresh user token:', err.message);
+        }
+        return null;
+      };
+    }
+
+    await provider.deletePlaylist(externalId, token, refreshTokenCb);
     console.log('  ✅ Deleted playlist from source');
     return { success: true };
   } catch (error) {
@@ -5647,6 +5669,26 @@ ipcMain.handle('sync:push-playlist', async (event, providerId, playlistExternalI
       if (developerToken && userToken) {
         token = JSON.stringify({ developerToken, userToken });
       }
+      // Apple Music token refresh: try to fetch a fresh user token via the
+      // native MusicKit bridge when a 401 occurs (expired user token).
+      refreshTokenCb = async () => {
+        try {
+          const bridge = getMusicKitBridge();
+          const freshDevToken = generatedMusicKitToken || process.env.MUSICKIT_DEVELOPER_TOKEN || store.get('applemusic_developer_token');
+          if (!freshDevToken) return null;
+          const result = await bridge.fetchUserToken(freshDevToken);
+          if (result && result.userToken) {
+            store.set('applemusic_user_token', result.userToken);
+            const newToken = JSON.stringify({ developerToken: freshDevToken, userToken: result.userToken });
+            token = newToken;
+            console.log('[AppleMusic] Refreshed user token successfully');
+            return newToken;
+          }
+        } catch (err) {
+          console.warn('[AppleMusic] Failed to refresh user token:', err.message);
+        }
+        return null;
+      };
     }
 
     if (!token) {
@@ -5695,9 +5737,9 @@ ipcMain.handle('sync:push-playlist', async (event, providerId, playlistExternalI
 
         for (const dup of toDelete) {
           try {
-            await provider.deletePlaylist(dup.externalId, token);
+            await provider.deletePlaylist(dup.externalId, token, refreshTokenCb);
             totalDeleted++;
-            console.log(`[Sync Cleanup] Cleared duplicate "${dup.name}" (${dup.externalId}, ${dup.trackCount || 0} tracks) — keeping ${keeper.externalId} (${keeper.trackCount || 0} tracks)`);
+            console.log(`[Sync Cleanup] Deleted duplicate "${dup.name}" (${dup.externalId}, ${dup.trackCount || 0} tracks) — keeping ${keeper.externalId} (${keeper.trackCount || 0} tracks)`);
             // Rate limit delay between deletions
             if (provider.getRateLimitDelay) {
               await new Promise(r => setTimeout(r, provider.getRateLimitDelay()));

--- a/sync-providers/applemusic.js
+++ b/sync-providers/applemusic.js
@@ -330,29 +330,76 @@ const AppleMusicSyncProvider = {
    * Delete a playlist from the user's Apple Music library
    * @param {string} playlistId - Apple Music library playlist ID
    * @param {string} token - JSON string with developerToken and userToken
+   * @param {function} [refreshTokenCb] - Optional async callback to refresh token on 401
    * @returns {Object} - { success: boolean }
    */
-  async deletePlaylist(playlistId, token) {
-    // Apple Music API does not support DELETE for library playlists.
-    // Instead, clear the playlist's tracks so it becomes an empty shell,
-    // and rename it to signal it's a leftover duplicate.
-    try {
-      await this.updatePlaylistTracks(playlistId, [], token);
-    } catch (err) {
-      // If clearing tracks fails, still try renaming
-      console.warn(`[AppleMusic] Failed to clear tracks for playlist ${playlistId}:`, err.message);
+  async deletePlaylist(playlistId, token, refreshTokenCb) {
+    // Try the actual DELETE endpoint first (Apple Music API supports it for
+    // library playlists). Fall back to clear+rename if DELETE is not supported.
+    const attemptDelete = async (currentToken) => {
+      const { developerToken, userToken } = JSON.parse(currentToken);
+      const resp = await fetch(
+        `${APPLE_MUSIC_API_BASE}/me/library/playlists/${playlistId}`,
+        {
+          method: 'DELETE',
+          headers: {
+            'Authorization': `Bearer ${developerToken}`,
+            'Music-User-Token': userToken
+          }
+        }
+      );
+      return resp;
+    };
+
+    // First attempt with current token
+    let resp = await attemptDelete(token);
+
+    // On 401, try refreshing the token and retry once
+    if ((resp.status === 401 || resp.status === 403) && refreshTokenCb) {
+      console.log(`[AppleMusic] Got ${resp.status} on DELETE, attempting token refresh...`);
+      const newToken = await refreshTokenCb();
+      if (newToken) {
+        token = newToken;
+        resp = await attemptDelete(token);
+      }
     }
 
-    try {
-      await this.updatePlaylistDetails(playlistId, {
-        name: `[Deleted] ${playlistId}`,
-        description: 'Duplicate cleared by Parachord sync cleanup'
-      }, token);
-    } catch (err) {
-      console.warn(`[AppleMusic] Failed to rename deleted playlist ${playlistId}:`, err.message);
+    if (resp.ok || resp.status === 204 || resp.status === 202) {
+      return { success: true };
     }
 
-    return { success: true };
+    // DELETE not supported (405) or other non-auth error — fall back to clear + rename
+    if (resp.status === 405 || resp.status === 404) {
+      console.log(`[AppleMusic] DELETE returned ${resp.status}, falling back to clear+rename for ${playlistId}`);
+      let cleared = false;
+      let renamed = false;
+      try {
+        await this.updatePlaylistTracks(playlistId, [], token);
+        cleared = true;
+      } catch (err) {
+        console.warn(`[AppleMusic] Failed to clear tracks for playlist ${playlistId}:`, err.message);
+      }
+      try {
+        await this.updatePlaylistDetails(playlistId, {
+          name: `[Deleted] ${playlistId}`,
+          description: 'Duplicate cleared by Parachord sync cleanup'
+        }, token);
+        renamed = true;
+      } catch (err) {
+        console.warn(`[AppleMusic] Failed to rename deleted playlist ${playlistId}:`, err.message);
+      }
+      if (!cleared && !renamed) {
+        throw new Error(`Failed to delete Apple Music playlist ${playlistId}: both clear and rename failed`);
+      }
+      return { success: true };
+    }
+
+    // Auth failure even after refresh
+    if (resp.status === 401 || resp.status === 403) {
+      throw new Error(`Apple Music authorization failed (${resp.status}). Please reconnect your Apple Music account.`);
+    }
+
+    throw new Error(`Failed to delete Apple Music playlist ${playlistId}: ${resp.status}`);
   },
 
   /**
@@ -555,8 +602,6 @@ const AppleMusicSyncProvider = {
   // Create a new playlist on Apple Music, or adopt an existing one with the same name
   async createPlaylist(name, description, token) {
     // Check for an existing playlist with the same name to avoid duplicates.
-    // Apple Music API does not support DELETE, so preventing duplicates at
-    // creation time is critical.
     try {
       const existing = await this.findPlaylistByName(name, token);
       if (existing) {


### PR DESCRIPTION
…resh

The duplicate playlist cleanup was silently failing with 401 errors because:
1. deletePlaylist used PUT/PATCH workaround instead of the actual DELETE endpoint
2. No token refresh mechanism existed for Apple Music (unlike Spotify)
3. Errors were swallowed, reporting success when operations actually failed

Now deletePlaylist tries DELETE /v1/me/library/playlists/{id} first, refreshes the user token via MusicKit bridge on 401, and properly propagates failures.

https://claude.ai/code/session_018BtYFNfapfCwXPMSWtXgDd