### PR TITLE
ci: skip code signing when CSC_LINK empty (fork-PR Windows builds)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,10 +169,32 @@ jobs:
           echo "=== End diagnostic ==="
 
       - name: Build for ${{ matrix.platform }}
-        run: npm run build:${{ matrix.platform }} -- --${{ matrix.arch }} --publish never
+        shell: bash
+        run: |
+          # Fork PRs run with secrets stripped (GitHub Actions security
+          # measure — prevents credential exfiltration by external
+          # contributors). When CSC_LINK is empty, electron-builder on
+          # Windows tries to resolve the empty value as a cert file path
+          # and bombs with "Env WIN_CSC_LINK is not correct, cannot
+          # resolve: D:\a\parachord\parachord not a file". macOS handles
+          # empty CSC_LINK gracefully via the "Import Code Signing
+          # Certificate" step's `env.CSC_LINK != ''` skip; Windows had no
+          # equivalent — so external-contributor PRs (e.g. gjtorikian's
+          # #857) would always fail Windows verification despite the code
+          # being fine. Explicitly unset the vars when empty so
+          # electron-builder uniformly skips signing across platforms.
+          # Internal-branch PRs and tag-pushed release builds still get
+          # the secrets normally.
+          if [ -z "${CSC_LINK:-}" ]; then
+            unset CSC_LINK CSC_KEY_PASSWORD
+            echo "[CI] CSC_LINK empty (likely a fork PR) — skipping code signing"
+          fi
+          npm run build:${{ matrix.platform }} -- --${{ matrix.arch }} --publish never
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # macOS code signing
+          # macOS code signing (also read by electron-builder on Windows
+          # to detect "should I sign?" — see comment in run: above for
+          # the fork-PR handling).
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           # macOS notarization — only on tagged releases


### PR DESCRIPTION
**TL;DR**: Fork PRs run without secrets (GitHub Actions security feature), so \`CSC_LINK\` resolves to empty on those builds. macOS handles empty CSC_LINK gracefully; Windows didn't. This fixes Windows.

## Reproduction

[@gjtorikian's #857](https://github.com/Parachord/parachord/pull/857) (which we just merged) failed Windows CI with:

> \`Env WIN_CSC_LINK is not correct, cannot resolve: D:\\a\\parachord\\parachord not a file\`

Mac arm64 / Mac x64 / Linux all passed on the same run. Code was fine — every external-contributor PR would have hit this.

## Root cause

[GitHub Actions strips repository secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow) from workflows triggered by \`pull_request\` events from forks. \`secrets.CSC_LINK\` resolves to empty string on those runs. electron-builder on Windows then tries to interpret the empty value as a cert file path, fails to resolve, exits 1.

macOS's "Import Code Signing Certificate" step has \`if: env.CSC_LINK != ''\` which skips cleanly. Windows had no equivalent guard.

## Fix

Two-line change to the "Build for ..." step: add a \`shell: bash\` pre-command that \`unset\`s \`CSC_LINK\` + \`CSC_KEY_PASSWORD\` when they arrive empty. electron-builder then sees them as absent (not empty-string) and skips signing uniformly across platforms.

- **Internal-branch PRs**: unchanged. \`CSC_LINK\` is populated → signing runs as before on Mac, no-op on Windows (no \`win.sign\` config in \`package.json\` anyway).
- **Tag-pushed releases**: unchanged. \`CSC_LINK\` is populated.
- **Fork PRs**: Windows now builds successfully (unsigned, but that's correct for a PR check).

## Diagnostic note

I initially diagnosed this as "the \`CSC_LINK\` secret was deleted" because the macOS "Import Code Signing Certificate" step transitioned from \`success\` (on #855) to \`skipped\` (on #857). Should have checked PR provenance first — \`gh pr view 857 --json headRepository\` would have shown \`gjtorikian/parachord\` immediately. Lesson logged.

## Test plan

- [ ] Mac arm64 / Mac x64 builds still pass on this internal PR (secrets flow normally — should be identical to before)
- [ ] Linux builds still pass (no signing anyway)
- [ ] Windows build now passes on this internal PR (no behavior change — CSC_LINK is non-empty here, so the unset branch doesn't trigger)
- [ ] After merge, next external-contributor PR should pass Windows without the WIN_CSC_LINK error

🤖 Generated with [Claude Code](https://claude.com/claude-code)