### PR TITLE
sync: skip unchanged playlists in inbound update branch (#796)

### DIFF
--- a/main.js
+++ b/main.js
@@ -6157,6 +6157,53 @@ ipcMain.handle('sync:start', async (event, providerId, options = {}) => {
             // Existing playlist - update metadata and check for track updates
             const idx = currentPlaylists.findIndex(p => p.id === localPlaylist.id);
             if (idx >= 0) {
+              // Hoisted re-read: pick up any concurrent renderer writes for
+              // this playlist BEFORE deciding short-circuit vs. full branch.
+              // Without this, the short-circuit below would use the L6090
+              // snapshot and clobber a concurrent renderer edit (e.g. user
+              // removed a track) at end-of-loop store.set. electron-store
+              // caches the parsed array, so this read is near-free.
+              //
+              // The full branch keeps its own inner re-read (post-
+              // fetchPlaylistTracks) to cover the narrower window of a
+              // concurrent edit during the track-fetch IPC. Both reads are
+              // defensive; both are cheap.
+              {
+                const freshPlaylists = store.get('local_playlists') || [];
+                const freshPlaylist = freshPlaylists.find(p => p.id === localPlaylist.id);
+                if (freshPlaylist) {
+                  currentPlaylists[idx] = freshPlaylist;
+                }
+              }
+
+              // Short-circuit unchanged playlists (parachord#796). When the
+              // playlist hasn't drifted on either side AND no metadata backfill
+              // is pending AND owner/collaborator state is stable, skip the
+              // spread-rewrite work and just bump syncedAt. This shrinks the
+              // in-memory mutation footprint of a steady-state sync (where
+              // most selected playlists haven't actually changed) and keeps
+              // the staleness timestamp accurate for #800's oldest-stale-first
+              // sort. Modest CPU win; the bigger sync-perf levers are in
+              // #797 (resolver concurrency) and #798 (push-loop idle deferral).
+              if (SyncEngine.canShortCircuitPlaylistUpdate({
+                localPlaylist: currentPlaylists[idx],
+                remotePlaylist,
+                providerId
+              })) {
+                const cur = currentPlaylists[idx];
+                currentPlaylists[idx] = {
+                  ...cur,
+                  syncSources: {
+                    ...cur.syncSources,
+                    [providerId]: {
+                      ...cur.syncSources?.[providerId],
+                      syncedAt: Date.now()
+                    }
+                  }
+                };
+                continue;
+              }
+
               const hasTrackUpdates = localPlaylist.syncedFrom?.snapshotId !== remotePlaylist.snapshotId;
               const existingTracks = currentPlaylists[idx].tracks || [];
               const isEmpty = existingTracks.length === 0;

--- a/sync-engine/index.js
+++ b/sync-engine/index.js
@@ -284,11 +284,89 @@ const calculatePlaylistDiff = (remotePlaylists, localPlaylists, selectedIds, pro
   return { toAdd, toUpdate, toRemove, unchanged };
 };
 
+/**
+ * Decide whether the inbound playlist update branch in sync:start can be
+ * short-circuited for a given (localPlaylist, remotePlaylist, providerId).
+ *
+ * A short-circuit means: the playlist hasn't changed on either side, no
+ * metadata backfills are needed, and ownership/collaborator state is stable.
+ * The caller can skip the heavy fresh-read + spread-rewrite + isOwnPullSource
+ * recomputation work, and only bump `syncSources[providerId].syncedAt`.
+ *
+ * This is the tier-1 perf win from parachord#796 (epic #803). Real CPU
+ * savings are modest because the dominant per-iteration cost is the
+ * `store.get('local_playlists')` fresh-read for concurrent-write protection,
+ * which still has to happen for changed playlists. The win here is avoiding
+ * the spread allocation + downstream rewrite for the typical case where most
+ * selected playlists haven't drifted since the last sync, plus more accurate
+ * `syncedAt` accounting for the staleness sort in #800.
+ *
+ * Returns true ONLY if ALL of the following hold:
+ *   - snapshotIds match (no track-level updates available)
+ *   - local has tracks (not the empty-playlist refill path)
+ *   - this provider IS the canonical pull source (resolver matches)
+ *   - local snapshotId is present (not heal-induced null requiring adoption)
+ *   - remote ownerId matches local syncedFrom.ownerId
+ *   - remote isCollaborator matches local syncedFrom.isCollaborator
+ *   - local.creator is either set OR remote has nothing to backfill from
+ *   - local.source is set (no backfill needed)
+ *
+ * If any condition fails, the caller MUST fall through to the full update
+ * branch to avoid losing legitimate state updates.
+ *
+ * Pure / deterministic / no I/O. Safe to call N times per sync without cost.
+ *
+ * @param {Object} args
+ * @param {Object} args.localPlaylist - The local playlist record (pre-fresh-read).
+ * @param {Object} args.remotePlaylist - The provider's reported playlist shape.
+ * @param {string} args.providerId - The provider running this sync iteration.
+ * @returns {boolean}
+ */
+const canShortCircuitPlaylistUpdate = ({ localPlaylist, remotePlaylist, providerId }) => {
+  if (!localPlaylist || !remotePlaylist || !providerId) return false;
+
+  // Snapshots must match. This is the primary signal of "nothing changed."
+  // Mismatch handles both real updates and AM count-churn / heal-null adoption.
+  if (localPlaylist.syncedFrom?.snapshotId !== remotePlaylist.snapshotId) return false;
+
+  // Empty-tracks case routes to the refill path; cannot short-circuit.
+  const tracks = localPlaylist.tracks;
+  if (!Array.isArray(tracks) || tracks.length === 0) return false;
+
+  // Must be the canonical pull source. Cross-provider mirrors (matched via
+  // syncedTo[providerId]) and locally-created push mirrors (no syncedFrom)
+  // still need the full branch to compute isOwnPullSource correctly.
+  if (localPlaylist.syncedFrom?.resolver !== providerId) return false;
+
+  // Heal-induced null snapshot needs silent-adopt path. The equality check
+  // above would actually have passed if remote also had null/undefined, so
+  // be explicit here to keep the contract obvious and prevent false short-
+  // circuits if a provider ever starts returning null snapshotIds.
+  if (!localPlaylist.syncedFrom?.snapshotId) return false;
+
+  // Ownership / collaborator state changes need to flow into syncedFrom.
+  // Normalize via `!!` so legacy records (undefined isCollaborator) compare
+  // as false rather than triggering a spurious "state changed" branch.
+  if (localPlaylist.syncedFrom?.ownerId !== remotePlaylist.ownerId) return false;
+  const localCollab = !!localPlaylist.syncedFrom?.isCollaborator;
+  const remoteCollab = !!remotePlaylist.isCollaborator;
+  if (localCollab !== remoteCollab) return false;
+
+  // Metadata backfills. If `creator` is missing locally AND remote has an
+  // ownerName to populate it with, we'd backfill in the full branch —
+  // can't short-circuit. Same for `source`.
+  if (!localPlaylist.creator && remotePlaylist.ownerName) return false;
+  if (!localPlaylist.source) return false;
+
+  return true;
+};
+
 module.exports = {
   getProvider,
   getAllProviders,
   calculateDiff,
   applyDiff,
   syncDataType,
-  calculatePlaylistDiff
+  calculatePlaylistDiff,
+  canShortCircuitPlaylistUpdate
 };

--- a/tests/sync/sync-engine.test.js
+++ b/tests/sync/sync-engine.test.js
@@ -5,6 +5,126 @@
  * Spotify library sync, pagination, diff calculation, rate limiting.
  */
 
+const { canShortCircuitPlaylistUpdate } = require('../../sync-engine');
+
+describe('canShortCircuitPlaylistUpdate (inbound sync optimization, see parachord#796)', () => {
+  // Helper to build a "happy path" local + remote pair where short-circuit
+  // should return true. Each test overrides the relevant field.
+  const makePair = (overrides = {}) => {
+    const local = {
+      id: 'spotify-abc123',
+      title: 'Test Playlist',
+      tracks: [{ id: 't1' }, { id: 't2' }],
+      creator: 'someuser',
+      source: 'spotify-import',
+      syncedFrom: {
+        resolver: 'spotify',
+        externalId: 'abc123',
+        snapshotId: 'snap_xyz',
+        ownerId: 'someuser',
+        isCollaborator: false
+      },
+      ...overrides.local
+    };
+    const remote = {
+      externalId: 'abc123',
+      name: 'Test Playlist',
+      snapshotId: 'snap_xyz', // matches local
+      ownerId: 'someuser',
+      ownerName: 'someuser',
+      isOwnedByUser: true,
+      isCollaborator: false,
+      trackCount: 2,
+      ...overrides.remote
+    };
+    return { local, remote, providerId: 'spotify', ...overrides.rest };
+  };
+
+  test('returns true when snapshots match, owner stable, metadata complete', () => {
+    const { local, remote, providerId } = makePair();
+    expect(canShortCircuitPlaylistUpdate({ localPlaylist: local, remotePlaylist: remote, providerId })).toBe(true);
+  });
+
+  test('returns false when snapshotIds differ', () => {
+    const { local, remote, providerId } = makePair({ remote: { snapshotId: 'snap_NEW' } });
+    expect(canShortCircuitPlaylistUpdate({ localPlaylist: local, remotePlaylist: remote, providerId })).toBe(false);
+  });
+
+  test('returns false when local has no tracks (needs refill path)', () => {
+    const { local, remote, providerId } = makePair({ local: { tracks: [] } });
+    expect(canShortCircuitPlaylistUpdate({ localPlaylist: local, remotePlaylist: remote, providerId })).toBe(false);
+  });
+
+  test('returns false when syncedFrom.resolver is a different provider (cross-provider mirror)', () => {
+    const { local, remote, providerId } = makePair({
+      local: { syncedFrom: { resolver: 'applemusic', externalId: 'abc123', snapshotId: 'snap_xyz', ownerId: 'someuser', isCollaborator: false } }
+    });
+    expect(canShortCircuitPlaylistUpdate({ localPlaylist: local, remotePlaylist: remote, providerId })).toBe(false);
+  });
+
+  test('returns false when local has no syncedFrom (locally-created push mirror)', () => {
+    const { local, remote, providerId } = makePair({ local: { syncedFrom: null } });
+    expect(canShortCircuitPlaylistUpdate({ localPlaylist: local, remotePlaylist: remote, providerId })).toBe(false);
+  });
+
+  test('returns false when local snapshotId is null (heal-induced — needs silent-adopt)', () => {
+    const { local, remote, providerId } = makePair({
+      local: { syncedFrom: { resolver: 'spotify', externalId: 'abc123', snapshotId: null, ownerId: 'someuser', isCollaborator: false } }
+    });
+    expect(canShortCircuitPlaylistUpdate({ localPlaylist: local, remotePlaylist: remote, providerId })).toBe(false);
+  });
+
+  test('returns false when ownerId changed on remote', () => {
+    const { local, remote, providerId } = makePair({ remote: { ownerId: 'DIFFERENT_USER' } });
+    expect(canShortCircuitPlaylistUpdate({ localPlaylist: local, remotePlaylist: remote, providerId })).toBe(false);
+  });
+
+  test('returns false when collaborator status changed on remote (false -> true)', () => {
+    const { local, remote, providerId } = makePair({ remote: { isCollaborator: true } });
+    expect(canShortCircuitPlaylistUpdate({ localPlaylist: local, remotePlaylist: remote, providerId })).toBe(false);
+  });
+
+  test('returns false when collaborator status changed on remote (true -> false)', () => {
+    const { local, remote, providerId } = makePair({
+      local: { syncedFrom: { resolver: 'spotify', externalId: 'abc123', snapshotId: 'snap_xyz', ownerId: 'someuser', isCollaborator: true } }
+    });
+    expect(canShortCircuitPlaylistUpdate({ localPlaylist: local, remotePlaylist: remote, providerId })).toBe(false);
+  });
+
+  test('returns false when creator needs backfill (local null, remote has ownerName)', () => {
+    const { local, remote, providerId } = makePair({ local: { creator: null } });
+    expect(canShortCircuitPlaylistUpdate({ localPlaylist: local, remotePlaylist: remote, providerId })).toBe(false);
+  });
+
+  test('returns true when creator is null on both sides (no backfill possible)', () => {
+    const { local, remote, providerId } = makePair({ local: { creator: null }, remote: { ownerName: null } });
+    expect(canShortCircuitPlaylistUpdate({ localPlaylist: local, remotePlaylist: remote, providerId })).toBe(true);
+  });
+
+  test('returns false when source needs backfill (local null)', () => {
+    const { local, remote, providerId } = makePair({ local: { source: null } });
+    expect(canShortCircuitPlaylistUpdate({ localPlaylist: local, remotePlaylist: remote, providerId })).toBe(false);
+  });
+
+  test('returns true even when remote.isCollaborator is undefined (treated as false to match local false)', () => {
+    const { local, remote, providerId } = makePair({ remote: { isCollaborator: undefined } });
+    expect(canShortCircuitPlaylistUpdate({ localPlaylist: local, remotePlaylist: remote, providerId })).toBe(true);
+  });
+
+  test('returns false when local.syncedFrom.isCollaborator is undefined but remote is true', () => {
+    const { local, remote, providerId } = makePair({
+      local: { syncedFrom: { resolver: 'spotify', externalId: 'abc123', snapshotId: 'snap_xyz', ownerId: 'someuser' } },
+      remote: { isCollaborator: true }
+    });
+    expect(canShortCircuitPlaylistUpdate({ localPlaylist: local, remotePlaylist: remote, providerId })).toBe(false);
+  });
+
+  test('handles missing tracks field as empty (forces full path)', () => {
+    const { local, remote, providerId } = makePair({ local: { tracks: undefined } });
+    expect(canShortCircuitPlaylistUpdate({ localPlaylist: local, remotePlaylist: remote, providerId })).toBe(false);
+  });
+});
+
 describe('Sync Engine', () => {
   describe('Provider Registration', () => {
     let syncEngine;


### PR DESCRIPTION
Tier 1 of epic #803 (lazier sync — reduce CPU spike + pinwheel).

## Summary
Adds a `canShortCircuitPlaylistUpdate` pure helper to `sync-engine/` that decides whether the inbound playlist update branch in `sync:start` can skip the spread-rewrite work for a given (local, remote, providerId) triple. Wired into `main.js` at the top of the existing-playlist branch.

When all gate conditions hold, the iteration only bumps `syncSources[providerId].syncedAt` and `continue`s. Otherwise it falls through to the existing full branch unchanged.

## Gate conditions
All of these must hold to short-circuit:
- snapshotIds match (no track-level updates)
- local has tracks (not the empty-playlist refill path)
- this provider IS the canonical pull source
- local snapshotId is present (not heal-induced null)
- remote `ownerId` matches local `syncedFrom.ownerId`
- remote `isCollaborator` matches local `syncedFrom.isCollaborator`
- creator/source backfills not pending

## Race safety
Hoisted the fresh-read `store.get` to BEFORE the short-circuit check so the optimization doesn't widen the existing concurrent-write race for unchanged playlists. The full branch keeps its post-fetch re-read for the narrower track-fetch race window. Both reads are cheap (electron-store caches the parsed array).

## Impact
Modest CPU win on steady-state syncs. Main benefits:
- Accurate `syncedAt` timestamps for the staleness sort in #800
- Fewer unnecessary spread allocations per sync
- Cleaner semantic intent (unchanged ≠ rewritten)

The bigger sync-perf wins are in #797 (resolver concurrency cap) and #798 (push-loop idle deferral) — both stacked on this branch.

## Test plan
- [x] 15 new test cases in `tests/sync/sync-engine.test.js` covering each gate condition and edge cases (undefined collaborator, null tracks, backfill states, cross-provider mirror, heal-induced null)
- [x] All 1598 existing tests pass

## Stack
1. **This PR** — `sync-skip-unchanged-playlists`
2. #798 — `sync-defer-push-to-idle` (yield push loop to idle)
3. #797 — `sync-resolver-concurrency-cap` (concurrency-cap YT/SC/BC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
