### PR TITLE
electron: switch renderer origin from file:// to parachord:// (fixes #834)

### DIFF
--- a/local-files/album-art.js
+++ b/local-files/album-art.js
@@ -18,27 +18,35 @@ class AlbumArtResolver {
     // 1. Check for cached embedded art
     if (track.has_embedded_art || track.hasEmbeddedArt) {
       const cached = await this.getOrExtractEmbeddedArt(track);
-      if (cached) return `file://${cached}`;
+      if (cached) return `local-art://${encodeURI(cached)}`;
     }
 
     // 2. Check folder art
     if (track.folder_art_path || track.folderArtPath) {
       const artPath = track.folder_art_path || track.folderArtPath;
       if (fs.existsSync(artPath)) {
-        return `file://${artPath}`;
+        return `local-art://${encodeURI(artPath)}`;
       }
     }
 
-    // 3. Check MusicBrainz cached art
+    // 3. Check MusicBrainz cached art. Existing DB rows still contain
+    // `file://`-prefixed values from before the scheme migration; rewrite
+    // them on-the-fly so the renderer (now `parachord://`-origin) can load
+    // them via the local-art:// handler. New writes use local-art:// directly
+    // (see fetchFromCoverArtArchive below).
     if (track.musicbrainz_art_url || track.musicbrainzArtUrl) {
-      return track.musicbrainz_art_url || track.musicbrainzArtUrl;
+      const stored = track.musicbrainz_art_url || track.musicbrainzArtUrl;
+      if (stored.startsWith('file://')) {
+        return `local-art://${encodeURI(stored.slice('file://'.length))}`;
+      }
+      return stored;
     }
 
     // 4. Try to fetch from Cover Art Archive if we have release ID
     if (track.musicbrainz_release_id || track.musicbrainzReleaseId) {
       const releaseId = track.musicbrainz_release_id || track.musicbrainzReleaseId;
       const caaArt = await this.fetchFromCoverArtArchive(track.id, releaseId);
-      if (caaArt) return `file://${caaArt}`;
+      if (caaArt) return `local-art://${encodeURI(caaArt)}`;
     }
 
     // 5. No art found - return null (UI will show placeholder)
@@ -90,9 +98,10 @@ class AlbumArtResolver {
         const buffer = Buffer.from(await response.arrayBuffer());
         fs.writeFileSync(cachePath, buffer);
 
-        // Update database with cached URL
+        // Update database with cached URL. Stored as `local-art://`; legacy
+        // `file://` rows are translated on read in resolveArt().
         if (trackId) {
-          this.db.updateTrackArt(trackId, { musicbrainzArtUrl: `file://${cachePath}` });
+          this.db.updateTrackArt(trackId, { musicbrainzArtUrl: `local-art://${encodeURI(cachePath)}` });
         }
 
         return cachePath;

--- a/local-files/index.js
+++ b/local-files/index.js
@@ -201,14 +201,18 @@ class LocalFilesService {
     // renderer's lazy background extraction kicks in to warm the cache so
     // subsequent loads pick it up. See LocalFilesService.resolveArtForTrack
     // for the on-demand IPC entry point.
+    // Album-art URLs use the custom `local-art://` scheme because the renderer
+    // is `parachord://`-origin and `file://` images are cross-origin (blocked
+    // by webSecurity). The handler in main.js validates that the path is
+    // inside a watch folder or the album-art cache before serving.
     if (track.folder_art_path && fs.existsSync(track.folder_art_path)) {
-      formatted.albumArt = `file://${track.folder_art_path}`;
+      formatted.albumArt = `local-art://${encodeURI(track.folder_art_path)}`;
     } else if (track.has_embedded_art && this.albumArt) {
       const hash = crypto.createHash('md5').update(track.file_path).digest('hex');
       const jpg = path.join(this.albumArt.cacheDir, `embedded-${hash}.jpg`);
       const png = path.join(this.albumArt.cacheDir, `embedded-${hash}.png`);
-      if (fs.existsSync(jpg)) formatted.albumArt = `file://${jpg}`;
-      else if (fs.existsSync(png)) formatted.albumArt = `file://${png}`;
+      if (fs.existsSync(jpg)) formatted.albumArt = `local-art://${encodeURI(jpg)}`;
+      else if (fs.existsSync(png)) formatted.albumArt = `local-art://${encodeURI(png)}`;
     }
     return formatted;
   }

--- a/main.js
+++ b/main.js
@@ -731,7 +731,13 @@ function createWindow() {
     show: false
   });
 
-  mainWindow.loadFile('index.html');
+  // Renderer loads via the custom `parachord://` scheme (registered as standard +
+  // secure + cors-enabled) rather than `file://`. This gives the app a stable,
+  // non-file origin — required for Apple Music user auth (the MusicKit JS popup
+  // postMessages the user token back to `window.opener` with a strict
+  // targetOrigin, which the browser drops when the parent origin is `file://`).
+  // See issue #834.
+  mainWindow.loadURL('parachord://app/index.html');
 
   let windowShown = false;
   const showWindow = () => {
@@ -780,7 +786,7 @@ function createWindow() {
       console.log('🔄 Auto-reloading after renderer crash...');
       setTimeout(() => {
         if (mainWindow && !mainWindow.isDestroyed()) {
-          mainWindow.loadFile('index.html');
+          mainWindow.loadURL('parachord://app/index.html');
         }
       }, 1000);
     }
@@ -1505,6 +1511,18 @@ async function exchangeSoundCloudCodeForToken(code) {
 
 // Register custom protocol schemes
 // Must be called before app is ready
+// `parachord://` is BOTH the renderer's origin (parachord://app/index.html) and
+// the deep-link command scheme (parachord://play?artist=X). The protocol.handle
+// for it (registered after app-ready) serves files under the `app` host segment
+// and 404s everything else — deep-link command URLs from outside the app come
+// in via `open-url` (macOS) / `second-instance` argv (Win/Linux), not through
+// the renderer's protocol handler, so the 404 path never affects them. Flipping
+// off `file://` to a custom scheme is what makes Apple Music user auth work on
+// Linux + Windows (issue #834): MusicKit JS's popup posts the user token back
+// to `window.opener` with a strict targetOrigin, and `file://` is rejected
+// cross-window. `local-art://` exists because `parachord://`-origin pages can't
+// load `file://` images under the default webSecurity model — see local-files
+// for the emit sites.
 protocol.registerSchemesAsPrivileged([
   {
     scheme: 'local-audio',
@@ -1516,11 +1534,21 @@ protocol.registerSchemesAsPrivileged([
     }
   },
   {
+    scheme: 'local-art',
+    privileges: {
+      secure: true,
+      supportFetchAPI: true,
+      stream: true,
+      bypassCSP: true
+    }
+  },
+  {
     scheme: 'parachord',
     privileges: {
       secure: true,
-      supportFetchAPI: false,
-      standard: true
+      supportFetchAPI: true,
+      standard: true,
+      corsEnabled: true
     }
   }
 ]);
@@ -1678,6 +1706,144 @@ app.whenReady().then(() => {
     } catch (error) {
       console.error('[LocalAudio] Error serving file:', error);
       return new Response('File not found', { status: 404 });
+    }
+  });
+
+  // Register protocol handler for app files (renderer origin = parachord://app).
+  // Serves files under __dirname for paths shaped `parachord://app/<relative>`.
+  // Anything else (e.g. `parachord://play` deep-link commands that arrive via
+  // OS-level open-url/second-instance) is 404'd here — those paths are handled
+  // by handleProtocolUrl, NOT by this in-process handler. They never reach
+  // protocol.handle because Electron dispatches them through app events before
+  // any navigation/fetch.
+  const APP_MIME_TYPES = {
+    '.html': 'text/html; charset=utf-8',
+    '.htm': 'text/html; charset=utf-8',
+    '.js': 'application/javascript; charset=utf-8',
+    '.mjs': 'application/javascript; charset=utf-8',
+    '.css': 'text/css; charset=utf-8',
+    '.json': 'application/json; charset=utf-8',
+    '.map': 'application/json; charset=utf-8',
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.gif': 'image/gif',
+    '.svg': 'image/svg+xml',
+    '.webp': 'image/webp',
+    '.ico': 'image/x-icon',
+    '.woff': 'font/woff',
+    '.woff2': 'font/woff2',
+    '.ttf': 'font/ttf',
+    '.otf': 'font/otf',
+    '.wasm': 'application/wasm',
+    '.txt': 'text/plain; charset=utf-8',
+    '.xml': 'application/xml; charset=utf-8'
+  };
+  protocol.handle('parachord', async (request) => {
+    try {
+      const url = new URL(request.url);
+      // Only the `app` host serves files. `parachord://play`, etc. fall through
+      // to the deep-link path (handled by open-url / second-instance) and
+      // should never actually hit this handler from inside the renderer.
+      if (url.host !== 'app') {
+        console.warn('[Parachord] Unknown host, returning 404:', request.url);
+        return new Response('Not found', { status: 404 });
+      }
+      // Strip leading slash, decode, and reject any traversal.
+      const requestedPath = decodeURIComponent(url.pathname.replace(/^\/+/, ''));
+      if (!requestedPath || requestedPath.includes('..')) {
+        console.warn('[Parachord] Invalid path, returning 400:', requestedPath);
+        return new Response('Bad request', { status: 400 });
+      }
+      // Resolve inside __dirname and verify containment (defense-in-depth
+      // against traversal that survives the `..` check on weird encodings).
+      const filePath = path.resolve(__dirname, requestedPath);
+      if (!filePath.startsWith(__dirname + path.sep) && filePath !== __dirname) {
+        console.warn('[Parachord] Path escapes __dirname, returning 403:', filePath);
+        return new Response('Forbidden', { status: 403 });
+      }
+      const stats = await fs.promises.stat(filePath);
+      if (!stats.isFile()) {
+        return new Response('Not a file', { status: 404 });
+      }
+      const ext = path.extname(filePath).toLowerCase();
+      const mimeType = APP_MIME_TYPES[ext] || 'application/octet-stream';
+      const buffer = await fs.promises.readFile(filePath);
+      return new Response(buffer, {
+        status: 200,
+        headers: {
+          'Content-Type': mimeType,
+          'Content-Length': stats.size.toString()
+        }
+      });
+    } catch (error) {
+      // ENOENT is normal for missing files; log others.
+      if (error.code !== 'ENOENT') {
+        console.error('[Parachord] Error serving file:', request.url, error);
+      }
+      return new Response('Not found', { status: 404 });
+    }
+  });
+
+  // Register protocol handler for local album-art files. Same security model
+  // as local-audio: only serve files inside a watched folder OR inside the
+  // album-art cache directory. Replaces the prior `file://` art URLs that
+  // were emitted by formatTrackForRenderer / AlbumArtResolver — the renderer
+  // is now `parachord://`-origin and `file://` images are cross-origin under
+  // default webSecurity.
+  const ART_MIME_TYPES = {
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.png': 'image/png',
+    '.gif': 'image/gif',
+    '.webp': 'image/webp',
+    '.bmp': 'image/bmp',
+    '.svg': 'image/svg+xml'
+  };
+  protocol.handle('local-art', async (request) => {
+    try {
+      // URL form: local-art:///path/to/file.jpg — host empty, pathname is the path.
+      const url = new URL(request.url);
+      const requestedPath = decodeURIComponent(url.pathname);
+      const resolvedPath = path.resolve(requestedPath);
+
+      // Validate: must be inside a watched folder OR the album-art cache dir.
+      let allowed = false;
+      if (localFilesService?.initialized) {
+        const watchFolders = localFilesService.getWatchFolders();
+        allowed = watchFolders.some(folder =>
+          resolvedPath.startsWith(folder.path + path.sep) || resolvedPath === folder.path
+        );
+        if (!allowed && localFilesService.albumArt?.cacheDir) {
+          const cacheDir = path.resolve(localFilesService.albumArt.cacheDir);
+          allowed = resolvedPath.startsWith(cacheDir + path.sep);
+        }
+      }
+      if (!allowed) {
+        console.error('[LocalArt] Access denied — not in watch folder or art cache:', resolvedPath);
+        return new Response('Access denied', { status: 403 });
+      }
+
+      const stats = await fs.promises.stat(resolvedPath);
+      if (!stats.isFile()) {
+        return new Response('Not a file', { status: 404 });
+      }
+      const ext = path.extname(resolvedPath).toLowerCase();
+      const mimeType = ART_MIME_TYPES[ext] || 'application/octet-stream';
+      const buffer = await fs.promises.readFile(resolvedPath);
+      return new Response(buffer, {
+        status: 200,
+        headers: {
+          'Content-Type': mimeType,
+          'Content-Length': stats.size.toString(),
+          'Cache-Control': 'public, max-age=86400'
+        }
+      });
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        console.error('[LocalArt] Error serving file:', request.url, error);
+      }
+      return new Response('Not found', { status: 404 });
     }
   });
 

--- a/main.js
+++ b/main.js
@@ -103,6 +103,18 @@ if (process.platform !== 'darwin') {
   }
 }
 
+// Disable Chromium's third-party storage partitioning so the cookies Apple's
+// MusicKit sign-in popup sets on `*.music.apple.com` remain visible to the
+// parent's MusicKit JS instance after the popup closes. Without this, Chromium
+// 115+ scopes cookies by top-level site (the popup's URL is one top-level
+// site; our `parachord://app` parent is another), and MusicKit JS can never
+// read the `media-user-token` cookie back to complete the handshake. The
+// origin fix in this PR is necessary but not sufficient on its own — Apple's
+// auth flow assumes a shared cookie jar between popup and parent. See
+// Chromium storage partitioning docs + the research synthesis on issue #834.
+// Must be set before app.whenReady().
+app.commandLine.appendSwitch('disable-features', 'ThirdPartyStoragePartitioning,PartitionedCookies');
+
 // electron-updater is optional - may not be available in development
 let autoUpdater = null;
 try {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,12 @@
       "owner": "Parachord",
       "repo": "parachord"
     },
+    "protocols": [
+      {
+        "name": "Parachord",
+        "schemes": ["parachord"]
+      }
+    ],
     "files": [
       "**/*",
       "!.DS_Store",


### PR DESCRIPTION
## Summary

- Fixes #834: Apple Music user authorization fails on Linux because MusicKit JS's auth popup postMessages the user token back with a strict `targetOrigin`, which the browser drops when the parent origin is \`file://\`. Popup closes, \`isAuthorized\` stays false, fallback to native MusicKit fails on Linux (Mac-only framework).
- Switches the renderer to a custom \`parachord://app/index.html\` origin via \`protocol.handle\`. The scheme was already registered for OS-level deep links; this adds the in-process handler that serves files under \`__dirname\` for the \`app\` host. Deep-link command URLs (\`parachord://play\`, etc.) continue to flow through \`open-url\` / \`second-instance\` argv unchanged.
- Adds \`local-art://\` for album art because \`parachord://\`-origin pages can't load \`file://\` images under default webSecurity. Same security model as \`local-audio://\` — path must be inside a watched folder or the art cache dir. Legacy DB-persisted \`file://\` rows translate on-the-fly in \`AlbumArtResolver.resolveArt\`.
- \`electron-builder\` gets a \`protocols\` block so Linux .desktop files and Windows registry entries register the URL handler at install time.

## Why this approach over alternatives

Considered: (a) local HTTP server on loopback — adds a port, harder to lock down; (b) \`https://localhost\` with self-signed cert — annoying cert UX; (c) document as Linux-only limitation — leaves Linux Apple Music subscribers shut out. Custom protocol is what Cider (\`cider://\`) already does for the same class of problem, and it gives us a stable origin for future browser-API features that gate on it.

## User-visible transition

The \`musickit_user_token\` localStorage entry was origin-keyed under \`file://\` and won't carry over to \`parachord://app\`. **Users on Mac/Windows where Apple Music auth previously worked will need to re-authorize Apple Music once after upgrading.** Linux users gain Apple Music user auth they never had before.

The MusicKit developer token also lives in localStorage but is auto-regenerated by main.js's \`generateMusicKitDeveloperToken()\` on demand — no user action needed.

All other app state (collections, playlists, sync config, scrobbler tokens, etc.) lives in electron-store (filesystem-backed, not origin-keyed) and survives the migration intact.

## Apple Developer portal action

The Apple Music team token is bound to allow-listed origins on the developer portal. After this PR ships, the new \`parachord://app\` origin needs to be added to the allowlist alongside (or replacing) any prior \`file://\` entry. Chromium's exact \`Origin\` header for \`parachord://app/...\` requests should be verified before adding (likely \`parachord://app\`); the renderer logs the configure call so it'll be visible in DevTools.

## Test plan

- [x] \`npx jest\` — 1638 tests pass (no test changes; covers SSRF guards, sync, resolvers, etc.)
- [ ] Launch desktop on macOS, verify renderer loads at \`parachord://app/index.html\`, no console errors, all existing features work (playback, queue, sync, search, library, settings)
- [ ] Verify album art renders for local files (folder art + embedded art + CAA-cached art paths all go through \`local-art://\`)
- [ ] Verify local-file playback still works (local-audio:// path unchanged)
- [ ] Verify deep links still work: open a \`parachord://play?artist=X&title=Y\` link from a browser; app focuses + plays the track
- [ ] Verify renderer auto-recovery: kill the renderer process; the \`render-process-gone\` handler should reload \`parachord://app/index.html\`
- [ ] Verify Apple Music re-auth flow on Mac (existing behavior)
- [ ] **Verify Apple Music auth works on Linux** — the actual fix. Issue reporter @<reporter> may be willing to test a build.
- [ ] Verify on Windows that the .nsis installer registers \`parachord://\` URL handler (Settings → Apps → Default Apps → Choose default apps by protocol)
- [ ] Verify on Linux \`.deb\` / \`.rpm\` / AppImage that the .desktop entry registers \`x-scheme-handler/parachord\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)