### PR TITLE
sync: per-provider mutex for playlist push loops (#831)

### DIFF
--- a/app.js
+++ b/app.js
@@ -6342,10 +6342,21 @@ const Parachord = () => {
   const resolverSyncSettingsRef = useRef(resolverSyncSettings);
   useEffect(() => { resolverSyncSettingsRef.current = resolverSyncSettings; }, [resolverSyncSettings]);
 
-  // Mutex to prevent concurrent playlist creation across background and manual sync paths.
-  // Without this, both paths can load playlists simultaneously, both see a playlist
-  // without syncedTo[providerId], and both create it on the remote — producing duplicates.
-  const playlistSyncInProgressRef = useRef(false);
+  // Per-provider mutex to prevent concurrent playlist creation for the same
+  // (local, provider) pair across the background-sync push loop and the
+  // post-wizard IIFE push loop. Without this, both paths can load playlists
+  // simultaneously, both see a playlist without syncedTo[providerId], and
+  // both call sync.createPlaylist on the same provider — producing duplicates.
+  //
+  // Previously a single boolean ref — too coarse. When one provider's push
+  // loop held it (e.g. an LB hosted-mirror push marathon taking minutes due
+  // to per-track MBID resolution + clear-and-add), every other provider's
+  // playlist phase that fired during that window got skipped entirely.
+  // Spotify's Daily Brew snapshot-diff check was starved that way (see
+  // parachord#831). The race the mutex actually needs to prevent is
+  // per-(local, provider) concurrent create — different providers' push
+  // loops touching different remote spaces don't race with each other.
+  const playlistSyncInProgressRef = useRef(new Set());
 
   // Cancel-on-focus infrastructure (parachord#799).
   //
@@ -6445,11 +6456,13 @@ const Parachord = () => {
                   }
                 }
               // Auto-sync local playlists to this provider
-              // Guard with mutex to prevent concurrent creation across background + manual sync
-              if (playlistSyncInProgressRef.current) {
-                console.log(`[Sync] Playlist sync already in progress, skipping background playlist sync for ${providerId}`);
+              // Guard with per-provider mutex to prevent concurrent creation
+              // across background + manual sync paths for the same provider.
+              // A different provider's in-flight push doesn't gate this one.
+              if (playlistSyncInProgressRef.current.has(providerId)) {
+                console.log(`[Sync] Playlist sync already in progress for ${providerId}, skipping background playlist sync`);
               } else {
-              playlistSyncInProgressRef.current = true;
+              playlistSyncInProgressRef.current.add(providerId);
               try {
                 const allPlaylists = await window.electron.playlists.load();
                 let playlistsChanged = false;
@@ -6706,7 +6719,7 @@ const Parachord = () => {
               } catch (err) {
                 console.warn(`[Sync] Local playlist sync failed for ${providerId}:`, err.message);
               } finally {
-                playlistSyncInProgressRef.current = false;
+                playlistSyncInProgressRef.current.delete(providerId);
               }
               } // end mutex guard
 
@@ -10827,11 +10840,13 @@ const Parachord = () => {
       (async () => {
         console.log(`[Sync] Post-sync IIFE started for ${providerId}`);
 
-        // Guard with mutex to prevent concurrent creation across background + manual sync
-        if (playlistSyncInProgressRef.current) {
-          console.log(`[Sync] Playlist sync already in progress, skipping manual playlist creation for ${providerId}`);
+        // Guard with per-provider mutex (parachord#831). Concurrent push for
+        // the SAME (local, provider) pair from the background sync loop is
+        // the race; different providers don't race with each other.
+        if (playlistSyncInProgressRef.current.has(providerId)) {
+          console.log(`[Sync] Playlist sync already in progress for ${providerId}, skipping manual playlist creation`);
         } else {
-          playlistSyncInProgressRef.current = true;
+          playlistSyncInProgressRef.current.add(providerId);
           try {
             const allPlaylists = await window.electron.playlists.load();
             let playlistsChanged = false;
@@ -11021,7 +11036,7 @@ const Parachord = () => {
           } catch (err) {
             console.warn('[Sync] Local playlist auto-create failed after manual sync:', err.message);
           } finally {
-            playlistSyncInProgressRef.current = false;
+            playlistSyncInProgressRef.current.delete(providerId);
           }
         } // end mutex guard
 
@@ -35250,11 +35265,13 @@ Variety guidance: ${theme} Be creative and surprising — avoid defaulting to th
       // produces a fresh record with NO sync state — next sync push loop
       // then treats it as needing create-on-each-provider. main.js's
       // three-layer dedup saves us from duplicate remote creation, but
-      // each cycle still pays the full clear-and-add cost (track-MBID
-      // resolution + delete + add for LB; same shape for other providers).
-      // Holding `playlistSyncInProgressRef` for the full marathon also
-      // starves other providers' playlist-diff phase (see Daily Brew not
-      // syncing during the LB hosted-mirror push window).
+      // each cycle would still pay the full clear-and-add cost without
+      // the inline-content short-circuit (parachord#832) AND without
+      // this state-preservation fix routing through the correct push
+      // path. The per-provider mutex (parachord#831) is the last layer:
+      // even when one provider's push DOES have legitimate work, sibling
+      // providers' playlist-diff phases now proceed in parallel rather
+      // than getting starved.
       let existingOnDisk = null;
       try {
         const onDisk = await window.electron.playlists.load();


### PR DESCRIPTION
Closes #831. Third and final fix in today's "Daily Brew didn't sync" investigation, after #830 (state hygiene) and #832 (per-push perf).

## The bug

`playlistSyncInProgressRef` was a single global boolean acquired before any provider's playlist push loop and released in `finally`. The race it was originally added for is genuinely per-(local, provider) — two code paths calling `sync.createPlaylist` for the same playlist on the same remote — but the implementation gated **every other provider too**.

Observed today: a 6-playlist LB hosted-mirror push marathon held the ref continuously for ~6 minutes. Every Spotify and AM background sync that fired during that window saw:

\`\`\`
[Sync] Playlist sync already in progress, skipping background playlist sync for spotify
\`\`\`

Net effect: Spotify's Daily Brew snapshot-diff was never computed. SmartPlaylists had rotated today's content. `hasUpdates` stayed false, no "Pull updates" banner.

## What lands

`playlistSyncInProgressRef.current` changes from `false` (boolean) to `new Set<providerId>()`. Four touch sites in lockstep:

- Background-sync push loop acquire/release
- Post-wizard IIFE push loop acquire/release

Both check `.has(providerId)` and use `.add(providerId)` / `.delete(providerId)`. Log messages now lead with the provider name.

Also refreshed two comments — the mutex declaration block and the stale "starves other providers" warning in `handleImportPlaylistFromUrl` that PR #830 left as a note.

## Race protection preserved

A second concurrent code path trying to acquire the mutex for the **same provider** still gets gated. The original duplicate-create race (background loop + post-wizard IIFE both calling `sync.createPlaylist` for the same `(local, spotify)` pair) still serializes through both the renderer-side per-provider mutex AND main.js's three-layer dedup. The only behavior change: a Spotify push loop and an LB push loop now run in parallel — they target different remote services and don't race with each other.

## Together with the recently-merged sync work

| PR | Layer | What it fixes |
|---|---|---|
| #830 | State hygiene | Hosted-XSPF re-import preserves `syncedTo` — renderer takes the right push branch |
| #832 | Per-push perf | `updatePlaylistTracks` short-circuits when remote already matches — common no-op case collapses to one GET |
| **#833 (this PR)** | Cross-provider safety net | Different providers' push loops run in parallel — slow single-provider pushes don't starve siblings |

After all three land, today's specific failure mode (LB hosted-mirror push marathon starving Spotify's Daily Brew diff) is structurally impossible.

## Test plan

- [x] Node syntax check passes
- [x] All 1637 tests pass (no test additions — pure refactor of a single render-side state ref, covered by existing flow tests)
- [ ] Manual: trigger a multi-provider sync where one provider (LB) has slow work. Other providers' background syncs should now run their playlist phases in parallel. Watch main-process log for normal `[Sync] Playlist has updates: X` / `[Sync] Skipping unchanged playlist: X` lines during the slow LB marathon, instead of the previous `[Sync] Playlist sync already in progress, skipping`.

## Related

- #820 — sibling starvation pattern (cancel signal inside paginate loops), same architectural shape: a coarse gate starving siblings; per-X gating fixes it.
- #830, #832 — the rest of today's three-piece fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)