### PR TITLE
sync: preserve syncedTo when re-importing hosted XSPF playlists

### DIFF
--- a/app.js
+++ b/app.js
@@ -35241,14 +35241,40 @@ Variety guidance: ${theme} Be creative and surprising — avoid defaulting to th
       const playlistTitle = metadataOverrides?.title || parsed.title;
       const playlistCreator = metadataOverrides?.creator ?? parsed.creator;
 
+      // Look up the on-disk record FIRST — disk is the source of truth for
+      // `syncedTo` / `syncedFrom` / `syncSources` even when React state is
+      // temporarily stale (e.g. background-sync reload race, or any other
+      // setPlaylists path that hasn't observed the latest hosted-import
+      // write yet). Without this, a hosted-XSPF re-import where the React
+      // state lookup misses falls into the "add new" branch below and
+      // produces a fresh record with NO sync state — next sync push loop
+      // then treats it as needing create-on-each-provider. main.js's
+      // three-layer dedup saves us from duplicate remote creation, but
+      // each cycle still pays the full clear-and-add cost (track-MBID
+      // resolution + delete + add for LB; same shape for other providers).
+      // Holding `playlistSyncInProgressRef` for the full marathon also
+      // starves other providers' playlist-diff phase (see Daily Brew not
+      // syncing during the LB hosted-mirror push window).
+      let existingOnDisk = null;
+      try {
+        const onDisk = await window.electron.playlists.load();
+        existingOnDisk = onDisk.find(p => p.sourceUrl === url || p.id === id);
+      } catch (e) {
+        console.warn('Failed to load on-disk playlists for hosted-import dedup:', e);
+      }
+
       // Check if playlist already exists (use updater form to avoid stale closure)
       let didUpdate = false;
       let updatedPlaylist = null;
       setPlaylists(prev => {
-        const existingIndex = prev.findIndex(p => p.sourceUrl === url);
-        if (existingIndex >= 0) {
+        const existingIndex = prev.findIndex(p => p.sourceUrl === url || p.id === id);
+        // React state takes precedence when present (it's the freshest write
+        // path); fall back to the on-disk record when React state is stale.
+        // The branch reached either way preserves `syncedTo` / `syncedFrom`
+        // / `syncSources` via the `...existing` spread.
+        const existing = existingIndex >= 0 ? prev[existingIndex] : existingOnDisk;
+        if (existing) {
           didUpdate = true;
-          const existing = prev[existingIndex];
           // Mark as locally modified only if the XSPF content actually changed —
           // so the sync loop pushes XSPF-driven updates to providers, but startup
           // reloads with unchanged content don't trigger spurious pushes.
@@ -35262,7 +35288,14 @@ Variety guidance: ${theme} Be creative and surprising — avoid defaulting to th
             lastUpdated: Date.now(),
             ...(contentChanged ? { locallyModified: true, lastModified: Date.now() } : {})
           };
-          return prev.map((p, i) => i === existingIndex ? updatedPlaylist : p);
+          if (existingIndex >= 0) {
+            return prev.map((p, i) => i === existingIndex ? updatedPlaylist : p);
+          }
+          // Existed on disk but not in React state — restore it. Without
+          // this, the "add new" branch below would create a duplicate
+          // playlist entry on next save, and the sync push loop would still
+          // see the fresh entry (no sync state) and re-push everything.
+          return [updatedPlaylist, ...prev];
         }
         return prev;
       });


### PR DESCRIPTION
Resolves the immediate state-hygiene piece of today's "Daily Brew didn't sync" investigation.

## The bug, in one paragraph

`handleImportPlaylistFromUrl` consulted only React state when deciding "update existing vs add new." Background sync's `playlists.load()` + `setPlaylists(...)` can race with the hosted-XSPF poller, momentarily leaving the hosted playlist absent from React state while disk still has it. When that race hits, the import fell into the "add new" branch and produced a fresh record with no `syncedTo` / `syncedFrom` / `syncSources`. Same regression class as the one CLAUDE.md flags at the top of the sync invariants: "Don't drop `syncedTo` on save."

## Symptom in today's log

Six hosted-XSPF playlists re-imported. Renderer logged `✅ Imported hosted playlist: X` (the "new" branch) every time — never `🔄 Updated hosted playlist: X` (the "existing" branch). Next LB push loop saw no `syncedTo[listenbrainz]` on each, called `sync.createPlaylist`. main.js's three-layer dedup correctly found the existing LB playlist via `sync_playlist_links` (same `8efa9606-...` MBID as yesterday for WFUV Rewind), but the path is logged renderer-side as `[Sync] Created playlist <name> on listenbrainz: <existing-MBID>` because the IPC succeeded. That's the renderer-side log misleadingly framing a link-to-existing as a create.

## Fix

`handleImportPlaylistFromUrl` now:

1. Calls `playlists.load()` before the `setPlaylists` lookup, captures any existing on-disk record for the URL/id.
2. Inside `setPlaylists(prev => ...)`, treats the playlist as "existing" if **either** React state OR disk has it. The `...existing` spread carries `syncedTo` / `syncedFrom` / `syncSources` / `hasUpdates` / `locallyModified` / `lastModified` either way.
3. If found only on disk, prepends the restored record into React state so subsequent reads in the same session see the correct shape.

The "add new" branch is unchanged — it's now correctly only reached for genuinely new hosted playlists (no record on disk, no record in state).

## What this does NOT fix

The expensive LB clear-and-add (and equivalent on other providers) still fires on every re-import because `locallyModified: true` is set whenever XSPF content actually changed. To shorten the LB push marathon — and stop starving sibling providers' playlist-diff phase via the global `playlistSyncInProgressRef` — separate follow-ups needed:

- **Short-circuit `updatePlaylistTracks` when remote tracks already match.** Mirrors what #796 does for the inbound direction.
- OR **per-provider mutex** instead of the current global one.

Will file both. This PR is the state-hygiene fix that lands first regardless.

## Test plan

- [x] Node syntax check passes
- [x] All 1628 tests pass
- [ ] Manual: import a hosted-XSPF playlist, sync it to LB, wait for next hosted-XSPF poll with upstream content change. Renderer should now log `[Sync] Pushing updates for "<name>" to listenbrainz` (push branch) instead of `[Sync] Created playlist "<name>" on listenbrainz: <existing-MBID>` (the misleading create-or-link line we've been seeing).
- [ ] Inspect `local_playlists` between hosted-XSPF polls: `syncedTo.listenbrainz.externalId` should remain present (was momentarily vanishing before this PR).

## Related

- Today's debug session showed a 6-playlist LB push marathon (~6 minutes) holding `playlistSyncInProgressRef`, starving Spotify's playlist-diff phase, leaving Daily Brew un-synced. This PR is one of two needed to close out that root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)