### PR TITLE
sync: yield hosted-XSPF poll to idle scheduler (#770 part 2)

### DIFF
--- a/app.js
+++ b/app.js
@@ -31943,6 +31943,13 @@ Variety guidance: ${theme} Be creative and surprising — avoid defaulting to th
 
       // Set up polling interval - faster when listen-along is active
       const pollInterval = listenAlongFriend ? 15 * 1000 : 2 * 60 * 1000; // 15 seconds vs 2 minutes
+      // NOT yield-wrapped intentionally — the 2-min cadence is already the
+      // user-visible freshness budget for `cachedRecentTrack`, and any
+      // yield-induced delay degrades the "click Listen Along → join the
+      // track my friend is actually playing right now" path. The poll is
+      // small enough (one HTTP/IPC call per pinned friend) that it doesn't
+      // compete with foreground work meaningfully even mid-busy-tick. See
+      // parachord#770 part 2 — hosted-XSPF poll is yielded; this one is not.
       friendPollIntervalRef.current = setInterval(() => {
         refreshPinnedFriends();
         // Periodic friend-graph sync gate
@@ -35485,11 +35492,20 @@ Variety guidance: ${theme} Be creative and surprising — avoid defaulting to th
       }
     };
 
-    // Poll every 5 minutes
-    hostedPlaylistPollInterval.current = setInterval(pollHostedPlaylists, 5 * 60 * 1000);
+    // Poll every 5 minutes. Wrap each tick in yieldToIdle so the work
+    // doesn't fight the main thread when other background jobs (sync,
+    // resolver enrichment, friend activity poll) happen to fire in the
+    // same window. The 10s timeout is generous — there's no urgency to
+    // a hosted-XSPF refresh, and the 5min cadence means a single delayed
+    // tick costs us nothing. parachord#770 part 2.
+    const idlePollHostedPlaylists = async () => {
+      await yieldToIdle(10000);
+      await pollHostedPlaylists();
+    };
+    hostedPlaylistPollInterval.current = setInterval(idlePollHostedPlaylists, 5 * 60 * 1000);
 
     // Also poll on mount (after a short delay to let playlists load)
-    const initialPoll = setTimeout(pollHostedPlaylists, 10000);
+    const initialPoll = setTimeout(idlePollHostedPlaylists, 10000);
 
     return () => {
       clearInterval(hostedPlaylistPollInterval.current);


### PR DESCRIPTION
## Summary

Wrap the hosted-XSPF playlist poller's per-tick work in the existing \`yieldToIdle\` helper (5min interval + the 10s post-mount initial poll). When a tick happens to land mid-busy (sync push loop, resolver burst, large React commit), the fetch+diff+state-update now waits for the next idle frame instead of fighting the main thread.

Tiny diff. The biggest part of this PR is the comment block explaining what's deliberately NOT changed.

## Scope vs. the issue body

Issue #770 had three fix parts:

| Part | Status |
|---|---|
| 1. Idle-wait before background pre-resolution | **Already done** — see app.js L25285-25302 (30s startup grace + 3s user-activity gate). Issue body was written before that landed. |
| 2. \`requestIdleCallback\` for non-time-critical polls | **This PR** — hosted-XSPF only |
| 3. Lazy \`trackSourcesCache\` hydration | Deferred — invasive, deserves own measurement-driven PR |

## Why only hosted-XSPF in part 2

Two other polls were candidates and were deliberately left as-is:

- **Friend activity poll** (2min / 15s listen-along). 2min is already the user-visible freshness budget for \`cachedRecentTrack\`. Adding even 3s of yield erodes the "click Listen Along → join the track my friend is actually playing right now" path. 15s listen-along is even more freshness-critical. The poll itself is small (one IPC per pinned friend) so it doesn't meaningfully compete with foreground work anyway.
- **Scrobbler retry queue.** Scrobble timing is contractually owed to Last.fm/ListenBrainz; yielding could push retries past their service-level expectations.

Hosted-XSPF poll has no comparable freshness requirement — a 5min poll detecting external XSPF file changes can wait another 10s without anyone noticing.

## Test plan

- [x] \`npx jest\` — 1638 tests pass
- [ ] Manual: with one or more hosted-XSPF playlists configured, launch the app; verify the initial poll still fires (~10s after mount) and the 5min recurring poll still detects XSPF content changes when the source URL is updated
- [ ] Manual: trigger a sync run that lands within the same window as a scheduled hosted-XSPF tick; observe in DevTools profiler that the XSPF work yields rather than competing with the sync push loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)