### PR TITLE
sync: cancel in-flight background sync on window focus (#799)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,17 @@ Two-layer dedup keeps blur-triggered runs cheap:
 
 Net effect for an always-open user: blur for >30s → sync fires while they're gone, completes before they return. Blur for <30s (quick Cmd+Tab) → pending sync cancelled, never fires. Sync never coincides with active app use.
 
-The handlers use `window.electron.app.onBackground` / `onForeground` (preload bridges `app-background` / `app-foreground` IPC). No unsubscribe paths are exposed by the preload (multi-listener safe); they detach when the renderer tears down. Mid-sync foreground events are NOT cancelled — too risky to interrupt a running save — only pending `setTimeout`s. A user who returns mid-sync may still see residual IPC activity for a few seconds; accepted vs the complexity of safe cancellation.
+The handlers use `window.electron.app.onBackground` / `onForeground` (preload bridges `app-background` / `app-foreground` IPC). No unsubscribe paths are exposed by the preload (multi-listener safe); they detach when the renderer tears down.
+
+**Cancel-on-focus** (parachord#799). Mid-sync foreground events DO cancel the in-flight background sync now — earlier doc said otherwise; that note is obsolete. Two-layer mechanism:
+
+1. **Renderer side** holds `backgroundSyncInFlightRef` (Set of provider IDs with active `sync.start` IPCs) and `backgroundSyncCancelledRef` (boolean flag). The foreground handler flips the flag true and fires `window.electron.sync.cancel(providerId)` for each in-flight provider. The next iteration of the provider loop and any in-flight push loop checks the flag and bails.
+
+2. **Main process** `sync:start` IPC handler checks `activeSyncs.get(providerId)?.cancelled` at every phase boundary (after tracks / after albums / after artists / before playlists) and per-iteration inside the playlist loop. When the flag flips, it runs `finalizeCancelled(collection, results)` which writes the partial collection to disk, bumps `lastSyncAt` so the staleness gate doesn't immediately re-fire, and returns `{success: true, cancelled: true, results, collection}`. Anything mutated in memory before the cancellation point sticks; remaining work defers to the next non-cancelled sync.
+
+**Wizard sync is exempt.** The wizard's manual `sync.start` doesn't go through `runBackgroundSync` and doesn't add to `backgroundSyncInFlightRef`, so foreground events don't cancel it. The user is engaged with the wizard; their sync runs to completion regardless.
+
+**Partial-save semantics.** When the playlist loop is cancelled mid-iteration, `local_playlists` IS written with the in-memory state (so playlists already processed get their `syncedAt` advanced) but the `syncedFrom`-clearing pass is SKIPPED (we may not have visited every selected playlist; clearing based on a partial iteration could mass-clear playlists that haven't been verified-missing-from-remote yet). The next non-cancelled sync re-runs the clearing pass over the full set.
 
 ### In-Session Mutex
 

--- a/app.js
+++ b/app.js
@@ -6241,6 +6241,22 @@ const Parachord = () => {
   // without syncedTo[providerId], and both create it on the remote — producing duplicates.
   const playlistSyncInProgressRef = useRef(false);
 
+  // Cancel-on-focus infrastructure (parachord#799).
+  //
+  // `backgroundSyncInFlightRef` tracks which provider IDs currently have an
+  // in-flight `sync.start` IPC fired from `runBackgroundSync`. The
+  // foreground handler reads this to know which providers to send
+  // `sync.cancel` to — the wizard's manual sync path doesn't touch this
+  // ref, so wizard syncs are exempt from focus-cancel as designed.
+  //
+  // `backgroundSyncCancelledRef` is the within-renderer flag that the
+  // background sync provider-loop AND its push-loop iterations check
+  // between iterations. Foreground sets it true; the next iteration sees
+  // it and bails. Reset to false at the start of each new background sync
+  // run.
+  const backgroundSyncInFlightRef = useRef(new Set());
+  const backgroundSyncCancelledRef = useRef(false);
+
   useEffect(() => {
     const SYNC_INTERVAL = 15 * 60 * 1000; // 15 minutes — timer cadence + default staleness gate
     const BACKGROUND_MIN_STALENESS = 5 * 60 * 1000; // tighter staleness for background-triggered runs
@@ -6248,10 +6264,19 @@ const Parachord = () => {
     const INITIAL_DELAY = 60 * 1000; // 60 seconds — let the app fully load first
 
     const runBackgroundSync = async (opts = {}) => {
+      // Reset cancellation state for this run. The foreground handler
+      // flips this true to interrupt long-running background syncs —
+      // see parachord#799 + `backgroundSyncCancelledRef` declaration.
+      backgroundSyncCancelledRef.current = false;
       const minStaleness = typeof opts.minStaleness === 'number' ? opts.minStaleness : SYNC_INTERVAL;
       const currentSettings = resolverSyncSettingsRef.current;
       // Check each enabled provider
       for (const [providerId, settings] of Object.entries(currentSettings)) {
+        // Honor cancel-on-focus: skip remaining providers if the user came back.
+        if (backgroundSyncCancelledRef.current) {
+          console.log('[Sync] Background sync cancelled on foreground — skipping remaining providers');
+          break;
+        }
         if (settings.enabled) {
           // Skip if last sync was recent (within the staleness threshold for this run)
           if (settings.lastSyncAt && (Date.now() - settings.lastSyncAt) < minStaleness) {
@@ -6262,7 +6287,20 @@ const Parachord = () => {
             const authStatus = await window.electron.sync.checkAuth(providerId);
             if (authStatus.authenticated) {
               console.log(`[Sync] Starting background sync for ${providerId}`);
-              const result = await window.electron.sync.start(providerId, { settings });
+              // Track this provider as in-flight so the foreground handler
+              // knows to send sync.cancel for it. Cleared in `finally`
+              // regardless of how the sync resolves.
+              backgroundSyncInFlightRef.current.add(providerId);
+              let result;
+              try {
+                result = await window.electron.sync.start(providerId, { settings });
+              } finally {
+                backgroundSyncInFlightRef.current.delete(providerId);
+              }
+              if (result?.cancelled) {
+                console.log(`[Sync] ${providerId} sync cancelled mid-flight — stopping run`);
+                break;
+              }
               if (result.success) {
                 if (result.collection) {
                   // Compare incoming collection against current state before updating UI.
@@ -6322,6 +6360,13 @@ const Parachord = () => {
                 const breathe = () => new Promise(r => setTimeout(r, SYNC_IPC_DELAY_MS));
 
                 for (const playlist of allPlaylists) {
+                  // Cancel-on-focus: drop out mid-push if the user returned
+                  // (parachord#799). Anything already pushed stays; the
+                  // remainder defers to the next sync cycle.
+                  if (backgroundSyncCancelledRef.current) {
+                    console.log(`[Sync] Push loop cancelled on foreground for ${providerId}`);
+                    break;
+                  }
                   // Yield to the renderer's idle scheduler before each
                   // iteration so user interactions get responsive frames
                   // even mid-sync. See parachord#798 + the `yieldToIdle`
@@ -6530,6 +6575,13 @@ const Parachord = () => {
                   let saveCount = 0;
                   for (const playlist of allPlaylists) {
                     if (!modifiedPlaylistIds.has(playlist.id)) continue;
+                    // Cancel-on-focus also drops out of the save loop
+                    // (parachord#799). Already-saved playlists stick;
+                    // remaining defer to the next cycle.
+                    if (backgroundSyncCancelledRef.current) {
+                      console.log(`[Sync] Save loop cancelled on foreground for ${providerId} (saved ${saveCount} so far)`);
+                      break;
+                    }
                     await yieldToIdle();
                     await window.electron.playlists.save(playlist);
                     saveCount++;
@@ -6720,9 +6772,30 @@ const Parachord = () => {
       }, BACKGROUND_DELAY);
     };
     const handleForeground = () => {
+      // Cancel any pending blur-triggered sync that hasn't fired yet.
       if (pendingBackgroundSync) {
         clearTimeout(pendingBackgroundSync);
         pendingBackgroundSync = null;
+      }
+      // Cancel any in-flight background sync (parachord#799). The wizard's
+      // manual sync path doesn't add to `backgroundSyncInFlightRef`, so
+      // user-initiated syncs run to completion regardless of focus state.
+      //
+      // Two-layer cancellation:
+      //   1. Flip the renderer-side ref so the provider loop + push loop
+      //      bail at their next iteration check (cheap, no IPC).
+      //   2. Fire sync.cancel for each in-flight provider so the main
+      //      process can short-circuit its phase-by-phase inbound sync
+      //      and save partial progress.
+      if (backgroundSyncInFlightRef.current.size > 0) {
+        const inFlight = [...backgroundSyncInFlightRef.current];
+        backgroundSyncCancelledRef.current = true;
+        console.log(`[Sync] Cancelling in-flight background sync on focus: ${inFlight.join(', ')}`);
+        for (const pid of inFlight) {
+          if (window.electron?.sync?.cancel) {
+            window.electron.sync.cancel(pid).catch(() => {});
+          }
+        }
       }
     };
     if (window.electron?.app?.onBackground) {

--- a/main.js
+++ b/main.js
@@ -6009,6 +6009,16 @@ ipcMain.handle('sync:start', async (event, providerId, options = {}) => {
     }
   };
 
+  // Cancellation check (parachord#799). The renderer's foreground handler
+  // fires `sync.cancel(providerId)` on window focus to interrupt long-running
+  // background syncs. This helper is checked at every phase boundary AND
+  // between playlist iterations; when it flips true we short-circuit to the
+  // save phase, preserve any progress already made (collection.json write +
+  // partial local_playlists updates), and return a `cancelled: true` result.
+  // The wizard's manual sync path is not affected — the renderer only sends
+  // cancel for syncs it started via `runBackgroundSync`.
+  const isCancelled = () => !!activeSyncs.get(providerId)?.cancelled;
+
   const fsPromises = require('fs').promises;
 
   try {
@@ -6017,6 +6027,37 @@ ipcMain.handle('sync:start', async (event, providerId, options = {}) => {
 
     // Load current collection
     const collectionPath = path.join(app.getPath('userData'), 'collection.json');
+
+    // Build a "save-partial-and-return" helper that runs collection.json
+    // write + lastSyncAt bump + result construction. Called from every
+    // cancellation point so partial progress is durable.
+    const finalizeCancelled = async (collectionState, resultsState) => {
+      try {
+        sendProgress({ phase: 'cancelled', message: 'Sync cancelled' });
+        await fsPromises.writeFile(collectionPath, JSON.stringify(collectionState), 'utf8');
+      } catch (err) {
+        console.warn(`[Sync] Cancellation save failed for ${providerId}:`, err.message);
+      }
+      // Bump lastSyncAt even for partial syncs so the staleness gate
+      // doesn't immediately re-trigger another full run. The next cycle
+      // picks up whatever still needs work.
+      const partialSyncSettings = store.get('resolver_sync_settings') || {};
+      partialSyncSettings[providerId] = {
+        ...partialSyncSettings[providerId],
+        lastSyncAt: Date.now()
+      };
+      store.set('resolver_sync_settings', partialSyncSettings);
+      const hasChanges = Object.values(resultsState).some(r =>
+        r && ((r.added || 0) > 0 || (r.removed || 0) > 0 || (r.updated || 0) > 0)
+      );
+      console.log(`[Sync] ${providerId} cancelled — partial progress saved`);
+      return {
+        success: true,
+        cancelled: true,
+        results: resultsState,
+        collection: hasChanges ? collectionState : null
+      };
+    };
     let collection;
     try {
       const content = await fsPromises.readFile(collectionPath, 'utf8');
@@ -6046,6 +6087,8 @@ ipcMain.handle('sync:start', async (event, providerId, options = {}) => {
       console.log(`[Sync] Skipping tracks sync. syncTracks=${settings.syncTracks}, capabilities.tracks=${provider.capabilities.tracks}`);
     }
 
+    if (isCancelled()) return await finalizeCancelled(collection, results);
+
     // Sync albums
     if (settings.syncAlbums !== false && provider.capabilities.albums) {
       sendProgress({ phase: 'fetching', type: 'albums', message: 'Fetching saved albums...' });
@@ -6065,6 +6108,8 @@ ipcMain.handle('sync:start', async (event, providerId, options = {}) => {
       console.log(`[Sync] Skipping albums sync. syncAlbums=${settings.syncAlbums}, capabilities.albums=${provider.capabilities.albums}`);
     }
 
+    if (isCancelled()) return await finalizeCancelled(collection, results);
+
     // Sync artists
     if (settings.syncArtists !== false && provider.capabilities.artists) {
       sendProgress({ phase: 'fetching', type: 'artists', message: 'Fetching followed artists...' });
@@ -6083,6 +6128,8 @@ ipcMain.handle('sync:start', async (event, providerId, options = {}) => {
     } else {
       console.log(`[Sync] Skipping artists sync. syncArtists=${settings.syncArtists}, capabilities.artists=${provider.capabilities.artists}`);
     }
+
+    if (isCancelled()) return await finalizeCancelled(collection, results);
 
     // Sync playlists
     if (settings.syncPlaylists && settings.selectedPlaylistIds?.length > 0 && provider.capabilities.playlists) {
@@ -6104,6 +6151,19 @@ ipcMain.handle('sync:start', async (event, providerId, options = {}) => {
       let playlistsFailed = 0;
 
       for (let i = 0; i < selectedRemote.length; i++) {
+        // Per-iteration cancellation check (parachord#799). Save partial
+        // progress before bailing — currentPlaylists already holds the
+        // in-memory mutations for playlists processed so far. Skip the
+        // syncedFrom-clearing pass below since we may not have visited
+        // every selected playlist; deferring it to the next non-cancelled
+        // sync is safer than clearing based on a partial iteration.
+        if (isCancelled()) {
+          store.set('local_playlists', currentPlaylists);
+          results.playlists = { added: playlistsAdded, updated: playlistsUpdated, failed: playlistsFailed, cancelled: true, processedCount: i };
+          console.log(`[Sync] ${providerId} playlist sync cancelled at ${i}/${selectedRemote.length} — partial progress saved`);
+          return await finalizeCancelled(collection, results);
+        }
+
         const remotePlaylist = selectedRemote[i];
         sendProgress({ phase: 'playlists', current: i + 1, total: selectedRemote.length, providerId });
 


### PR DESCRIPTION
Tier 2 of epic #803 (lazier sync — reduce CPU spike + pinwheel).

## What this fixes

Directly addresses the "I came back and the app is frozen" complaint. Today, focus events only cancel the **pending** blur-triggered `setTimeout`. Once a background sync actually starts, returning to the window has zero effect — the user just waits out the multi-minute IPC chain. CLAUDE.md explicitly disclaimed cancel-on-focus as too-risky-to-implement; that note is now obsolete.

## How

Two-layer cancellation.

### Renderer (app.js)

Two new refs alongside the existing focus-handler infrastructure:

- `backgroundSyncInFlightRef: useRef(new Set())` — provider IDs currently mid-`sync.start` from `runBackgroundSync`. The wizard's `startSync` path doesn't touch this ref, so wizard syncs are **exempt from focus-cancel** (intentional — user is engaged with the wizard, runs to completion).
- `backgroundSyncCancelledRef: useRef(false)` — within-renderer flag the provider loop and push loop check between iterations. Reset to false at start of every new `runBackgroundSync` run.

`handleForeground` now does two things on focus:
1. Flips `backgroundSyncCancelledRef.current = true`.
2. For each provider in `backgroundSyncInFlightRef`, fires `window.electron.sync.cancel(providerId)`.

Provider loop in `runBackgroundSync` checks the ref before each iteration; bails if cancelled. Push loop and inner save loop also check between iterations.

### Main process (main.js)

`sync:start` IPC handler gains an `isCancelled()` helper that reads `activeSyncs.get(providerId)?.cancelled`. Checks placed at:
- After tracks phase, before albums
- After albums phase, before artists
- After artists phase, before playlists
- Per-iteration inside the playlist loop

When the flag flips, `finalizeCancelled(collection, results)` runs:
- Writes partial `collection.json` to disk (anything synced so far sticks).
- Bumps `resolver_sync_settings[providerId].lastSyncAt` so the staleness gate doesn't immediately re-trigger.
- Returns `{success: true, cancelled: true, results, collection}`.

For the playlist loop specifically: `local_playlists` IS written with in-memory state (already-processed playlists keep their advanced `syncedAt`), but the `syncedFrom`-clearing pass is SKIPPED. Clearing based on a partial iteration could mass-clear playlists that haven't been verified-missing-from-remote; defer to next full sync.

## UX

Silent. No toast, no banner. The user wanted the app to be responsive when they returned; they don't need a "sync paused" notification on top of that. The next background tick picks up where it left off.

## Test plan (manual)

The IPC handler + ref-coordination logic isn't unit-testable in the current Node harness. Manual verification:

- [ ] Trigger background sync with N selected playlists, blur during the 30s grace, return before 30s — pending sync cancelled, no new run starts. (Existing behavior, unchanged.)
- [ ] Trigger background sync with N selected playlists, let it start, blur, return mid-flight — sync stops at next phase or iteration boundary; main process logs `[Sync] {provider} cancelled — partial progress saved`; renderer logs `[Sync] Cancelling in-flight background sync on focus`.
- [ ] Open wizard, click "Sync Now", blur mid-sync, return — sync continues to completion (wizard exempt).
- [ ] After a cancelled sync, the next background tick picks up where it left off (next stalest playlist; previously-processed ones stay processed).
- [ ] All 1598 existing tests pass.

## Related

- Tier 1 (#796, #797, #798) — already merged. Together with #799 should noticeably reduce the post-blur CPU spike experience.
- CLAUDE.md "Background Sync Cadence" section updated to reflect the new behavior + partial-save semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
