### PR TITLE
sync: atomic-rename writes for collection.json (#795)

### DIFF
--- a/main.js
+++ b/main.js
@@ -5870,6 +5870,35 @@ ipcMain.handle('localFiles:saveId3Tags', async (event, filePath, tags) => {
   }
 });
 
+// Atomic collection.json writer (parachord#795). Plain writeFile to an
+// existing path will leave a truncated file if the process crashes / is
+// force-quit / runs out of disk mid-write, and JSON.parse fails on the
+// next launch with "Unterminated string in JSON at position N". The
+// load path silently falls back to an empty collection, which means
+// anything reading collection.json between corruption and the next
+// save sees empty data — track scrobbling, background resolution, etc.
+// all operate on the empty state until the next sync rewrites it.
+//
+// Standard tmp+rename pattern: write to a sibling `.tmp`, then rename
+// it over the canonical path. rename(2) is atomic on POSIX when source
+// and destination are on the same filesystem (always true here — both
+// live in userData/). On Windows, Node's fs.rename uses MoveFileEx with
+// MOVEFILE_REPLACE_EXISTING which provides equivalent "either old or
+// new, never partial" semantics for the visible file. A leftover `.tmp`
+// from a crashed mid-write is harmless — the next save overwrites it
+// before the rename, so partial `.tmp` files self-heal.
+//
+// All three collection.json writes in main.js route through here:
+//   - collection:save IPC handler (with .bak rotation upstream)
+//   - finalizeCancelled inside sync:start
+//   - the end-of-sync save inside sync:start
+async function writeCollectionAtomic(collectionPath, collection) {
+  const fsPromises = require('fs').promises;
+  const tmpPath = `${collectionPath}.tmp`;
+  await fsPromises.writeFile(tmpPath, JSON.stringify(collection), 'utf8');
+  await fsPromises.rename(tmpPath, collectionPath);
+}
+
 // Collection handlers - store in userData directory for persistence across app updates
 ipcMain.handle('collection:load', async () => {
   console.log('=== Load Collection ===');
@@ -5919,7 +5948,7 @@ ipcMain.handle('collection:save', async (event, collection) => {
       console.warn('  ⚠️ Backup rotation failed (non-fatal):', backupErr.message);
     }
 
-    await fsPromises.writeFile(collectionPath, JSON.stringify(collection), 'utf8');
+    await writeCollectionAtomic(collectionPath, collection);
     console.log(`✅ Saved collection: ${collection.tracks?.length || 0} tracks, ${collection.albums?.length || 0} albums, ${collection.artists?.length || 0} artists`);
     return { success: true };
   } catch (error) {
@@ -6149,7 +6178,7 @@ ipcMain.handle('sync:start', async (event, providerId, options = {}) => {
     const finalizeCancelled = async (collectionState, resultsState) => {
       try {
         sendProgress({ phase: 'cancelled', message: 'Sync cancelled' });
-        await fsPromises.writeFile(collectionPath, JSON.stringify(collectionState), 'utf8');
+        await writeCollectionAtomic(collectionPath, collectionState);
       } catch (err) {
         console.warn(`[Sync] Cancellation save failed for ${providerId}:`, err.message);
       }
@@ -6631,7 +6660,7 @@ ipcMain.handle('sync:start', async (event, providerId, options = {}) => {
     // Save collection
     sendProgress({ phase: 'saving', message: 'Saving collection...' });
     console.log(`[Sync] Saving collection: ${collection.tracks?.length || 0} tracks, ${collection.albums?.length || 0} albums, ${collection.artists?.length || 0} artists`);
-    await fsPromises.writeFile(collectionPath, JSON.stringify(collection), 'utf8');
+    await writeCollectionAtomic(collectionPath, collection);
 
     // Update sync settings with last sync time
     const syncSettings = store.get('resolver_sync_settings') || {};


### PR DESCRIPTION
## Summary

\`collection.json\` is written via plain \`fs.promises.writeFile\` at three sites in main.js (collection:save IPC + two inside sync:start). A crash / force-quit / out-of-disk mid-write leaves the file truncated, and the next launch fails the JSON.parse:

\`\`\`
❌ Load failed: Unterminated string in JSON at position 524264
\`\`\`

The load handler silently falls back to \`{ tracks: [], albums: [], artists: [] }\`. Self-heals on the next sync (rewrites from in-memory state), but anything reading collection.json between corruption and the next save sees the empty state — and the next save can be hours away for users whose only sync trigger is the 30s blur path's 5-min staleness gate.

Switch all three writes to a tmp+rename pattern via a new \`writeCollectionAtomic\` helper. \`rename(2)\` is atomic on POSIX same-filesystem (always true — both paths in \`userData/\`); Windows's \`fs.rename\` uses MoveFileEx with MOVEFILE_REPLACE_EXISTING for equivalent semantics on the visible file. Partial \`.tmp\` files self-heal — next save overwrites them before the rename.

## What's NOT in this PR

- **\`.bak\` fallback chain on load failure** — exists for the save path (rotation at L5910-5915) but tempting to wire into load as belt-and-suspenders. Decided against: silently loading a stale \`.bak\` after corruption could lose recent user changes without them knowing. Keep recovery surface small; the next-sync-rewrites path already heals existing corruption.
- **electron-store keys** (\`local_playlists\`, \`cache_*\`, etc.) — electron-store has its own atomic-write internally; verified, no change needed.

## Test plan

- [x] \`npx jest\` — 1638 tests pass (no test changes; the helper is filesystem-side and not unit-targetable without process-kill simulation)
- [ ] Manual: synthesize a corrupted collection.json (\`echo '{\"tracks\":[{\"id\":\"abc\"' > collection.json\`), launch, verify the load falls back cleanly to empty and the next sync rewrites a valid file
- [ ] Manual: trigger many save cycles, force-quit Parachord mid-\`Saving collection: N tracks...\`, relaunch — verify no "Unterminated string in JSON" log line and that the collection is intact (either the pre-write state or the post-write state, never partial)
- [ ] Manual: after a few save cycles, look in userData/ for any leftover \`collection.json.tmp\` files; ok if absent, ok if present (next save cleans them up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)