### PR TITLE
mcp seek: read back actual position from AM engines + document three-if pattern (#858)

### DIFF
--- a/app.js
+++ b/app.js
@@ -11751,6 +11751,16 @@ const Parachord = () => {
               confirmedMs = Math.round(audioRef.current.currentTime * 1000);
             }
             if (activeResolver === 'applemusic') {
+              // Three sequential `if`s (NOT an else-if chain) is deliberate:
+              // each engine's seek can silently fail (e.g. native bridge
+              // exists but isn't authorized for the current track) and the
+              // try/catch swallows the error. With independent `if`s, a later
+              // tier still gets a chance to seek the engine that's actually
+              // playing. In practice only one engine has the active source
+              // for any given track, so confirmedMs ends up reflecting that
+              // engine's read-back. parachord#858 (nit 2) noted the pattern
+              // looks brittle but the alternative (early else-if returns)
+              // regresses the silent-failure recovery path.
               if (window._appleMusicPreviewAudio && !window._appleMusicPreviewAudio.paused) {
                 window._appleMusicPreviewAudio.currentTime = positionSec;
                 confirmedMs = Math.round(window._appleMusicPreviewAudio.currentTime * 1000);
@@ -11758,8 +11768,20 @@ const Parachord = () => {
               if (window.electron?.musicKit?.seek) {
                 try {
                   await window.electron.musicKit.seek(positionSec);
-                  confirmedMs = Math.round(positionSec * 1000);
-                  appleMusicProgressBaselineRef.current = { progress: positionSec, timestamp: Date.now(), isPlaying: true };
+                  // parachord#858 nit 1: query the engine for its actual
+                  // post-seek position rather than reporting the requested
+                  // offset. The seek may clamp at track end, DRM boundaries,
+                  // etc. Fall back to the requested value if the state query
+                  // fails so we still return SOMETHING reasonable.
+                  let actualSec = positionSec;
+                  try {
+                    const state = await window.electron.musicKit.getPlaybackState();
+                    if (state?.success && typeof state.position === 'number') {
+                      actualSec = state.position;
+                    }
+                  } catch {}
+                  confirmedMs = Math.round(actualSec * 1000);
+                  appleMusicProgressBaselineRef.current = { progress: actualSec, timestamp: Date.now(), isPlaying: true };
                 } catch {}
               }
               if (window.getMusicKitWeb) {
@@ -11767,8 +11789,18 @@ const Parachord = () => {
                   const mk = window.getMusicKitWeb();
                   if (mk?.seek) {
                     await mk.seek(positionSec);
-                    confirmedMs = Math.round(positionSec * 1000);
-                    appleMusicProgressBaselineRef.current = { progress: positionSec, timestamp: Date.now(), isPlaying: true };
+                    // Same rationale as native path above — query actual.
+                    // musickit-web's getPlaybackState() returns
+                    // { state, position, duration, ... } in seconds.
+                    let actualSec = positionSec;
+                    try {
+                      const state = mk.getPlaybackState?.();
+                      if (state && typeof state.position === 'number') {
+                        actualSec = state.position;
+                      }
+                    } catch {}
+                    confirmedMs = Math.round(actualSec * 1000);
+                    appleMusicProgressBaselineRef.current = { progress: actualSec, timestamp: Date.now(), isPlaying: true };
                   }
                 } catch {}
               }


### PR DESCRIPTION
Two of the three nits from #858. Nit 3 (extract handlers into pure helpers for unit testing) is being deferred — see [the issue thread](https://github.com/Parachord/parachord/issues/858) for the reasoning.

## Nit 1 — read back actual position from AM engines

The HTML5 audio path was already doing real read-back (\`audioRef.current.currentTime\` after the assignment). The two Apple Music paths were reporting the requested offset rather than what the engine landed on:

\`\`\`js
await window.electron.musicKit.seek(positionSec);
confirmedMs = Math.round(positionSec * 1000);  // ← assumed, not queried
\`\`\`

If MusicKit silently clamped (track end, DRM boundary, edge cases), \`position_ms\` would lie. Both engines expose \`getPlaybackState\` that returns the actual current position:

- **Native bridge** (\`musickit:get-playback-state\` IPC, main.js L8010-8018) → \`{ success, position, ... }\` in seconds
- **MusicKit JS** (musickit-web.js L371-391) → \`{ state, position, duration, ... }\` in seconds

Now both paths query post-seek and use that value for both \`confirmedMs\` AND the \`appleMusicProgressBaselineRef\` write. Falls back to the requested value if the state query throws.

## Nit 2 — document the three-if pattern's intent

#858 flagged the three sequential \`if\` blocks in the AM branch as "brittle." Investigated and they're actually deliberate:

\`\`\`js
if (preview is playing) { try seek preview; confirmedMs = ... }
if (native bridge exposes seek) { try seek native; confirmedMs = ... }
if (mk web available) { try seek mk web; confirmedMs = ... }
\`\`\`

Each tier's seek can silently fail inside its try/catch (e.g. native bridge exists but isn't authorized for this track). With independent \`if\`s, a later tier still gets a chance to seek the engine that's actually playing. An else-if chain would regress that recovery — the moment the native tier's catch swallows an "not authorized" error, MusicKit JS wouldn't get a turn.

Added an inline comment explaining the intent so future readers (or future agents) don't accidentally "fix" it into an else-if.

## Not in this PR

Nit 3 — extracting \`handleSeek\` and \`getCurrentPosition\` into pure helpers in \`tools/playback-position.js\` so they're unit-testable without React state — deserves its own focused refactor PR, and per the discussion on #858 should wait until we actually need coverage.

## Test plan

- [x] \`npx jest\` — 1649 tests pass (no test changes; the existing dj-tools wrapper tests still pass with the new read-back logic since they mock the entire \`handleSeek\` context method)
- [ ] Manual: seek a local file → verify position_ms matches HTML5 audio's read-back (unchanged behavior)
- [ ] Manual: seek an Apple Music track on macOS (native MusicKit) → verify position_ms reflects native engine's actual state, not the requested offset. The difference is observable when seeking past end-of-track: pre-fix reports the requested offset (e.g. 999000ms); post-fix reports where MusicKit actually landed (e.g. duration_ms or wherever the engine clamped).
- [ ] Manual: seek an Apple Music track via MusicKit JS on Linux/Windows (post-#843 auth-window flow) → same verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)