### PR TITLE
feat(mcp): add seek and get_position tools

### DIFF
--- a/app.js
+++ b/app.js
@@ -10934,7 +10934,79 @@ const Parachord = () => {
           getCurrentTrack: () => currentTrackRef.current,
           getQueue: () => currentQueueRef.current || [],
           getIsPlaying: () => isPlayingRef.current,
-          blockRecommendation: () => {}
+          blockRecommendation: () => {},
+          // Seek the active playback engine to a position (ms within the track).
+          // Mirrors the playbar slider's onChange — only the same engines that
+          // support seek there support it here. Spotify (Web SDK + Connect) is
+          // not currently seekable; returns {supported:false} to let callers
+          // (e.g. external sync clients) degrade gracefully.
+          handleSeek: async (offsetMs) => {
+            const track = currentTrackRef.current;
+            if (!track) return { success: false, supported: false, error: 'no track' };
+            const activeResolver = track._activeResolver || determineResolverIdFromTrack(track);
+            if (activeResolver === 'spotify') {
+              return { success: false, supported: false, error: 'spotify seek not supported' };
+            }
+            const positionSec = Math.max(0, Number(offsetMs) / 1000);
+            let touched = false;
+            if (audioRef.current && (track?.sources?.localfiles || track?.sources?.soundcloud || track?.sources?.youtube || track?.sources?.bandcamp || activeResolver === 'soundcloud' || activeResolver === 'youtube' || activeResolver === 'bandcamp' || activeResolver === 'localfiles')) {
+              audioRef.current.currentTime = positionSec;
+              touched = true;
+            }
+            if (activeResolver === 'applemusic') {
+              if (window._appleMusicPreviewAudio && !window._appleMusicPreviewAudio.paused) {
+                window._appleMusicPreviewAudio.currentTime = positionSec;
+                touched = true;
+              }
+              try {
+                appleMusicProgressBaselineRef.current = { progress: positionSec, timestamp: Date.now(), isPlaying: true };
+              } catch {}
+              if (window.electron?.musicKit?.seek) {
+                try { await window.electron.musicKit.seek(positionSec); touched = true; } catch {}
+              }
+              if (window.getMusicKitWeb) {
+                try {
+                  const mk = window.getMusicKitWeb();
+                  if (mk?.seek) { await mk.seek(positionSec); touched = true; }
+                } catch {}
+              }
+            }
+            if (!touched) return { success: false, supported: false, error: 'no seekable engine for active resolver' };
+            return { success: true, supported: true, position_ms: Math.round(positionSec * 1000) };
+          },
+          // Read current playback offset + duration in ms. Tries HTML5 audio
+          // first; falls back to the Apple Music interpolated baseline; finally
+          // the track's reported duration. Returns supported:false for
+          // playback paths that don't expose a position (Spotify Connect).
+          getCurrentPosition: () => {
+            const track = currentTrackRef.current;
+            const audio = audioRef.current;
+            const audioPositionSec = audio?.currentTime;
+            const audioDurationSec = audio?.duration;
+            if (typeof audioPositionSec === 'number' && audioPositionSec > 0) {
+              return {
+                position_ms: Math.round(audioPositionSec * 1000),
+                duration_ms: Math.round(((audioDurationSec || track?.duration || 0) * 1000)),
+                supported: true
+              };
+            }
+            try {
+              const b = appleMusicProgressBaselineRef.current;
+              if (b && b.timestamp) {
+                const elapsedSec = b.isPlaying ? b.progress + (Date.now() - b.timestamp) / 1000 : b.progress;
+                return {
+                  position_ms: Math.round(Math.max(0, elapsedSec) * 1000),
+                  duration_ms: Math.round((track?.duration || 0) * 1000),
+                  supported: true
+                };
+              }
+            } catch {}
+            return {
+              position_ms: 0,
+              duration_ms: Math.round((track?.duration || 0) * 1000),
+              supported: false
+            };
+          }
         };
         const result = await executeDjTool(toolName, args, context);
         window.electron.mcp.respond(requestId, result);

--- a/tests/chat/dj-tools.test.js
+++ b/tests/chat/dj-tools.test.js
@@ -3,7 +3,16 @@
  *
  * Tests for executeDjTool - the function that executes playback actions
  * on behalf of AI chat providers (play, search, queue, shuffle, etc.)
+ *
+ * Two test styles live in this file:
+ *   1. The original style (further down) reimplements `executeDjTool` inline
+ *      to test the playback logic without pulling in app.js's React deps.
+ *   2. The `seek` / `get_position` / `registry` blocks at the bottom import
+ *      directly from `tools/dj-tools.js` to verify the tool definitions and
+ *      their thin execute wrappers exactly as the MCP server sees them.
  */
+
+const { getTool } = require('../../tools/dj-tools');
 
 // Extract executeDjTool and related code from app.js
 // Since app.js is a monolithic React component, we recreate the pure functions here
@@ -630,5 +639,95 @@ describe('DJ Tools - executeDjTool', () => {
       expect(result.success).toBe(false);
       expect(result.error).toBe('Playback failed');
     });
+  });
+});
+
+// ─── Real-import tests for the new seek / get_position tools ──────────────────
+// These verify the tool definitions and `execute` wrappers exported from
+// `tools/dj-tools.js`. Unlike the executeDjTool tests above, they do not
+// reimplement anything — they call into the actual module.
+
+describe('seek tool', () => {
+  test('calls context.handleSeek with offset_ms and returns its result', async () => {
+    const handleSeek = jest.fn().mockResolvedValue({ success: true, supported: true, position_ms: 12345 });
+    const tool = getTool('seek');
+    expect(tool).toBeDefined();
+    const result = await tool.execute({ offset_ms: 12345 }, { handleSeek });
+    expect(handleSeek).toHaveBeenCalledWith(12345);
+    expect(result.success).toBe(true);
+    expect(result.position_ms).toBe(12345);
+  });
+
+  test('coerces non-number offsets to 0', async () => {
+    const handleSeek = jest.fn().mockResolvedValue({ success: true, supported: true });
+    const tool = getTool('seek');
+    await tool.execute({ offset_ms: 'not a number' }, { handleSeek });
+    expect(handleSeek).toHaveBeenCalledWith(0);
+  });
+
+  test('returns supported:false when context lacks handleSeek (older app build)', async () => {
+    const tool = getTool('seek');
+    const result = await tool.execute({ offset_ms: 1000 }, {});
+    expect(result.success).toBe(false);
+    expect(result.supported).toBe(false);
+  });
+
+  test('passes through supported:false from the engine (e.g. spotify)', async () => {
+    const handleSeek = jest.fn().mockResolvedValue({ success: false, supported: false, error: 'spotify seek not supported' });
+    const tool = getTool('seek');
+    const result = await tool.execute({ offset_ms: 1000 }, { handleSeek });
+    expect(result.supported).toBe(false);
+    expect(result.error).toBe('spotify seek not supported');
+  });
+});
+
+describe('get_position tool', () => {
+  test('returns context.getCurrentPosition() with numeric normalization', async () => {
+    const getCurrentPosition = jest.fn().mockReturnValue({ position_ms: 30000, duration_ms: 240000, supported: true });
+    const tool = getTool('get_position');
+    expect(tool).toBeDefined();
+    const result = await tool.execute({}, { getCurrentPosition });
+    expect(getCurrentPosition).toHaveBeenCalled();
+    expect(result.position_ms).toBe(30000);
+    expect(result.duration_ms).toBe(240000);
+    expect(result.supported).toBe(true);
+  });
+
+  test('handles missing supported flag as true', async () => {
+    const getCurrentPosition = jest.fn().mockReturnValue({ position_ms: 0, duration_ms: 1000 });
+    const tool = getTool('get_position');
+    const result = await tool.execute({}, { getCurrentPosition });
+    expect(result.supported).toBe(true);
+  });
+
+  test('returns supported:false when context lacks getCurrentPosition', async () => {
+    const tool = getTool('get_position');
+    const result = await tool.execute({}, {});
+    expect(result.position_ms).toBe(0);
+    expect(result.duration_ms).toBe(0);
+    expect(result.supported).toBe(false);
+  });
+
+  test('coerces non-number values to 0', async () => {
+    const getCurrentPosition = jest.fn().mockReturnValue({ position_ms: 'oops', duration_ms: null, supported: true });
+    const tool = getTool('get_position');
+    const result = await tool.execute({}, { getCurrentPosition });
+    expect(result.position_ms).toBe(0);
+    expect(result.duration_ms).toBe(0);
+  });
+});
+
+describe('registry exposes the new tools', () => {
+  test('seek and get_position are both registered by name', () => {
+    expect(getTool('seek')).toBeDefined();
+    expect(getTool('get_position')).toBeDefined();
+  });
+
+  test('both have JSON-schema parameters consumable by MCP/Claude/OpenAI', () => {
+    const seek = getTool('seek');
+    expect(seek.parameters.required).toEqual(['offset_ms']);
+    expect(seek.parameters.properties.offset_ms.type).toBe('number');
+    const pos = getTool('get_position');
+    expect(pos.parameters.type).toBe('object');
   });
 });

--- a/tools/dj-tools.js
+++ b/tools/dj-tools.js
@@ -24,6 +24,8 @@
  * @property {function(): Object|null} getCurrentTrack - Get current track
  * @property {function(): Array} getQueue - Get current queue
  * @property {function(): boolean} getIsPlaying - Get playback state
+ * @property {function(number): Promise<{success: boolean, supported?: boolean, error?: string}>} handleSeek - Seek to a position (ms) within the current track
+ * @property {function(): {position_ms: number, duration_ms: number, supported: boolean}} getCurrentPosition - Get current playback position (ms) and duration (ms)
  * @property {function(): Array} getPlaylists - Get all playlists
  * @property {function(string): Object|null} findPlaylist - Find playlist by name
  * @property {function(string, Array): void} addTracksToPlaylist - Add tracks to playlist
@@ -147,6 +149,64 @@ const controlTool = {
       default:
         return { success: false, error: `Unknown action: ${action}` };
     }
+  }
+};
+
+/**
+ * Seek to a specific position within the currently playing track.
+ *
+ * Supported playback paths (mirrors the playbar slider in app.js):
+ *   - Local files, SoundCloud, YouTube, Bandcamp (HTML5 audio)
+ *   - Apple Music (native MusicKit and MusicKit JS)
+ *
+ * Not supported: Spotify (Web Playback SDK and Spotify Connect both lack
+ * seek in the current playback wiring). Callers receive `supported: false`
+ * with no error so they can degrade gracefully.
+ *
+ * @type {Tool}
+ */
+const seekTool = {
+  name: 'seek',
+  description: 'Seek the currently playing track to a specific position. Returns {success, supported}. Not all playback paths support seek (notably Spotify); callers should handle supported=false.',
+  parameters: {
+    type: 'object',
+    properties: {
+      offset_ms: {
+        type: 'number',
+        description: 'Target position within the track, in milliseconds from the start. Clamped to [0, duration].'
+      }
+    },
+    required: ['offset_ms']
+  },
+  execute: async ({ offset_ms }, context) => {
+    if (typeof context.handleSeek !== 'function') {
+      return { success: false, supported: false, error: 'seek not wired in this build' };
+    }
+    const result = await context.handleSeek(Number(offset_ms) || 0);
+    return result ?? { success: true };
+  }
+};
+
+/**
+ * Read the current playback position and duration. Used by external sync
+ * clients (e.g. Office Jukebox companion) to keep multiple listeners aligned.
+ *
+ * @type {Tool}
+ */
+const getPositionTool = {
+  name: 'get_position',
+  description: 'Get the current playback position and track duration in milliseconds. Returns {position_ms, duration_ms, supported}.',
+  parameters: { type: 'object', properties: {} },
+  execute: async (_args, context) => {
+    if (typeof context.getCurrentPosition !== 'function') {
+      return { position_ms: 0, duration_ms: 0, supported: false };
+    }
+    const pos = context.getCurrentPosition() || {};
+    return {
+      position_ms: Number(pos.position_ms) || 0,
+      duration_ms: Number(pos.duration_ms) || 0,
+      supported: pos.supported !== false
+    };
   }
 };
 
@@ -695,6 +755,8 @@ const deletePlaylistTool = {
 const djTools = [
   playTool,
   controlTool,
+  seekTool,
+  getPositionTool,
   searchTool,
   queueAddTool,
   queueClearTool,


### PR DESCRIPTION
Adds two new MCP tools to the DJ tool surface:

- `seek({offset_ms})` — seek the active playback engine to a position in the current track. Mirrors the playbar slider in app.js; supports HTML5-audio-backed engines (local files, SoundCloud, YouTube, Bandcamp) and Apple Music (preview audio, native MusicKit, MusicKit JS web). 

  Returns `{success, supported}`; Spotify returns `supported: false` (both Web Playback SDK and Spotify Connect lack seek in the current playback wiring), so callers can degrade gracefully.

- `get_position()` — returns `{position_ms, duration_ms, supported}`. 

Motivation: I'm working on another extension where external sync clients need precise position to keep listeners aligned mid-track. Without these, sync is limited to track boundaries.

Spotify is the only painful gap; left as `supported: false` rather than a partial half-working implementation. Web Playback SDK does expose seek and could be wired through `streamingPlaybackActiveRef` in a follow-up; Spotify Connect's `PUT /me/player/seek` is also possible but adds another auth path. Let me know if you'd like either.