### PR TITLE
sync: gate cancel-on-focus on blur transitions + log short-circuits (#821, #822)

### DIFF
--- a/app.js
+++ b/app.js
@@ -6883,7 +6883,19 @@ const Parachord = () => {
     //     residual IPC activity for a few seconds — accept that vs the
     //     complexity of safe cancellation.
     let pendingBackgroundSync = null;
+    // parachord#821: gate cancel-on-focus on actual blur → focus transitions.
+    // Electron's `browser-window-focus` (the underlying signal behind
+    // onForeground) fires for many in-app interactions on macOS Chromium —
+    // clicking the sidebar, switching panels, opening DevTools, etc. Without
+    // this flag, every such interaction calls sync.cancel on the in-flight
+    // background sync, effectively starving sync for any user who actively
+    // uses the app while it runs (the reporter on #821 measured 5 focus
+    // events in 2 minutes of normal usage). We only want to fire the
+    // cancel-on-focus path when the user genuinely returned from elsewhere
+    // — i.e. a blur preceded the focus.
+    let parachordBlurred = false;
     const handleBackground = () => {
+      parachordBlurred = true;
       if (pendingBackgroundSync) clearTimeout(pendingBackgroundSync);
       pendingBackgroundSync = setTimeout(() => {
         pendingBackgroundSync = null;
@@ -6891,6 +6903,12 @@ const Parachord = () => {
       }, BACKGROUND_DELAY);
     };
     const handleForeground = () => {
+      // Ignore spurious focus events that don't follow a blur (#821). In the
+      // not-actually-blurred state there can't be a pending blur-triggered
+      // sync (it's set in handleBackground), and there's no "user just
+      // returned" semantics to honor on the cancel-in-flight path either.
+      if (!parachordBlurred) return;
+      parachordBlurred = false;
       // Cancel any pending blur-triggered sync that hasn't fired yet.
       if (pendingBackgroundSync) {
         clearTimeout(pendingBackgroundSync);

--- a/main.js
+++ b/main.js
@@ -6389,6 +6389,15 @@ ipcMain.handle('sync:start', async (event, providerId, options = {}) => {
                 remotePlaylist,
                 providerId
               })) {
+                // parachord#822: log the short-circuit so it's distinguishable
+                // from "playlist never reached" in [Sync] traces. The snapshot
+                // preview makes "snap matched, no work" auditable when a user
+                // reports "why didn't sync update X" — you can see both that
+                // the playlist was visited AND what snapshot was matched.
+                const localSnap = (currentPlaylists[idx].syncedFrom?.snapshotId || '').slice(0, 12);
+                const remoteSnap = (remotePlaylist.snapshotId || '').slice(0, 12);
+                const playlistName = remotePlaylist.name || currentPlaylists[idx].name || remotePlaylist.id;
+                console.log(`[Sync] ${providerId} "${playlistName}": short-circuit (snap matched, no work) local=${localSnap} remote=${remoteSnap}`);
                 const cur = currentPlaylists[idx];
                 currentPlaylists[idx] = {
                   ...cur,


### PR DESCRIPTION
## Summary

Two small fixes against code that just landed in v0.9.3:

- **#821** — cancel-on-focus (#799) was firing on bare \`browser-window-focus\` events, including in-app interactions (sidebar clicks, panel switches, DevTools focus). 5 spurious focus events in 2 min of normal usage per the reporter, each killing the in-flight background sync. Active users were starving their own syncs. Fix: gate the cancel-on-focus path on actual \`blur → focus\` transitions via a closure flag.
- **#822** — \`canShortCircuitPlaylistUpdate\` (#796) was silently bumping \`syncedAt\` and continuing the loop with no log line. Made "playlist short-circuited" indistinguishable from "playlist never reached" in [Sync] traces. Fix: log the short-circuit decision with a 12-char snapshot preview so it's auditable when debugging "why didn't sync update X."

Both fix bugs in code shipping in v0.9.3 — worth bundling so the release doesn't ship #799 in a quasi-disabled state for active users.

## Test plan

- [x] \`npx jest\` — 1638 tests pass, no test changes needed (both fixes are inside code paths covered by integration testing, not unit-targetable)
- [ ] Manual: launch desktop, click around sidebar/panels/DevTools while a background sync is mid-flight, verify no \`[Sync] Cancelling in-flight background sync on focus\` log
- [ ] Manual: cmd-tab away → wait > BACKGROUND_DELAY (30s) → cmd-tab back → verify the cancel-on-focus log DOES fire
- [ ] Manual: trigger a sync where the playlist hasn't drifted, verify the new short-circuit log line appears with snapshot preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)