### PR TITLE
announcements: filter by surfaces field

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -927,9 +927,12 @@ Public banner notifications fetched from Achordion. Used to push messages (relea
   "cta": { "label": "string", "url": "https://..." },  // optional
   "minVersion": "0.9.2",              // optional inclusive lower bound
   "maxVersion": "1.0.0",              // optional inclusive upper bound
-  "expiresAt": "2026-06-01T00:00:00Z" // optional ISO-8601
+  "expiresAt": "2026-06-01T00:00:00Z", // optional ISO-8601
+  "surfaces": ["parachord"]           // optional; ('achordion' | 'parachord')[]
 }
 ```
+
+`surfaces` scopes an item to a subset of clients. Omitting it (or sending an empty array) shows the item on every surface — the pre-`surfaces` default, kept for backwards compatibility with entries authored before the field existed. The Achordion API (`app/api/announcements/route.ts`) explicitly delegates surface filtering to the client; Parachord's `activeAnnouncements` filter chain enforces it after the version-range check. If you add a new surface name (e.g. `ios`), both the Achordion zod schema in `lib/announcements.ts` and Parachord's filter need to know about it for the new client to receive items scoped to it.
 
 `iconUrl` takes precedence over `icon`; on image error the banner silently falls back to `icon` (or nothing). Multiple items: id-sort descending wins (date-prefixed ids = recency-sorted), banner shows one at a time, dismiss surfaces the next.
 

--- a/app.js
+++ b/app.js
@@ -10313,6 +10313,19 @@ const Parachord = () => {
         if (a.maxVersion && compareSemver3(appVersion, a.maxVersion) > 0) return false;
         return true;
       })
+      // Surface filter: items can scope themselves to a subset of clients via
+      // the optional `surfaces` array (per achordion/lib/announcements.ts —
+      // 'achordion' | 'parachord'). Items omitting the field — or sending an
+      // empty array — show on every surface (the pre-`surfaces` default, so
+      // existing entries keep working). Items with an explicit list only show
+      // on clients whose surface name appears in it. The achordion API
+      // explicitly delegates this filter to the desktop client (see
+      // achordion/app/api/announcements/route.ts) — the route hands back the
+      // full validated list regardless of surface.
+      .filter(a => {
+        if (!Array.isArray(a.surfaces) || a.surfaces.length === 0) return true;
+        return a.surfaces.includes('parachord');
+      })
       .sort((a, b) => String(b.id).localeCompare(String(a.id)));
   }, [announcements, dismissedAnnouncementIds, appVersion]);
 


### PR DESCRIPTION
The Achordion announcements admin UI now lets publishers scope items to a subset of clients via a \`surfaces\` array (\`'achordion' | 'parachord'\`). The Achordion API ([app/api/announcements/route.ts](https://github.com/jherskowitz/achordion/blob/main/app/api/announcements/route.ts)) explicitly hands back the full validated list and delegates surface filtering to the client — but Parachord's \`activeAnnouncements\` filter chain handled dismissed / expired / version-range filters and missed this one.

Surfaced today by a "Degraded Site Performance" item the user explicitly scoped to achordion only, which rendered in Parachord's Collection view anyway.

## Fix

One additional \`.filter\` step in \`activeAnnouncements\` (app.js):

\`\`\`js
.filter(a => {
  if (!Array.isArray(a.surfaces) || a.surfaces.length === 0) return true;
  return a.surfaces.includes('parachord');
})
\`\`\`

Items omitting the field (or sending an empty array) still show on every surface — the pre-\`surfaces\` default, backwards-compatible with entries authored before the field existed.

Also documents the field in CLAUDE.md's In-App Announcements section so future agents know about it.

## Test plan

- [x] \`npx jest\` — 1638 tests pass
- [ ] Manual: publish an achordion-only item (Surfaces: ☑ achordion ☐ parachord), verify it does NOT render in Parachord
- [ ] Manual: publish a parachord-only item (Surfaces: ☐ achordion ☑ parachord), verify it DOES render in Parachord
- [ ] Manual: publish an item with no \`surfaces\` field at all (legacy shape), verify it still renders in Parachord (backwards compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)