### PR TITLE
local-files: surface CAA-cached art in Library view (#786)

### DIFF
--- a/local-files/index.js
+++ b/local-files/index.js
@@ -201,6 +201,10 @@ class LocalFilesService {
     // renderer's lazy background extraction kicks in to warm the cache so
     // subsequent loads pick it up. See LocalFilesService.resolveArtForTrack
     // for the on-demand IPC entry point.
+    //
+    // Three tiers, matching the first three tiers of the async resolveArt()
+    // resolver in album-art.js. Tier 4 (Cover Art Archive fetch) is async
+    // and intentionally skipped — that happens during play-time resolve().
     if (track.folder_art_path && fs.existsSync(track.folder_art_path)) {
       formatted.albumArt = `file://${track.folder_art_path}`;
     } else if (track.has_embedded_art && this.albumArt) {
@@ -209,6 +213,24 @@ class LocalFilesService {
       const png = path.join(this.albumArt.cacheDir, `embedded-${hash}.png`);
       if (fs.existsSync(jpg)) formatted.albumArt = `file://${jpg}`;
       else if (fs.existsSync(png)) formatted.albumArt = `file://${png}`;
+    }
+    // Tier 3: MusicBrainz / Cover Art Archive art written to the DB by a
+    // prior play-time resolveArt() (fetchFromCoverArtArchive caches the
+    // image to disk and persists the `file://` URL in musicbrainz_art_url).
+    // Only used when tiers 1+2 didn't hit, since folder/embedded art is
+    // closer to the user's actual file. The existsSync guard handles the
+    // case where cleanCache() pruned the file but left the stale DB row.
+    if (!formatted.albumArt && track.musicbrainz_art_url) {
+      const stored = track.musicbrainz_art_url;
+      if (stored.startsWith('file://')) {
+        if (fs.existsSync(stored.slice('file://'.length))) {
+          formatted.albumArt = stored;
+        }
+      } else {
+        // Non-file URL (e.g. legacy direct CAA URL) — pass through; the
+        // renderer's <img> tag will request it directly.
+        formatted.albumArt = stored;
+      }
     }
     return formatted;
   }


### PR DESCRIPTION
## Summary

The sync formatter \`formatTrackForRenderer\` (used by \`getAllTracks\` / \`search\` / \`getTrackByPath\` — i.e. all the non-playback paths into the Library view) already handled the first two tiers of the album-art resolver (folder art, embedded-art cache file), but missed **tier 3**: \`musicbrainz_art_url\` — the \`file://\` URL written to the DB by play-time CAA fetches.

So tracks that had been resolved via Cover Art Archive at some point in the past came back with \`albumArt: undefined\` from the bulk Library load, even though the image was already on disk and the DB knew where it was. Net effect: well-tagged collections show placeholder art in the Library view for any track that doesn't have embedded ID3 art or a folder cover but DOES have a previously-fetched CAA cache entry.

Fix: add tier 3 to the sync fast-path, with an \`existsSync\` guard for the \`cleanCache()\`-pruned-but-stale-DB-row case, and a non-\`file://\` pass-through for legacy direct-CAA URLs.

## Why this matters together with the rest of v0.9.3

This compounds with #784 (big-library freeze) — the renderer's \`enrichLocalTracksWithArtwork\` loop sees \`albumArt: undefined\` on every CAA-cached track and treats them as artless candidates for further work. With this fix, the bulk Library load reflects the actual on-disk art state, and the warmup loop has strictly less to chase.

## Cost

One extra \`fs.existsSync\` per track that has CAA-cached art and didn't hit tiers 1/2. ~30k extra stat calls on a 150k-track library if 20% of tracks fit that profile — ~30ms on SSD. Bounded sync work in exchange for "Library shows correct art on first paint."

## Test plan

- [x] \`npx jest\` — 1638 tests pass
- [ ] Manual: launch desktop on a library where some tracks have been played long enough for CAA art to populate \`musicbrainz_art_url\` rows; verify those tracks now show art on first paint in the Library view instead of waiting for a play-time resolve
- [ ] Manual: with a track whose CAA cache file has been pruned (\`rm cache/caa-*.jpg\` for one), verify the Library view shows the placeholder cleanly rather than a broken \`<img>\`
- [ ] Manual: with a track in cold-cache state (no folder art, has\\_embedded\\_art true, no extracted cache file, no musicbrainz\\_art\\_url), verify the existing lazy warmup path still runs and populates art after the background extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)