### PR TITLE
Fix Apple Music playlist track insertion by using POST for /me/library/playlists/{id}/tracks

### DIFF
--- a/sync-providers/applemusic.js
+++ b/sync-providers/applemusic.js
@@ -660,7 +660,7 @@ const AppleMusicSyncProvider = {
     const resp = await fetch(
       `${APPLE_MUSIC_API_BASE}/me/library/playlists/${playlistId}/tracks`,
       {
-        method: 'PUT',
+        method: 'POST',
         headers: {
           'Authorization': `Bearer ${developerToken}`,
           'Music-User-Token': userToken,


### PR DESCRIPTION
## Summary

This PR fixes Apple Music playlist sync creating an empty playlist after successful playlist creation.

The current Apple Music sync flow successfully creates the destination playlist, but can then fail while adding tracks to it. In my local repro, Parachord resolved the tracks, created the playlist on Apple Music, and then failed on the track insertion step with:

`Failed to update Apple Music playlist tracks: 401`

The current implementation uses `PUT` for:

`/v1/me/library/playlists/{playlistId}/tracks`

This PR changes that request to `POST`, which matches Apple Music API documentation for adding tracks to a library playlist.

## Changes

- change `updatePlaylistTracks(...)` in `sync-providers/applemusic.js` from `PUT` to `POST`

## Repro

1. Create a playlist in Parachord with 1–2 tracks already resolved to Apple Music
2. Sync the playlist to Apple Music
3. Observe:
   - playlist is created successfully
   - tracks are not added
   - log shows track insertion failure

Example log from local repro:

```text
[Sync] Resolved 2/2 tracks for applemusic (0 unresolved)
[Sync] Created playlist "new2" on applemusic: p.GE5rp8DTYkZdO5
[Sync] Playlist "new2" created on applemusic but failed to add tracks: Failed to update Apple Music playlist tracks: 401
```

## Reference

Apple Developer Documentation:
- [Add Tracks to a Library Playlist](https://developer.apple.com/documentation/applemusicapi/add-tracks-to-a-library-playlist)

Documented endpoint:
- `POST /v1/me/library/playlists/{id}/tracks`