### PR TITLE
fix(sync/spotify): use /me/tracks + /me/albums DELETE (not /me/library)

### DIFF
--- a/sync-providers/spotify.js
+++ b/sync-providers/spotify.js
@@ -627,8 +627,16 @@ const SpotifySyncProvider = {
   },
 
   /**
-   * Remove tracks from user's Spotify library
-   * Uses the unified DELETE /me/library endpoint (Feb 2026 API update)
+   * Remove tracks from user's Spotify library (Liked Songs)
+   *
+   * DELETE /me/tracks with { ids } for Liked Songs. The previously-coded
+   * /me/library endpoint does not exist (same root cause that was fixed
+   * for saveTracks/saveAlbums; the remove* methods were missed in that
+   * pass). Symptom: local Collection removal succeeds, IPC fires, fetch
+   * 404s, fire-and-forget catch swallows the error, and the next sync
+   * re-imports the track because there's no tombstone. See bug report
+   * traced in achordion#72-adjacent investigation.
+   *
    * @param {string[]} trackIds - Array of Spotify track IDs (not URIs)
    * @param {string} token - Access token
    * @returns {Object} - { success: boolean }
@@ -638,20 +646,20 @@ const SpotifySyncProvider = {
       return { success: true, removed: 0 };
     }
 
-    // Convert IDs to Spotify URIs for the unified /me/library endpoint
-    const uris = trackIds.map(id => id.startsWith('spotify:') ? id : `spotify:track:${id}`);
+    // Strip URIs down to bare IDs if needed
+    const ids = trackIds.map(id => id.startsWith('spotify:track:') ? id.replace('spotify:track:', '') : id);
 
     // Spotify allows max 50 items per request
     const batches = [];
-    for (let i = 0; i < uris.length; i += 50) {
-      batches.push(uris.slice(i, i + 50));
+    for (let i = 0; i < ids.length; i += 50) {
+      batches.push(ids.slice(i, i + 50));
     }
 
     let totalRemoved = 0;
     for (const batch of batches) {
-      await spotifyRequest('/me/library', token, {
+      await spotifyRequest('/me/tracks', token, {
         method: 'DELETE',
-        body: { uris: batch }
+        body: { ids: batch }
       });
       totalRemoved += batch.length;
       await new Promise(resolve => setTimeout(resolve, 100)); // Rate limit
@@ -662,7 +670,10 @@ const SpotifySyncProvider = {
 
   /**
    * Remove albums from Spotify library
-   * Uses the unified DELETE /me/library endpoint (Feb 2026 API update)
+   *
+   * DELETE /me/albums with { ids }. Same broken-endpoint regression as
+   * removeTracks above — see that method's docblock for context.
+   *
    * @param {string[]} albumIds - Array of Spotify album IDs
    * @param {string} token - Access token
    * @returns {Object} - { success: boolean, removed: number }
@@ -672,20 +683,20 @@ const SpotifySyncProvider = {
       return { success: true, removed: 0 };
     }
 
-    // Convert IDs to Spotify URIs for the unified /me/library endpoint
-    const uris = albumIds.map(id => id.startsWith('spotify:') ? id : `spotify:album:${id}`);
+    // Strip URIs down to bare IDs if needed
+    const ids = albumIds.map(id => id.startsWith('spotify:album:') ? id.replace('spotify:album:', '') : id);
 
     // Spotify allows max 50 items per request
     const batches = [];
-    for (let i = 0; i < uris.length; i += 50) {
-      batches.push(uris.slice(i, i + 50));
+    for (let i = 0; i < ids.length; i += 50) {
+      batches.push(ids.slice(i, i + 50));
     }
 
     let totalRemoved = 0;
     for (const batch of batches) {
-      await spotifyRequest('/me/library', token, {
+      await spotifyRequest('/me/albums', token, {
         method: 'DELETE',
-        body: { uris: batch }
+        body: { ids: batch }
       });
       totalRemoved += batch.length;
       await new Promise(resolve => setTimeout(resolve, 100)); // Rate limit


### PR DESCRIPTION
## Bug

User reports tracks removed from Collection silently reappearing after sync. Traced via systematic debugging to a broken Spotify DELETE endpoint.

## Root cause

The `saveTracks` / `saveAlbums` provider methods were corrected in an earlier commit with the rationale: *\"PUT /me/tracks with { ids } for Liked Songs, PUT /me/albums with { ids } for saved albums. The previous /me/library endpoint doesn't exist.\"* That fix missed `removeTracks` and `removeAlbums`, which still hit:

```js
await spotifyRequest('/me/library', token, { method: 'DELETE', body: { uris: batch } });
```

Every \"remove from Collection\" click for a Spotify-synced track:
1. Local: removes ✓
2. IPC fires → `DELETE /me/library` → 404 (endpoint doesn't exist)
3. Renderer's `.catch` swallows the rejection as `console.warn`
4. Spotify Liked Songs still has the track
5. Next `sync:start` calls `fetchTracks`, gets the track back from Spotify
6. `calculateDiff` sees it as missing locally → `toAdd` → re-imports

The bug is compounded by the absence of any track-level tombstone (no analog of the playlist `suppressSync` pattern), so even when the remote DELETE fails, there's nothing to remember the user's intent — every sync repeats the re-import.

## Fix

Mirror the prior `save*` commit:

| Before | After |
|---|---|
| `DELETE /me/library` body `{uris}` (tracks) | `DELETE /me/tracks` body `{ids}` |
| `DELETE /me/library` body `{uris}` (albums) | `DELETE /me/albums` body `{ids}` |

Strip URIs to bare IDs if the caller passed URI form — same shape as `saveTracks` / `saveAlbums` after the prior fix. Endpoints match [Spotify Web API docs](https://developer.spotify.com/documentation/web-api/reference/remove-tracks-user).

## Tests

`tests/sync/` — 188/188 pass.

## Scope

This is the proximate cause for the reported \"removals revert\" symptom on Spotify-synced tracks. It does NOT cover:

- **Apple Music removals.** AM has no public-API remove endpoint (per CLAUDE.md \"Apple Music library DELETE returns 401\"). Local removal is silently undone by every sync. Needs a track-level tombstone to fix. Separate issue forthcoming.
- **Spotify removals with `spotifyId` missing on the local track row.** The renderer's conditional `existingTrack.spotifyId` gates the IPC call — falsy IDs skip the remote remove entirely. Tombstone covers this case too.
- **Spotify DELETE failures from other causes** (network blip, token scope drift). Same — tombstone is the durable fix.

The track-level tombstone work is real and worth doing, but it deserves a design pass (TTL? per-provider scoping? mobile mirror?) rather than a same-PR tack-on. Will file an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)