### PR TITLE
sync: yield push loop to renderer idle scheduler (#798)

### DIFF
--- a/app.js
+++ b/app.js
@@ -267,6 +267,31 @@ const validateResolvedTrack = (result, targetArtist, targetTitle) => {
 // 0.95 (both-axis match) passes.
 const MIN_CONFIDENCE_THRESHOLD = 0.6;
 
+// Yield the renderer thread to the browser's idle scheduler. Used by the
+// sync push loops (parachord#798) to interleave per-playlist IPCs with user
+// input handling, scroll/animation frames, and other React work. Without
+// this, a sync touching 50+ playlists × ~250ms per iteration ties up the
+// renderer for tens of seconds even though the `await breathe()` already
+// yields the event loop — React's commit work that would otherwise be
+// scheduled during a sync run gets perpetually deferred behind the next
+// iteration's microtask queue. requestIdleCallback explicitly tells the
+// browser "let other queued work go first."
+//
+// The `timeout` ensures sync still makes forward progress when the renderer
+// is genuinely busy (active interaction, large reflow). 2000ms is generous
+// enough to never feel like sync is stalled, tight enough that a totally-
+// pegged renderer doesn't completely block sync.
+//
+// Falls back to `setTimeout(r, 16)` (~1 frame) on rare platforms where
+// requestIdleCallback is unavailable. Current Electron has it natively.
+const yieldToIdle = (timeoutMs = 2000) => new Promise(resolve => {
+  if (typeof window !== 'undefined' && typeof window.requestIdleCallback === 'function') {
+    window.requestIdleCallback(resolve, { timeout: timeoutMs });
+  } else {
+    setTimeout(resolve, 16);
+  }
+});
+
 // Debug flags. Render-path / resolution-path logs are gated on these so they
 // don't fire dozens-to-hundreds of times per page load in normal operation.
 // Flip to true locally when troubleshooting that subsystem; do NOT commit a
@@ -6297,6 +6322,11 @@ const Parachord = () => {
                 const breathe = () => new Promise(r => setTimeout(r, SYNC_IPC_DELAY_MS));
 
                 for (const playlist of allPlaylists) {
+                  // Yield to the renderer's idle scheduler before each
+                  // iteration so user interactions get responsive frames
+                  // even mid-sync. See parachord#798 + the `yieldToIdle`
+                  // helper at the top of this file.
+                  await yieldToIdle();
                   // Skip playlists that are local-only
                   if (playlist.localOnly) continue;
 
@@ -6493,10 +6523,14 @@ const Parachord = () => {
                   // small breath between writes so the main-process disk-IO
                   // queue doesn't starve UI-related IPCs (the pinwheel
                   // pattern). Previously this loop awaited save() on every
-                  // playlist regardless of whether it mutated.
+                  // playlist regardless of whether it mutated. Also yields
+                  // to the renderer idle scheduler before each save so
+                  // user interactions get responsive frames during the
+                  // save burst (parachord#798).
                   let saveCount = 0;
                   for (const playlist of allPlaylists) {
                     if (!modifiedPlaylistIds.has(playlist.id)) continue;
+                    await yieldToIdle();
                     await window.electron.playlists.save(playlist);
                     saveCount++;
                     if (saveCount % 5 === 0) {
@@ -10575,6 +10609,12 @@ const Parachord = () => {
             const breathe = () => new Promise(r => setTimeout(r, SYNC_IPC_DELAY_MS));
 
             for (const playlist of allPlaylists) {
+              // Yield to the renderer's idle scheduler before each iteration
+              // so user interactions get responsive frames mid-sync. See
+              // parachord#798 + the `yieldToIdle` helper at the top of this
+              // file. Mirrors the same yield in the background-sync push
+              // loop above.
+              await yieldToIdle();
               if (playlist.localOnly) continue;
               // Only skip if this playlist was pulled FROM this provider —
               // playlists pulled from a different provider must still be
@@ -10726,10 +10766,14 @@ const Parachord = () => {
 
               // Save only the playlists that actually changed, throttling
               // every 5 saves to give the main process room to service
-              // unrelated IPCs (UI rendering, etc.).
+              // unrelated IPCs (UI rendering, etc.). Also yields to the
+              // renderer idle scheduler before each save so user
+              // interactions get responsive frames during the save burst
+              // (parachord#798).
               let saveCount = 0;
               for (const playlist of allPlaylists) {
                 if (!modifiedPlaylistIds.has(playlist.id)) continue;
+                await yieldToIdle();
                 await window.electron.playlists.save(playlist);
                 saveCount++;
                 if (saveCount % 5 === 0) {


### PR DESCRIPTION
Tier 1 of epic #803 (lazier sync — reduce CPU spike + pinwheel).

**Stacked on #796** — review that one first; this branch builds on top.

## Summary
Wraps each iteration of the four sync-related push loops in `app.js` with `await yieldToIdle()`, a thin Promise-wrapper around `window.requestIdleCallback`. The renderer's idle scheduler gets to run user-interaction events, scroll/animation frames, and React commit work between sync iterations.

## Why this matters even though `await breathe()` already yields the event loop
`setTimeout`-based yields hand the thread back, but the next iteration's IPC immediately re-takes it via the microtask queue. `requestIdleCallback` explicitly says "let other queued work go first" — React's reconciliation work gets a chance to land, user click handlers get serviced, and the UI feels responsive even mid-sync.

The 2000ms timeout ensures sync still makes forward progress when the renderer is genuinely busy. Falls back to `setTimeout(r, 16)` on platforms missing `requestIdleCallback` (current Electron has it).

## Loops affected
- Background-sync push loop (~L6324 in app.js)
- Background-sync inner save loop (~L6531)
- Post-wizard IIFE push loop (~L10611)
- Post-wizard IIFE inner save loop (~L10771)

## Impact
The highest-user-perceived-impact fix in tier 1. Addresses "I came back and the app pinwheels" by making sync work actually yield, not just superficially-yield via `setTimeout`. Tests it: load Parachord with 50+ synced playlists, trigger a sync, verify clicks/scroll commit frames during the push loop instead of waiting for it to finish.

## Test plan
- [x] All 1598 tests pass (no new tests — the helper is a 5-line wrapper around a browser API, behavioral contract observable directly via inspection)

## Stack
1. #796 — `sync-skip-unchanged-playlists` (skip unchanged playlists)
2. **This PR** — `sync-defer-push-to-idle`
3. #797 — `sync-resolver-concurrency-cap` (concurrency-cap YT/SC/BC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
