### PR TITLE
sync: stagger playlists across cycles, oldest-stale-first (#800)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,20 @@ Net effect for an always-open user: blur for >30s → sync fires while they're g
 
 The handlers use `window.electron.app.onBackground` / `onForeground` (preload bridges `app-background` / `app-foreground` IPC). No unsubscribe paths are exposed by the preload (multi-listener safe); they detach when the renderer tears down. Mid-sync foreground events are NOT cancelled — too risky to interrupt a running save — only pending `setTimeout`s. A user who returns mid-sync may still see residual IPC activity for a few seconds; accepted vs the complexity of safe cancellation.
 
+### Staggered playlist sync per cycle (parachord#800)
+
+`sync:start`'s inbound playlist loop processes the **top N oldest-stale playlists** per cycle rather than every selected playlist. With 50 selected × 15-min cadence × batch=15, the whole selection rolls through in ~2.5h worst-case. Most users don't notice; cross-platform power-users get a manual escape via "Sync Now."
+
+`staggerPlaylistsForCycle` (sync-engine/index.js) is the pure sort+slice helper. Sort order:
+
+1. `hasUpdates: true` first — user is waiting on a pending pull.
+2. `syncSources[providerId].syncedAt` ascending — oldest-stale next. Playlists with no local entry sort to top (first-time imports run on the first cycle after wizard selection).
+3. `lastModified` descending — breaks ties; recent local edits get sync priority over dormant playlists.
+
+**Full-sync bypass** via `options.fullSync = true` on the `sync:start` IPC. All renderer-side user-initiated sync paths pass it: wizard "Sync Now" (post-config + post-syncing-complete), Spotify/AM re-auth catch-up triggers. `runBackgroundSync` does NOT pass it — that's the cadenced path the stagger targets.
+
+The clearing pass for "remote playlist no longer exists" still runs against the FULL fetched `remotePlaylists` (not the staggered subset), so deleted-on-remote detection is unaffected by which subset we iterate.
+
 ### In-Session Mutex
 
 The renderer has **two independent code paths** that call `sync.createPlaylist` and `sync.pushPlaylist`:

--- a/app.js
+++ b/app.js
@@ -10544,11 +10544,15 @@ const Parachord = () => {
 
     setSyncSetupModal(prev => ({ ...prev, step: 'syncing' }));
 
+    // Wizard "Sync Now" is explicit user intent — bypass the per-cycle
+    // playlist staggering (parachord#800) so every selected playlist is
+    // visited in this one run rather than spread over 4-5 background cycles.
     const result = await window.electron.sync.start(providerId, {
       settings: {
         ...settings,
         selectedPlaylistIds: selectedPlaylists
-      }
+      },
+      fullSync: true
     });
 
     if (result.success) {
@@ -35763,7 +35767,9 @@ Variety guidance: ${theme} Be creative and surprising — avoid defaulting to th
           window.electron.syncSettings?.load().then(syncSettings => {
             if (syncSettings?.applemusic?.enabled) {
               console.log('[Sync] Apple Music re-authenticated with sync enabled, triggering immediate sync');
-              window.electron.sync.start('applemusic', { settings: syncSettings.applemusic }).then(result => {
+              // Re-auth catch-up — user just reconnected, treat as full sync
+              // so they don't have to wait 4-5 background cycles (parachord#800).
+              window.electron.sync.start('applemusic', { settings: syncSettings.applemusic, fullSync: true }).then(result => {
                 if (result?.success && result.collection) {
                   const incoming = {
                     tracks: result.collection.tracks || [],
@@ -35886,7 +35892,9 @@ Variety guidance: ${theme} Be creative and surprising — avoid defaulting to th
           window.electron.syncSettings?.load().then(syncSettings => {
             if (syncSettings?.applemusic?.enabled) {
               console.log('[Sync] Apple Music re-authenticated with sync enabled, triggering immediate sync');
-              window.electron.sync.start('applemusic', { settings: syncSettings.applemusic }).then(result => {
+              // Re-auth catch-up — user just reconnected, treat as full sync
+              // so they don't have to wait 4-5 background cycles (parachord#800).
+              window.electron.sync.start('applemusic', { settings: syncSettings.applemusic, fullSync: true }).then(result => {
                 if (result?.success && result.collection) {
                   const incoming = {
                     tracks: result.collection.tracks || [],
@@ -36308,7 +36316,9 @@ useEffect(() => {
         window.electron.syncSettings?.load().then(syncSettings => {
           if (syncSettings?.spotify?.enabled) {
             console.log('[Sync] Spotify re-authenticated with sync enabled, triggering immediate sync');
-            window.electron.sync.start('spotify', { settings: syncSettings.spotify }).then(result => {
+            // Re-auth catch-up — user just reconnected, treat as full sync
+            // (parachord#800).
+            window.electron.sync.start('spotify', { settings: syncSettings.spotify, fullSync: true }).then(result => {
               if (result?.success && result.collection) {
                 const incoming = {
                   tracks: result.collection.tracks || [],
@@ -62355,7 +62365,9 @@ useEffect(() => {
                   try {
                     const authStatus = await window.electron.sync.checkAuth(providerId);
                     if (authStatus.authenticated) {
-                      const result = await window.electron.sync.start(providerId, { settings });
+                      // Explicit "Sync Now" button — bypass per-cycle stagger
+                      // so the user gets a full sweep (parachord#800).
+                      const result = await window.electron.sync.start(providerId, { settings, fullSync: true });
                       if (result.success && result.collection) {
                         latestCollection = result.collection;
                       }

--- a/main.js
+++ b/main.js
@@ -6094,10 +6094,31 @@ ipcMain.handle('sync:start', async (event, providerId, options = {}) => {
       const { playlists: remotePlaylists } = await provider.fetchPlaylists(token, null, refreshToken);
       const suppressedPlaylists = store.get('suppressed_sync_playlists') || {};
       const suppressedForProvider = suppressedPlaylists[providerId] || [];
-      const selectedRemote = remotePlaylists.filter(p =>
+      const allSelectedRemote = remotePlaylists.filter(p =>
         settings.selectedPlaylistIds.includes(p.externalId) &&
         !suppressedForProvider.includes(p.externalId)
       );
+
+      // Stagger across cycles (parachord#800). Background sync processes
+      // the top N oldest-stale-first per cycle; over 4-5 cycles the whole
+      // selection gets covered. Explicit full-sync paths (wizard "Sync
+      // Now", cleanup-duplicates, etc.) bypass via `options.fullSync` so
+      // they still see every selected playlist in one run.
+      //
+      // The sort is provider-scoped (`syncSources[providerId].syncedAt`),
+      // so each provider's stagger queue is independent — a Spotify-stale
+      // playlist gets priority on Spotify's next cycle without competing
+      // with AM's separate queue.
+      const selectedRemote = options.fullSync
+        ? allSelectedRemote
+        : SyncEngine.staggerPlaylistsForCycle({
+            selectedRemote: allSelectedRemote,
+            localPlaylists: currentPlaylists,
+            providerId
+          });
+      if (!options.fullSync && selectedRemote.length < allSelectedRemote.length) {
+        console.log(`[Sync] Staggered ${providerId}: processing ${selectedRemote.length}/${allSelectedRemote.length} oldest-stale this cycle (remainder defers to next cycle)`);
+      }
 
       let playlistsAdded = 0;
       let playlistsUpdated = 0;

--- a/sync-engine/index.js
+++ b/sync-engine/index.js
@@ -361,6 +361,102 @@ const canShortCircuitPlaylistUpdate = ({ localPlaylist, remotePlaylist, provider
   return true;
 };
 
+// Default batch size for staggered playlist sync. With ~50 selected playlists
+// and the 15-min background cadence, 15 per cycle covers everything in roughly
+// 2.5 hours worst-case. Tune via the explicit `batchSize` argument if needed.
+const DEFAULT_STAGGER_BATCH_SIZE = 15;
+
+/**
+ * Stagger selected remote playlists across multiple sync cycles
+ * (parachord#800, part of epic #803). Returns the top N playlists for
+ * this cycle, sorted "oldest stale first" with hasUpdates jumping the
+ * queue and lastModified breaking ties.
+ *
+ * Why: today every sync cycle processes ALL selected remote playlists
+ * for the provider. With 50+ playlists × 3 providers, that's 150+
+ * remote-list comparisons + per-playlist update logic per cycle, every
+ * 15 minutes. Most of that work finds nothing changed (see
+ * `canShortCircuitPlaylistUpdate` for the cheap-iter win). Staggering
+ * cuts the *volume* of work per cycle: only the oldest-stale N get
+ * processed; the rest defer to the next cycle. Over 4-5 cycles the
+ * whole selection is covered.
+ *
+ * Sort order:
+ *   1. `hasUpdates: true` first — user is waiting on a pending pull.
+ *   2. `syncSources[providerId].syncedAt` ascending — oldest-stale next.
+ *      Playlists with no local entry (never imported) treat as 0,
+ *      which floats them to the top of this tier (so first-time
+ *      imports happen on the first cycle after wizard selection).
+ *   3. `lastModified` descending — breaks ties; recent local edits get
+ *      sync priority over dormant playlists.
+ *
+ * Caller is expected to bypass staggering entirely for explicit
+ * full-sync paths (wizard "Sync Now", cleanup-duplicates, etc.) by
+ * NOT calling this helper for those flows.
+ *
+ * Pure / deterministic / no I/O. Does NOT mutate inputs — returns a
+ * new sorted-and-sliced array.
+ *
+ * @param {Object} args
+ * @param {Array} args.selectedRemote - Remote playlists already filtered to
+ *   the user's selected set. Each entry has at minimum `externalId`.
+ * @param {Array} args.localPlaylists - The full `local_playlists` array
+ *   loaded from store at the top of `sync:start`. Used to look up
+ *   `syncSources[providerId].syncedAt`, `hasUpdates`, `lastModified`
+ *   for the staleness sort.
+ * @param {string} args.providerId - Provider running this sync iteration.
+ *   Used both as the syncSources sub-key and for matching local
+ *   playlists via `syncedFrom.externalId` / `syncedTo[providerId].externalId`.
+ * @param {number} [args.batchSize=DEFAULT_STAGGER_BATCH_SIZE] - Max
+ *   playlists to process this cycle.
+ * @returns {Array} Sorted and sliced subset of `selectedRemote`.
+ */
+const staggerPlaylistsForCycle = ({
+  selectedRemote,
+  localPlaylists,
+  providerId,
+  batchSize = DEFAULT_STAGGER_BATCH_SIZE
+}) => {
+  if (!Array.isArray(selectedRemote) || selectedRemote.length === 0) return [];
+
+  // Build externalId → local-playlist map so we don't O(N²) for each
+  // remote in the comparator. A single remote can match either via
+  // syncedFrom (we pulled FROM this provider for this playlist) or
+  // via syncedTo (we pushed TO this provider — i.e. push mirror).
+  const localByExternalId = new Map();
+  if (Array.isArray(localPlaylists)) {
+    for (const p of localPlaylists) {
+      if (!p) continue;
+      if (p.syncedFrom?.externalId) {
+        localByExternalId.set(p.syncedFrom.externalId, p);
+      }
+      const pushedId = p.syncedTo?.[providerId]?.externalId;
+      if (pushedId) {
+        localByExternalId.set(pushedId, p);
+      }
+    }
+  }
+
+  const sorted = [...selectedRemote].sort((a, b) => {
+    const localA = localByExternalId.get(a.externalId);
+    const localB = localByExternalId.get(b.externalId);
+    // 1. hasUpdates first
+    const updA = !!localA?.hasUpdates;
+    const updB = !!localB?.hasUpdates;
+    if (updA !== updB) return updA ? -1 : 1;
+    // 2. Oldest syncedAt next (missing → 0 → top)
+    const tsA = localA?.syncSources?.[providerId]?.syncedAt || 0;
+    const tsB = localB?.syncSources?.[providerId]?.syncedAt || 0;
+    if (tsA !== tsB) return tsA - tsB;
+    // 3. lastModified desc breaks ties (recent local edits → priority)
+    const lmA = localA?.lastModified || 0;
+    const lmB = localB?.lastModified || 0;
+    return lmB - lmA;
+  });
+
+  return sorted.slice(0, batchSize);
+};
+
 module.exports = {
   getProvider,
   getAllProviders,
@@ -368,5 +464,7 @@ module.exports = {
   applyDiff,
   syncDataType,
   calculatePlaylistDiff,
-  canShortCircuitPlaylistUpdate
+  canShortCircuitPlaylistUpdate,
+  staggerPlaylistsForCycle,
+  DEFAULT_STAGGER_BATCH_SIZE
 };

--- a/tests/sync/sync-engine.test.js
+++ b/tests/sync/sync-engine.test.js
@@ -5,7 +5,184 @@
  * Spotify library sync, pagination, diff calculation, rate limiting.
  */
 
-const { canShortCircuitPlaylistUpdate } = require('../../sync-engine');
+const { canShortCircuitPlaylistUpdate, staggerPlaylistsForCycle } = require('../../sync-engine');
+
+describe('staggerPlaylistsForCycle (oldest-stale-first batching, see parachord#800)', () => {
+  // Helper to build a remote-shape playlist (what fetchPlaylists returns).
+  const remote = (externalId) => ({ externalId, name: `Playlist ${externalId}` });
+
+  // Helper to build a local-shape playlist (what's in `local_playlists`).
+  const local = ({ id, externalId, syncedAt, hasUpdates, lastModified }) => ({
+    id: id || `spotify-${externalId}`,
+    title: `Playlist ${externalId}`,
+    syncedFrom: { resolver: 'spotify', externalId },
+    syncSources: syncedAt != null ? { spotify: { syncedAt } } : {},
+    hasUpdates: !!hasUpdates,
+    lastModified: lastModified || 0
+  });
+
+  test('returns all when count <= batchSize', () => {
+    const selected = [remote('a'), remote('b'), remote('c')];
+    const result = staggerPlaylistsForCycle({
+      selectedRemote: selected,
+      localPlaylists: [],
+      providerId: 'spotify',
+      batchSize: 10
+    });
+    expect(result).toHaveLength(3);
+  });
+
+  test('takes top N when count > batchSize', () => {
+    const selected = Array.from({ length: 50 }, (_, i) => remote(`p${i}`));
+    const result = staggerPlaylistsForCycle({
+      selectedRemote: selected,
+      localPlaylists: [],
+      providerId: 'spotify',
+      batchSize: 15
+    });
+    expect(result).toHaveLength(15);
+  });
+
+  test('hasUpdates playlists come first regardless of syncedAt', () => {
+    const selected = [remote('a'), remote('b'), remote('c')];
+    const locals = [
+      local({ externalId: 'a', syncedAt: 1000 }),                       // fresh, no updates
+      local({ externalId: 'b', syncedAt: 500, hasUpdates: true }),      // older, but has updates
+      local({ externalId: 'c', syncedAt: 100 }),                        // oldest, no updates
+    ];
+    const result = staggerPlaylistsForCycle({
+      selectedRemote: selected,
+      localPlaylists: locals,
+      providerId: 'spotify',
+      batchSize: 2
+    });
+    expect(result[0].externalId).toBe('b'); // hasUpdates wins
+    expect(result[1].externalId).toBe('c'); // then oldest syncedAt
+  });
+
+  test('among non-hasUpdates, oldest syncedAt comes first', () => {
+    const selected = [remote('a'), remote('b'), remote('c')];
+    const locals = [
+      local({ externalId: 'a', syncedAt: 3000 }),
+      local({ externalId: 'b', syncedAt: 1000 }),
+      local({ externalId: 'c', syncedAt: 2000 }),
+    ];
+    const result = staggerPlaylistsForCycle({
+      selectedRemote: selected,
+      localPlaylists: locals,
+      providerId: 'spotify',
+      batchSize: 3
+    });
+    expect(result.map(r => r.externalId)).toEqual(['b', 'c', 'a']);
+  });
+
+  test('never-synced playlists (no syncSources entry) sort to top via 0-syncedAt', () => {
+    const selected = [remote('new'), remote('old'), remote('newer')];
+    const locals = [
+      // 'new' has no local entry — first import; treated as syncedAt 0
+      local({ externalId: 'old', syncedAt: 100 }),
+      local({ externalId: 'newer', syncedAt: 200 }),
+    ];
+    const result = staggerPlaylistsForCycle({
+      selectedRemote: selected,
+      localPlaylists: locals,
+      providerId: 'spotify',
+      batchSize: 3
+    });
+    expect(result[0].externalId).toBe('new');   // no local match → 0 syncedAt → top
+    expect(result[1].externalId).toBe('old');
+    expect(result[2].externalId).toBe('newer');
+  });
+
+  test('lastModified descending breaks ties in syncedAt', () => {
+    const selected = [remote('a'), remote('b'), remote('c')];
+    const locals = [
+      local({ externalId: 'a', syncedAt: 1000, lastModified: 500 }),
+      local({ externalId: 'b', syncedAt: 1000, lastModified: 2000 }),
+      local({ externalId: 'c', syncedAt: 1000, lastModified: 1000 }),
+    ];
+    const result = staggerPlaylistsForCycle({
+      selectedRemote: selected,
+      localPlaylists: locals,
+      providerId: 'spotify',
+      batchSize: 3
+    });
+    // All same syncedAt → lastModified desc: b > c > a
+    expect(result.map(r => r.externalId)).toEqual(['b', 'c', 'a']);
+  });
+
+  test('matches local playlist via syncedFrom.externalId', () => {
+    const selected = [remote('xyz')];
+    const locals = [
+      local({ externalId: 'xyz', syncedAt: 999 })
+    ];
+    const result = staggerPlaylistsForCycle({
+      selectedRemote: selected,
+      localPlaylists: locals,
+      providerId: 'spotify',
+      batchSize: 1
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].externalId).toBe('xyz');
+  });
+
+  test('matches local playlist via syncedTo[providerId].externalId (push mirror)', () => {
+    const selected = [remote('am-id-1')];
+    const locals = [
+      {
+        id: 'spotify-something',
+        title: 'Push mirror',
+        syncedFrom: { resolver: 'spotify', externalId: 'spotify-something' },
+        syncedTo: { applemusic: { externalId: 'am-id-1', syncedAt: 500 } },
+        syncSources: { applemusic: { syncedAt: 500 } },
+        hasUpdates: false,
+        lastModified: 0
+      }
+    ];
+    const result = staggerPlaylistsForCycle({
+      selectedRemote: selected,
+      localPlaylists: locals,
+      providerId: 'applemusic',
+      batchSize: 1
+    });
+    expect(result[0].externalId).toBe('am-id-1');
+  });
+
+  test('does not mutate the input array', () => {
+    const selected = [remote('z'), remote('a'), remote('m')];
+    const before = selected.map(r => r.externalId);
+    staggerPlaylistsForCycle({
+      selectedRemote: selected,
+      localPlaylists: [],
+      providerId: 'spotify',
+      batchSize: 10
+    });
+    expect(selected.map(r => r.externalId)).toEqual(before);
+  });
+
+  test('handles empty selectedRemote', () => {
+    const result = staggerPlaylistsForCycle({
+      selectedRemote: [],
+      localPlaylists: [],
+      providerId: 'spotify',
+      batchSize: 15
+    });
+    expect(result).toEqual([]);
+  });
+
+  test('falls back to default batchSize when omitted', () => {
+    const selected = Array.from({ length: 30 }, (_, i) => remote(`p${i}`));
+    const result = staggerPlaylistsForCycle({
+      selectedRemote: selected,
+      localPlaylists: [],
+      providerId: 'spotify'
+      // batchSize omitted
+    });
+    // Default batch size; just verify it's a sensible cap (< 30 since input is 30).
+    expect(result.length).toBeLessThanOrEqual(30);
+    expect(result.length).toBeGreaterThan(0);
+  });
+});
 
 describe('canShortCircuitPlaylistUpdate (inbound sync optimization, see parachord#796)', () => {
   // Helper to build a "happy path" local + remote pair where short-circuit


### PR DESCRIPTION
Tier 2 of epic #803 (lazier sync — reduce CPU spike + pinwheel).

## Summary

Background `sync:start` runs now process the **top N oldest-stale-first** playlists per cycle instead of every selected playlist. With 50 selected × 15-min cadence × batchSize=15, the whole selection covers in ~2.5h worst-case. Cuts per-cycle work proportionally to ~30%.

Complementary to #796 (skip-unchanged, cheaper per-iteration) and #798 (yield-to-idle, mid-iteration responsiveness). Together: less work, more responsive between iterations, and now — less work per cycle.

## How

New pure helper in `sync-engine/index.js`:

```js
staggerPlaylistsForCycle({
  selectedRemote,        // user-selected remote playlists
  localPlaylists,        // full local_playlists from store
  providerId,            // for syncSources lookup + push-mirror match
  batchSize = 15
})
```

Sort order:

1. **`hasUpdates: true` first** — user is waiting on a pending pull.
2. **`syncSources[providerId].syncedAt` ascending** — oldest-stale next. Never-synced playlists (no local entry) treat as 0-syncedAt → float to top, so first-time imports run on the first cycle after wizard selection.
3. **`lastModified` descending** — breaks ties; recent local edits get sync priority over dormant playlists.

Wired into `sync:start` after the existing `selectedPlaylistIds` filter, behind an `options.fullSync` bypass.

## Full-sync bypass

`options.fullSync = true` on the `sync:start` IPC bypasses staggering for user-initiated paths:

- Wizard's `startSync` (post-config "Sync Now")
- The post-syncing-complete "Sync Now" button
- Spotify and AM re-auth-triggered catch-up syncs (the user just reconnected — don't make them wait 4-5 cycles)

`runBackgroundSync` does NOT pass it — that's the cadenced path being staggered.

## Invariants

The clearing pass for "remote playlist no longer exists" continues to use the FULL `remotePlaylists` list from `provider.fetchPlaylists`, not the staggered subset. So deleted-on-remote detection is unaffected by which subset we iterate this cycle.

## Test plan

- [x] 11 new test cases for `staggerPlaylistsForCycle`:
  - Returns all when count ≤ batchSize
  - Takes top N when count > batchSize
  - `hasUpdates` jumps the queue regardless of syncedAt
  - Oldest syncedAt ordering within non-hasUpdates tier
  - Never-synced playlists float to top (no local match → 0 syncedAt)
  - `lastModified` desc breaks syncedAt ties
  - Matches local via `syncedFrom.externalId`
  - Matches local via `syncedTo[providerId].externalId` (push mirrors)
  - Doesn't mutate input array
  - Handles empty `selectedRemote`
  - Default `batchSize` when omitted
- [x] All 1609 tests pass

## Related

- Epic #803.
- Tier 1 (#796, #798) on main. #797 re-land PR #813 in flight.
- Tier 2 #799 (cancel-on-focus) in flight as PR #812. This PR is independent of both.
- Future: per-provider `staggerBatchSize` override in `resolver_sync_settings` for users who want tighter cadence on a specific provider — explicitly NOT done here (YAGNI; default behavior tunable via the one constant if needed).

CLAUDE.md updated with a new "Staggered playlist sync per cycle" subsection covering the sort order, full-sync bypass, and the deleted-on-remote-detection invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
