### PR TITLE
desktop: set window.__parachordClient = 'desktop' for plugin telemetry (#851)

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="apple-music-app-name" content="Parachord">
   <meta name="apple-music-app-build" content="1.0.0">
+  <!-- parachord#851 — client identifier read by the achordion plugin's
+       /api/track-links/submit call to set X-Parachord-Client. Set in head
+       (before any script) so the global is in place before resolver-loader
+       compiles plugins and calls their init(). Android sets the same global
+       to 'android' from its scrobbler-plugin bridge. -->
+  <script>window.__parachordClient = 'desktop';</script>
   <title>Parachord Desktop</title>
   <link rel="stylesheet" href="vendor/tailwind.css">
   <style>


### PR DESCRIPTION
Closes #851.

Single-line inline script in \`index.html\`'s \`<head>\`, set before any \`<script src=>\` tags so the global is in place by the time \`resolver-loader.js\` compiles plugins and runs their \`init()\`.

\`\`\`html
<script>window.__parachordClient = 'desktop';</script>
\`\`\`

The achordion.axe plugin (1.0.8+) reads this when posting to \`/api/track-links/submit\` to set the \`X-Parachord-Client\` header. Android sets the same global to \`'android'\` from its scrobbler-plugin bridge; desktop's contributions were defaulting to \`'unknown'\`.

No runtime cost, no behavior change beyond the header value attribution being correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)