### PR TITLE
sync: drop hasUpdates-first stagger sort priority (#835)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,9 +201,10 @@ The handlers use `window.electron.app.onBackground` / `onForeground` (preload br
 
 `staggerPlaylistsForCycle` (sync-engine/index.js) is the pure sort+slice helper. Sort order:
 
-1. `hasUpdates: true` first — user is waiting on a pending pull.
-2. `syncSources[providerId].syncedAt` ascending — oldest-stale next. Playlists with no local entry sort to top (first-time imports run on the first cycle after wizard selection).
-3. `lastModified` descending — breaks ties; recent local edits get sync priority over dormant playlists.
+1. `syncSources[providerId].syncedAt` ascending — oldest-stale first. Playlists with no local entry sort to top (first-time imports run on the first cycle after wizard selection).
+2. `lastModified` descending — breaks ties; recent local edits get sync priority over dormant playlists.
+
+**`hasUpdates: true` is NOT a sort priority** (parachord#835). Earlier the sort put hasUpdates-true playlists first on the reasoning that the user is "waiting on a pending pull" — but hasUpdates is a state flag, not an action signal. Once set, the banner is already visible in the UI and re-running sync on the playlist doesn't change anything (the inbound diff just re-confirms what we already know; `stillHasUpdates` keeps the local snapshotId pinned to the pre-detection value until the user actually pulls). When N playlists accumulate hasUpdates=true (easy with daily/weekly algorithmic playlists the user hasn't acted on), they monopolize every batch and the syncedAt-asc tail starves — discovery of NEW pending updates (e.g. Daily Brew rotating from yesterday's content to today's) never happens. Pure syncedAt-asc keeps discovery on its target ~2.5h-worst-case cadence regardless of how many hasUpdates banners are outstanding.
 
 **Full-sync bypass** via `options.fullSync = true` on the `sync:start` IPC. All renderer-side user-initiated sync paths pass it: wizard "Sync Now" (post-config + post-syncing-complete), Spotify/AM re-auth catch-up triggers. `runBackgroundSync` does NOT pass it — that's the cadenced path the stagger targets.
 

--- a/sync-engine/index.js
+++ b/sync-engine/index.js
@@ -382,8 +382,8 @@ const DEFAULT_STAGGER_BATCH_SIZE = 15;
 /**
  * Stagger selected remote playlists across multiple sync cycles
  * (parachord#800, part of epic #803). Returns the top N playlists for
- * this cycle, sorted "oldest stale first" with hasUpdates jumping the
- * queue and lastModified breaking ties.
+ * this cycle, sorted "oldest stale first" with lastModified breaking
+ * ties.
  *
  * Why: today every sync cycle processes ALL selected remote playlists
  * for the provider. With 50+ playlists × 3 providers, that's 150+
@@ -395,13 +395,29 @@ const DEFAULT_STAGGER_BATCH_SIZE = 15;
  * whole selection is covered.
  *
  * Sort order:
- *   1. `hasUpdates: true` first — user is waiting on a pending pull.
- *   2. `syncSources[providerId].syncedAt` ascending — oldest-stale next.
+ *   1. `syncSources[providerId].syncedAt` ascending — oldest-stale first.
  *      Playlists with no local entry (never imported) treat as 0,
- *      which floats them to the top of this tier (so first-time
- *      imports happen on the first cycle after wizard selection).
- *   3. `lastModified` descending — breaks ties; recent local edits get
+ *      which floats them to the top (so first-time imports happen on
+ *      the first cycle after wizard selection).
+ *   2. `lastModified` descending — breaks ties; recent local edits get
  *      sync priority over dormant playlists.
+ *
+ * **`hasUpdates: true` is NOT a sort priority.** Earlier the sort
+ * put hasUpdates-true playlists first, on the reasoning that the user
+ * is "waiting on a pending pull." But hasUpdates is a state flag, not
+ * an action signal — once it's set, the banner is already visible in
+ * the UI and re-running sync on the playlist doesn't change anything
+ * (the inbound diff just re-confirms what we already know;
+ * `stillHasUpdates` keeps the local snapshotId pinned to the
+ * pre-detection value until the user actually pulls).
+ *
+ * The starvation pathology: when N playlists accumulate hasUpdates=true
+ * (because the user hasn't acted on them yet — easy with daily/weekly
+ * algorithmic playlists), they monopolize every staggered batch and
+ * the syncedAt-asc tail never makes progress. Discovery of NEW
+ * pending updates (Daily Brew flipping from "yesterday's content"
+ * to "today's content") never happens because Daily Brew sits at
+ * position N+1 forever. See parachord#835.
  *
  * Caller is expected to bypass staggering entirely for explicit
  * full-sync paths (wizard "Sync Now", cleanup-duplicates, etc.) by
@@ -415,8 +431,8 @@ const DEFAULT_STAGGER_BATCH_SIZE = 15;
  *   the user's selected set. Each entry has at minimum `externalId`.
  * @param {Array} args.localPlaylists - The full `local_playlists` array
  *   loaded from store at the top of `sync:start`. Used to look up
- *   `syncSources[providerId].syncedAt`, `hasUpdates`, `lastModified`
- *   for the staleness sort.
+ *   `syncSources[providerId].syncedAt` and `lastModified` for the
+ *   staleness sort.
  * @param {string} args.providerId - Provider running this sync iteration.
  *   Used both as the syncSources sub-key and for matching local
  *   playlists via `syncedFrom.externalId` / `syncedTo[providerId].externalId`.
@@ -453,15 +469,11 @@ const staggerPlaylistsForCycle = ({
   const sorted = [...selectedRemote].sort((a, b) => {
     const localA = localByExternalId.get(a.externalId);
     const localB = localByExternalId.get(b.externalId);
-    // 1. hasUpdates first
-    const updA = !!localA?.hasUpdates;
-    const updB = !!localB?.hasUpdates;
-    if (updA !== updB) return updA ? -1 : 1;
-    // 2. Oldest syncedAt next (missing → 0 → top)
+    // 1. Oldest syncedAt first (missing → 0 → absolute top)
     const tsA = localA?.syncSources?.[providerId]?.syncedAt || 0;
     const tsB = localB?.syncSources?.[providerId]?.syncedAt || 0;
     if (tsA !== tsB) return tsA - tsB;
-    // 3. lastModified desc breaks ties (recent local edits → priority)
+    // 2. lastModified desc breaks ties (recent local edits → priority)
     const lmA = localA?.lastModified || 0;
     const lmB = localB?.lastModified || 0;
     return lmB - lmA;

--- a/tests/sync/sync-engine.test.js
+++ b/tests/sync/sync-engine.test.js
@@ -43,11 +43,16 @@ describe('staggerPlaylistsForCycle (oldest-stale-first batching, see parachord#8
     expect(result).toHaveLength(15);
   });
 
-  test('hasUpdates playlists come first regardless of syncedAt', () => {
+  test('hasUpdates does NOT jump the queue (parachord#835 starvation fix)', () => {
+    // hasUpdates is a state flag (banner visible to user), not a sort
+    // priority. Re-running sync on a hasUpdates=true playlist confirms
+    // what we already know; meanwhile the syncedAt-asc tail starves and
+    // never discovers new updates. Pure syncedAt-asc ordering means the
+    // oldest-stale playlist wins regardless of hasUpdates state.
     const selected = [remote('a'), remote('b'), remote('c')];
     const locals = [
       local({ externalId: 'a', syncedAt: 1000 }),                       // fresh, no updates
-      local({ externalId: 'b', syncedAt: 500, hasUpdates: true }),      // older, but has updates
+      local({ externalId: 'b', syncedAt: 500, hasUpdates: true }),      // middle-aged, has updates
       local({ externalId: 'c', syncedAt: 100 }),                        // oldest, no updates
     ];
     const result = staggerPlaylistsForCycle({
@@ -56,8 +61,38 @@ describe('staggerPlaylistsForCycle (oldest-stale-first batching, see parachord#8
       providerId: 'spotify',
       batchSize: 2
     });
-    expect(result[0].externalId).toBe('b'); // hasUpdates wins
-    expect(result[1].externalId).toBe('c'); // then oldest syncedAt
+    expect(result[0].externalId).toBe('c'); // oldest syncedAt wins
+    expect(result[1].externalId).toBe('b'); // hasUpdates is irrelevant to position
+  });
+
+  test('many hasUpdates-true playlists do NOT monopolize the batch (parachord#835)', () => {
+    // Real-world repro: a user with 96 hasUpdates=true playlists
+    // (accumulated pending pulls they haven't acted on) and one
+    // stale-but-undetected-yet playlist (Daily Brew) at syncedAt=
+    // yesterday. With the old hasUpdates-first sort, Daily Brew sits at
+    // position 97 every cycle and never gets discovered. With the fix,
+    // the oldest-stale entry wins regardless of how many hasUpdates-true
+    // playlists exist.
+    const NOW = 1_000_000;
+    const stale = remote('stale');
+    const pending = Array.from({ length: 50 }, (_, i) => remote(`p${i}`));
+    const selected = [...pending, stale];
+    const locals = [
+      // 50 playlists with hasUpdates=true and FRESH syncedAt (today)
+      ...pending.map((r, i) =>
+        local({ externalId: r.externalId, syncedAt: NOW - i, hasUpdates: true })
+      ),
+      // The starvation victim: syncedAt is YESTERDAY, no hasUpdates yet
+      local({ externalId: 'stale', syncedAt: NOW - 24 * 60 * 60 * 1000 }),
+    ];
+    const result = staggerPlaylistsForCycle({
+      selectedRemote: selected,
+      localPlaylists: locals,
+      providerId: 'spotify',
+      batchSize: 15
+    });
+    expect(result[0].externalId).toBe('stale'); // wins by syncedAt-asc
+    expect(result.length).toBe(15);
   });
 
   test('among non-hasUpdates, oldest syncedAt comes first', () => {


### PR DESCRIPTION
Closes #835. The real reason Daily Brew never updates: the stagger sort starves the syncedAt-asc tail when many \`hasUpdates: true\` playlists accumulate.

## Repro (this user's data, captured today)

127 Spotify stagger candidates. 96 have \`hasUpdates: true\` (accumulated pending pulls — the user hasn't clicked "Pull" on each banner). Daily Brew is at **position 120/127**, last synced 5/18 10:19 AM (~30 hours ago).

Batch size is 15. The 96 hasUpdates-true playlists fill 6+ consecutive batches before any non-hasUpdates entry gets a slot. Daily Brew's daily rotation never gets discovered → no "Pull updates" banner → user concludes sync is broken.

## Why the previous sort was wrong

\`hasUpdates: true\` was put **first** in the stagger sort by #800, on the reasoning "user is waiting on a pending pull." But \`hasUpdates\` is a **state flag, not an action signal**:

- The banner is already visible in the UI once set.
- Re-running sync just re-confirms what we already know.
- \`stillHasUpdates\` keeps the local snapshotId pinned until the user actually pulls.

So re-processing a hasUpdates=true playlist every cycle does literally nothing — except consume a precious batch slot that should be going to discovery work in the syncedAt-asc tail.

## What changes

Sort order:

| | Before (#800) | After (this PR) |
|---|---|---|
| 1 | hasUpdates: true first | syncedAt asc (oldest first) |
| 2 | syncedAt asc | lastModified desc (tiebreaker) |
| 3 | lastModified desc | — |

A hasUpdates=true playlist that's queue-tail-stale now competes equally with all others. Its banner is unchanged; the user's action queue is unchanged. Only behavior change: the syncedAt-asc tail starts making progress.

## Test coverage

- **Renamed + flipped:** existing test `hasUpdates playlists come first regardless of syncedAt` → `hasUpdates does NOT jump the queue`. Same fixture, inverted expectation.
- **New starvation test:** 50 fresh-syncedAt hasUpdates=true playlists + 1 stale-syncedAt hasUpdates=false playlist. Verifies the stale entry wins position 0 and the batch is full.
- All 1638 tests pass.

CLAUDE.md updated to describe the new sort + the reasoning (with a pointer back to #835).

## Out of scope (filed separately or worth tracking)

- **Duplicate \`local_playlists\` records** — this user has WFUV Rewind ×2, WFMU Rewind ×2 leftover from before #830 fixed the hosted-XSPF re-import bug. New duplicates can't form post-#830 but existing ones persist. Worth a one-shot startup cleanup migration; separate ticket.
- **Bulk-dismiss UI for hasUpdates banners** — when 96 pending pulls accumulate, asking the user to click "Pull" 96 times isn't great UX. A "Pull all" / "Dismiss all" affordance would reduce accumulation. Separate UX ticket.

## Related (today's chain of fixes)

- #830 (merged): hosted-XSPF re-import preserves \`syncedTo\`
- #832 (merged): \`updatePlaylistTracks\` short-circuit on remote-matches-local
- #833 (open): per-provider mutex
- **#836 (this PR):** stagger sort no longer starves discovery

After #836 merges, the user's specific failure ("Daily Brew shows yesterday's tracks even though Spotify rotated today") becomes structurally impossible regardless of how many hasUpdates banners are outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)