### PR TITLE
sync: honor cancel signal inside library-fetch paginate loops (#820)

### DIFF
--- a/main.js
+++ b/main.js
@@ -6078,7 +6078,8 @@ ipcMain.handle('sync:start', async (event, providerId, options = {}) => {
         'tracks',
         collection.tracks || [],
         (p) => sendProgress({ phase: 'fetching', type: 'tracks', ...p }),
-        refreshToken
+        refreshToken,
+        isCancelled  // parachord#820: poll between paginated pages
       );
       console.log(`[Sync] Track sync complete. Output: ${trackResult.data.length} tracks. Stats:`, trackResult.stats);
       collection.tracks = trackResult.data;
@@ -6099,7 +6100,8 @@ ipcMain.handle('sync:start', async (event, providerId, options = {}) => {
         'albums',
         collection.albums || [],
         (p) => sendProgress({ phase: 'fetching', type: 'albums', ...p }),
-        refreshToken
+        refreshToken,
+        isCancelled
       );
       console.log(`[Sync] Album sync complete. Output: ${albumResult.data.length} albums. Stats:`, albumResult.stats);
       collection.albums = albumResult.data;
@@ -6120,7 +6122,8 @@ ipcMain.handle('sync:start', async (event, providerId, options = {}) => {
         'artists',
         collection.artists || [],
         (p) => sendProgress({ phase: 'fetching', type: 'artists', ...p }),
-        refreshToken
+        refreshToken,
+        isCancelled
       );
       console.log(`[Sync] Artist sync complete. Output: ${artistResult.data.length} artists. Stats:`, artistResult.stats);
       collection.artists = artistResult.data;

--- a/sync-engine/index.js
+++ b/sync-engine/index.js
@@ -155,9 +155,18 @@ const applyDiff = (collectionItems, diff) => {
 };
 
 /**
- * Sync a specific data type (tracks, albums, artists) for a provider
+ * Sync a specific data type (tracks, albums, artists) for a provider.
+ *
+ * `isCancelled` (optional) is a 0-arg predicate the provider's pagination
+ * loop can poll between pages so a `sync:cancel` IPC takes effect within
+ * one page of latency (~1s) instead of waiting for the entire library
+ * fetch to complete (~90s for a 2,600-track Spotify library). When
+ * cancellation fires mid-paginate, the provider returns `null` to signal
+ * "no usable result — treat as unchanged"; the next phase-boundary
+ * `isCancelled()` check in `sync:start` then routes to `finalizeCancelled`
+ * and the run exits without applying a partial diff. See parachord#820.
  */
-const syncDataType = async (provider, token, dataType, localData, onProgress, refreshToken) => {
+const syncDataType = async (provider, token, dataType, localData, onProgress, refreshToken, isCancelled) => {
   // Count how many local items came from this provider (for incremental check)
   const syncedItems = localData.filter(item => item.syncSources?.[provider.id]);
   const localSyncedCount = syncedItems.length;
@@ -167,7 +176,11 @@ const syncDataType = async (provider, token, dataType, localData, onProgress, re
     const latestDate = latest ? (latest.addedAt || latest.syncSources?.[provider.id]?.addedAt || 0) : 0;
     return itemDate > latestDate ? item : latest;
   }, null);
-  const fetchOptions = { localSyncedCount, localLatestExternalId: mostRecentItem?.externalId || null };
+  const fetchOptions = {
+    localSyncedCount,
+    localLatestExternalId: mostRecentItem?.externalId || null,
+    isCancelled
+  };
 
   // Fetch remote data
   let remoteData;

--- a/sync-providers/applemusic.js
+++ b/sync-providers/applemusic.js
@@ -46,7 +46,11 @@ const generateTrackId = (artist, title, album) => {
  */
 const MAX_RETRIES = 5;
 
-const appleMusicFetch = async (endpoint, developerToken, userToken, allItems = [], onProgress, _retryCount = 0) => {
+const appleMusicFetch = async (endpoint, developerToken, userToken, allItems = [], onProgress, _retryCount = 0, isCancelled = null) => {
+  // Mid-paginate cancel hook (parachord#820). When `isCancelled?.()` fires,
+  // return null so the caller treats the result as "no change to apply"; the
+  // next phase-boundary check in `sync:start` then routes to finalizeCancelled.
+  if (isCancelled?.()) return null;
   const url = endpoint.startsWith('http') ? endpoint : `${APPLE_MUSIC_API_BASE}${endpoint}`;
 
   // Validate pagination URLs stay on the expected host
@@ -72,7 +76,7 @@ const appleMusicFetch = async (endpoint, developerToken, userToken, allItems = [
       }
       const retryAfter = parseInt(response.headers.get('Retry-After') || '5', 10);
       await new Promise(resolve => setTimeout(resolve, retryAfter * 1000));
-      return appleMusicFetch(endpoint, developerToken, userToken, allItems, onProgress, _retryCount + 1);
+      return appleMusicFetch(endpoint, developerToken, userToken, allItems, onProgress, _retryCount + 1, isCancelled);
     }
     if (response.status === 401 || response.status === 403) {
       throw new Error('Apple Music token expired or unauthorized. Please reconnect your Apple Music account.');
@@ -96,7 +100,7 @@ const appleMusicFetch = async (endpoint, developerToken, userToken, allItems = [
     const nextUrl = data.next.startsWith('http')
       ? data.next
       : `https://api.music.apple.com${data.next}`;
-    return appleMusicFetch(nextUrl, developerToken, userToken, combined, onProgress, 0);
+    return appleMusicFetch(nextUrl, developerToken, userToken, combined, onProgress, 0, isCancelled);
   }
 
   return combined;
@@ -204,30 +208,38 @@ const AppleMusicSyncProvider = {
    * @param {string} token - JSON string with { developerToken, userToken }
    * @param {function} onProgress - Progress callback
    */
-  async fetchTracks(token, onProgress) {
+  async fetchTracks(token, onProgress, _refreshToken, { isCancelled } = {}) {
     const { developerToken, userToken } = JSON.parse(token);
     const items = await appleMusicFetch(
       '/me/library/songs?limit=100',
       developerToken,
       userToken,
       [],
-      onProgress
+      onProgress,
+      0,
+      isCancelled
     );
+    // appleMusicFetch returns null when isCancelled fires; propagate up so
+    // syncDataType treats it as "no change" (parachord#820).
+    if (items === null) return null;
     return items.map(transformTrack);
   },
 
   /**
    * Fetch all saved albums from Apple Music
    */
-  async fetchAlbums(token, onProgress) {
+  async fetchAlbums(token, onProgress, _refreshToken, { isCancelled } = {}) {
     const { developerToken, userToken } = JSON.parse(token);
     const items = await appleMusicFetch(
       '/me/library/albums?limit=100',
       developerToken,
       userToken,
       [],
-      onProgress
+      onProgress,
+      0,
+      isCancelled
     );
+    if (items === null) return null;
     return items.map(transformAlbum);
   },
 

--- a/sync-providers/spotify.js
+++ b/sync-providers/spotify.js
@@ -78,9 +78,18 @@ const spotifyRequest = async (endpoint, token, options = {}, _retryCount = 0) =>
 };
 
 /**
- * Make an authenticated Spotify API request with pagination support
+ * Make an authenticated Spotify API request with pagination support.
+ *
+ * `isCancelled` is an optional 0-arg predicate polled at the start of each
+ * paginate iteration (parachord#820). When it returns true mid-fetch, the
+ * helper returns `null` to signal "abort — discard partial result." Callers
+ * map a null return to a null `fetchTracks`/`fetchAlbums`/`fetchArtists`
+ * result, which `syncDataType` interprets as "no change to apply" — safe
+ * because the next phase-boundary cancel check in `sync:start` will fire
+ * within milliseconds and route to `finalizeCancelled`.
  */
-const spotifyFetch = async (endpoint, token, allItems = [], onProgress, refreshToken, _retryCount = 0) => {
+const spotifyFetch = async (endpoint, token, allItems = [], onProgress, refreshToken, _retryCount = 0, isCancelled = null) => {
+  if (isCancelled?.()) return null;
   const url = endpoint.startsWith('http') ? endpoint : `${SPOTIFY_API_BASE}${endpoint}`;
 
   // Validate pagination URLs stay on the expected host
@@ -106,7 +115,7 @@ const spotifyFetch = async (endpoint, token, allItems = [], onProgress, refreshT
       // Rate limited - get retry-after header
       const retryAfter = parseInt(response.headers.get('Retry-After') || '5', 10);
       await new Promise(resolve => setTimeout(resolve, retryAfter * 1000));
-      return spotifyFetch(endpoint, token, allItems, onProgress, refreshToken, _retryCount + 1);
+      return spotifyFetch(endpoint, token, allItems, onProgress, refreshToken, _retryCount + 1, isCancelled);
     }
     // Retry on transient server errors (502, 503, 504) with exponential backoff
     if ([502, 503, 504].includes(response.status)) {
@@ -115,14 +124,14 @@ const spotifyFetch = async (endpoint, token, allItems = [], onProgress, refreshT
       }
       const delay = Math.min(1000 * Math.pow(2, _retryCount), 30000);
       await new Promise(resolve => setTimeout(resolve, delay));
-      return spotifyFetch(endpoint, token, allItems, onProgress, refreshToken, _retryCount + 1);
+      return spotifyFetch(endpoint, token, allItems, onProgress, refreshToken, _retryCount + 1, isCancelled);
     }
     // Only refresh on 401 (expired token). 403 means insufficient scopes —
     // refreshing gives the same scopes, so retrying would be wasteful.
     if (response.status === 401 && refreshToken) {
       const newToken = await refreshToken();
       if (newToken) {
-        return spotifyFetch(endpoint, newToken, allItems, onProgress, null, 0);
+        return spotifyFetch(endpoint, newToken, allItems, onProgress, null, 0, isCancelled);
       }
     }
     if (response.status === 401) {
@@ -146,7 +155,7 @@ const spotifyFetch = async (endpoint, token, allItems = [], onProgress, refreshT
   if (data.next) {
     // Small delay to avoid rate limiting
     await new Promise(resolve => setTimeout(resolve, 100));
-    return spotifyFetch(data.next, token, combined, onProgress, refreshToken, 0);
+    return spotifyFetch(data.next, token, combined, onProgress, refreshToken, 0, isCancelled);
   }
 
   return combined;
@@ -266,7 +275,7 @@ const SpotifySyncProvider = {
    * returns null when the remote total matches AND the most recent track
    * is the same (no changes → skip full fetch).
    */
-  async fetchTracks(token, onProgress, refreshToken, { localSyncedCount, localLatestExternalId } = {}) {
+  async fetchTracks(token, onProgress, refreshToken, { localSyncedCount, localLatestExternalId, isCancelled } = {}) {
     // Quick check: 1 API call to see if the library size or most recent track changed
     if (localSyncedCount !== undefined) {
       const probe = await spotifyRequest('/me/tracks?limit=1', token, { refreshToken });
@@ -281,7 +290,11 @@ const SpotifySyncProvider = {
         console.log(`[Spotify] Track count same (${probe.total}) but latest track differs: remote ${remoteLatestId} vs local ${localLatestExternalId}`);
       }
     }
-    const items = await spotifyFetch('/me/tracks?limit=50', token, [], onProgress, refreshToken);
+    const items = await spotifyFetch('/me/tracks?limit=50', token, [], onProgress, refreshToken, 0, isCancelled);
+    // spotifyFetch returns null when isCancelled fires mid-paginate. Propagate
+    // up — syncDataType treats null as "no change to apply", and sync:start's
+    // next phase-boundary check exits via finalizeCancelled.
+    if (items === null) return null;
     return items.map(item => transformTrack(item, item.added_at));
   },
 
@@ -289,7 +302,7 @@ const SpotifySyncProvider = {
    * Fetch all saved albums from Spotify.
    * Returns null when remote count and latest album match (no changes).
    */
-  async fetchAlbums(token, onProgress, refreshToken, { localSyncedCount, localLatestExternalId } = {}) {
+  async fetchAlbums(token, onProgress, refreshToken, { localSyncedCount, localLatestExternalId, isCancelled } = {}) {
     if (localSyncedCount !== undefined) {
       const probe = await spotifyRequest('/me/albums?limit=1', token, { refreshToken });
       const remoteLatestId = probe.items?.[0]?.album?.id || null;
@@ -303,7 +316,8 @@ const SpotifySyncProvider = {
         console.log(`[Spotify] Album count same (${probe.total}) but latest album differs: remote ${remoteLatestId} vs local ${localLatestExternalId}`);
       }
     }
-    const items = await spotifyFetch('/me/albums?limit=50', token, [], onProgress, refreshToken);
+    const items = await spotifyFetch('/me/albums?limit=50', token, [], onProgress, refreshToken, 0, isCancelled);
+    if (items === null) return null;
     return items.map(transformAlbum);
   },
 
@@ -311,7 +325,7 @@ const SpotifySyncProvider = {
    * Fetch all followed artists from Spotify.
    * Returns null when remote count and latest artist match (no changes).
    */
-  async fetchArtists(token, onProgress, refreshToken, { localSyncedCount, localLatestExternalId } = {}) {
+  async fetchArtists(token, onProgress, refreshToken, { localSyncedCount, localLatestExternalId, isCancelled } = {}) {
     // Quick count check for artists (first page includes total)
     if (localSyncedCount !== undefined) {
       const probeData = await spotifyRequest('/me/following?type=artist&limit=1', token, { refreshToken });
@@ -325,9 +339,12 @@ const SpotifySyncProvider = {
         console.log(`[Spotify] Artist count changed: remote ${remoteTotal} vs local ${localSyncedCount}`);
       }
     }
-    // Artists use cursor-based pagination, different from other endpoints
+    // Artists use cursor-based pagination, different from other endpoints.
+    // Same isCancelled gating as spotifyFetch (parachord#820): poll between
+    // pages and return null on cancel so the partial result is discarded.
     let currentRefreshToken = refreshToken;
     const fetchArtistsPage = async (after = null, allArtists = []) => {
+      if (isCancelled?.()) return null;
       const url = `/me/following?type=artist&limit=50${after ? `&after=${after}` : ''}`;
       const data = await spotifyRequest(url, token, { refreshToken: currentRefreshToken });
       // Only allow one refresh attempt across all pages
@@ -349,6 +366,7 @@ const SpotifySyncProvider = {
     };
 
     const artists = await fetchArtistsPage();
+    if (artists === null) return null;
     return artists.map(transformArtist);
   },
 

--- a/tests/sync/sync-engine.test.js
+++ b/tests/sync/sync-engine.test.js
@@ -5,7 +5,7 @@
  * Spotify library sync, pagination, diff calculation, rate limiting.
  */
 
-const { canShortCircuitPlaylistUpdate, staggerPlaylistsForCycle } = require('../../sync-engine');
+const { canShortCircuitPlaylistUpdate, staggerPlaylistsForCycle, syncDataType } = require('../../sync-engine');
 
 describe('staggerPlaylistsForCycle (oldest-stale-first batching, see parachord#800)', () => {
   // Helper to build a remote-shape playlist (what fetchPlaylists returns).
@@ -1358,5 +1358,80 @@ describe('Track Removal with Special Characters', () => {
       collectionTracks
     );
     expect(result.removed).toBe(true);
+  });
+});
+
+describe('syncDataType isCancelled propagation (parachord#820)', () => {
+  // Minimal provider stub. fetchTracks consults the isCancelled callback from
+  // the options bag the same way the real Spotify/AM providers do, mirroring
+  // the mid-paginate cancel path: when isCancelled fires, return null so
+  // syncDataType treats the result as "no change to apply" rather than
+  // computing a diff against partial data.
+  const makeProvider = ({ trackData = [], onFetch = null } = {}) => ({
+    id: 'spotify',
+    fetchTracks: jest.fn(async (token, onProgress, refreshToken, opts = {}) => {
+      if (onFetch) onFetch();
+      if (opts.isCancelled?.()) return null;
+      return trackData;
+    }),
+    fetchAlbums: jest.fn(async () => []),
+    fetchArtists: jest.fn(async () => [])
+  });
+
+  const localTrack = (id) => ({
+    id, title: `t${id}`, artist: `a${id}`, album: `A${id}`,
+    syncSources: { spotify: { syncedAt: 100 } }
+  });
+
+  test('returns localData unchanged with stats 0/0/0/N when isCancelled fires before fetch', async () => {
+    const local = [localTrack('1'), localTrack('2'), localTrack('3')];
+    const provider = makeProvider({ trackData: [localTrack('1')] }); // would-be removal of 2,3
+
+    const result = await syncDataType(
+      provider, 'token', 'tracks', local, () => {}, null,
+      () => true  // already cancelled
+    );
+
+    expect(result.data).toBe(local); // same reference — no diff applied
+    expect(result.stats).toEqual({ added: 0, removed: 0, updated: 0, unchanged: 3 });
+  });
+
+  test('passes isCancelled through fetchOptions to the provider', async () => {
+    const isCancelled = jest.fn(() => false);
+    const provider = makeProvider({ trackData: [] });
+
+    await syncDataType(provider, 'token', 'tracks', [], () => {}, null, isCancelled);
+
+    expect(provider.fetchTracks).toHaveBeenCalledWith(
+      'token',
+      expect.any(Function),
+      null,
+      expect.objectContaining({ isCancelled })
+    );
+  });
+
+  test('omitting isCancelled is backward-compatible (provider receives undefined)', async () => {
+    const provider = makeProvider({ trackData: [] });
+
+    await syncDataType(provider, 'token', 'tracks', [], () => {}, null);
+
+    const opts = provider.fetchTracks.mock.calls[0][3];
+    expect(opts.isCancelled).toBeUndefined();
+  });
+
+  test('full diff still applies when isCancelled never fires', async () => {
+    const local = [localTrack('1')];
+    const provider = makeProvider({ trackData: [
+      { id: '1', title: 't1', artist: 'a1', album: 'A1' },
+      { id: '2', title: 't2', artist: 'a2', album: 'A2' }
+    ]});
+
+    const result = await syncDataType(
+      provider, 'token', 'tracks', local, () => {}, null,
+      () => false
+    );
+
+    expect(result.stats.added).toBe(1);
+    expect(result.data.length).toBe(2);
   });
 });


### PR DESCRIPTION
Closes #820.

## The bug, in one paragraph

The `isCancelled` flag added in #799 was only polled at major **phase boundaries** in `sync:start` — between tracks → albums → artists → playlists. But the actual library-fetch work happens **inside** `SyncEngine.syncDataType` → `provider.fetchTracks/Albums/Artists`, and those didn't see the flag at all. For a user with ~2,600 liked Spotify tracks, the tracks-phase runs 30–90s of paginated `/v1/me/tracks?offset=N` calls; a `sync:cancel` IPC during that window would flip the flag but the run would continue through every page until the phase completed.

## How that manifests in real use

Combined with #799's cancel-on-focus, a user actively interacting with Parachord effectively can't sync at all:

1. Focus event → cancel flag set
2. Tracks-fetch keeps running (90s drain)
3. Manual "Sync Now" attempt → rejected (`{success: false, error: 'Sync already in progress'}`)
4. User clicks anywhere → another focus event → flag re-set
5. Repeat. Daily Brew never gets pulled.

Diagnosed today during a live debugging session — 2 hours of investigation, captured in #820.

## What this PR does

Threads `isCancelled` (a 0-arg predicate) through the existing options bag:

- **`SyncEngine.syncDataType`** — new 7th parameter, passed via `fetchOptions`.
- **`Spotify.fetchTracks/Albums/Artists`** — pluck `isCancelled` from options, thread into the paginator (`spotifyFetch` for tracks/albums, `fetchArtistsPage` for cursor-based artists). Both check the flag at the start of each paginate iteration and return `null` on cancel.
- **`Apple Music.fetchTracks/Albums`** — same pattern; `appleMusicFetch` paginator checks at the top of each call.
- **`main.js sync:start`** — pass `isCancelled` (already declared at L6020) into each of the three `SyncEngine.syncDataType` calls.

## Cancel propagation contract (the load-bearing part)

When `isCancelled?.()` fires mid-paginate, the paginator returns `null` instead of accumulated-so-far. The provider's `fetchTracks/Albums/Artists` method receives `null` and returns `null`. `syncDataType` already has a `remoteData === null` path (the existing \"count check passed, nothing changed\" branch) that returns `{ data: localData, stats: 0/0/0/N }`. Back in `sync:start`, the next phase-boundary `isCancelled()` check fires within milliseconds and routes to `finalizeCancelled`.

**Safety property**: a partial paginate result is **never** fed to `applyDiff`. The `null` short-circuits before any diff that would have seen a flood of \"missing\" items and triggered the mass-removal safeguard (or, worse, silently lost data if the safeguard threshold didn't kick in).

## Result

Worst-case cancel-response latency drops from **~2 minutes to ~1 second** — one paginate-iteration plus the in-flight network call.

## Test plan

- [x] 4 new focused tests in `tests/sync/sync-engine.test.js`:
  - pre-fetch cancel → returns local unchanged with 0/0/0/N
  - `isCancelled` propagated through `fetchOptions` to the provider
  - omitting `isCancelled` is backward-compatible (provider receives `undefined`)
  - full diff still applies when `isCancelled` never fires
- [x] All 1628 tests pass (1624 previous + 4 new)
- [x] Node syntax check passes on all 5 modified files
- [ ] Manual: trigger sync on a >1000-track Spotify library, fire `sync.cancel` mid-tracks-phase, verify exit ≤2s
- [ ] Manual: subsequent `sync.start` succeeds immediately after the cancel exits

## Out of scope (deferred)

- `fetchPlaylists` / `fetchPlaylistTracks` paginator-cancel. `sync:start` already has per-iteration cancel inside the inbound playlist loop (#799). The `fetchPlaylists` API call itself is typically fast (<5s even for large users), so it doesn't have the catastrophic UX impact of a 90s tracks-fetch.
- ListenBrainz `fetchPlaylists` while-loop. Same reason.

## Related

- #820 — this PR's ticket
- #799 — surfaced this latency as a real DoS
- #821 — partner fix (cancel-on-focus shouldn't fire on Parachord-internal events); together with this PR fully cures the \"interacting starves sync\" problem
- #803 — sync perf epic umbrella

🤖 Generated with [Claude Code](https://claude.com/claude-code)