### PR TITLE
feat(sync): track-level remove tombstones (#864)

### DIFF
--- a/app.js
+++ b/app.js
@@ -14734,6 +14734,34 @@ ${trackListXml}
   }, [activeView, flushPendingCollectionSources, flushPendingPlaylistSources]);
 
   // Add track to collection
+  // Derive (providerId, externalId) tuples for every provider that
+  // could have a track-link record for `track`. Used by both the add
+  // path (to clear tombstones — see parachord#864) and the remove path
+  // (to write tombstones). The same track may yield tuples for
+  // multiple providers when cross-resolver enrichment populated them.
+  const deriveTombstoneEntries = useCallback((track) => {
+    if (!track) return [];
+    const entries = [];
+    const seen = new Set();
+    const push = (providerId, externalId) => {
+      if (!providerId || !externalId || typeof externalId !== 'string') return;
+      const key = `${providerId}:${externalId}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      entries.push({ providerId, externalId });
+    };
+    push('spotify', track.spotifyId);
+    push('spotify', track.sources?.spotify?.spotifyId);
+    push('applemusic', track.appleMusicId);
+    push('applemusic', track.sources?.applemusic?.appleMusicId);
+    // ListenBrainz uses recording MBID as the external identifier on
+    // its sync surface (loved-tracks sync — currently one-way push,
+    // no inbound; included for forward-compat if LB inbound lands).
+    push('listenbrainz', track.mbid);
+    push('listenbrainz', track.sources?.listenbrainz?.mbid);
+    return entries;
+  }, []);
+
   const addTrackToCollection = useCallback((track) => {
     const trackId = generateTrackId(track.artist, track.title, track.album);
 
@@ -14763,6 +14791,17 @@ ${trackListXml}
       return newData;
     });
 
+    // Clear any existing tombstones for this track on all providers
+    // (parachord#864) — user is re-adding intentionally, so future
+    // syncs should let the track through. Fire-and-forget; local add
+    // is authoritative regardless of tombstone-clear success.
+    const tombstoneEntries = deriveTombstoneEntries(track);
+    if (tombstoneEntries.length > 0 && window.electron?.tombstones) {
+      window.electron.tombstones.clearBatch(tombstoneEntries)
+        .then(r => r?.cleared > 0 && console.log(`[Tombstones] Cleared ${r.cleared} entries for re-added "${track.title}"`))
+        .catch(err => console.warn('[Tombstones] clearBatch failed:', err?.message || err));
+    }
+
     // Push to connected sync providers (fire-and-forget)
     const syncSettings = resolverSyncSettingsRef.current;
     if (syncSettings && window.electron?.sync) {
@@ -14787,7 +14826,7 @@ ${trackListXml}
     pushLoveToScrobblers({ ...track, id: trackId }).catch(err => {
       console.warn('[love-push] error:', err?.message || err);
     });
-  }, [saveCollection, showToast, showSidebarBadge]);
+  }, [saveCollection, showToast, showSidebarBadge, deriveTombstoneEntries]);
 
   // Push a track's love to any service whose toggle is on. Idempotent
   // via lovePushedKeysRef — if already pushed, skips silently. Persists
@@ -15005,6 +15044,21 @@ ${trackListXml}
 
       const existingTrack = prev.tracks[existingIndex];
 
+      // Write tombstones for every (providerId, externalId) we can
+      // derive from the removed track (parachord#864). This is the
+      // durable record of "user removed this on purpose" — even when
+      // remote-remove succeeds, even when it fails silently, even
+      // when no remove API exists (Apple Music). Without this, the
+      // next sync sees the track present on the remote, missing
+      // locally, and re-imports it. Fire-and-forget; local removal
+      // is authoritative regardless of tombstone-write outcome.
+      const tombstoneEntries = deriveTombstoneEntries(existingTrack);
+      if (tombstoneEntries.length > 0 && window.electron?.tombstones) {
+        window.electron.tombstones.addBatch(tombstoneEntries)
+          .then(r => r?.written > 0 && console.log(`[Tombstones] Wrote ${r.written} entries for removed "${track.title}"`))
+          .catch(err => console.warn('[Tombstones] addBatch failed:', err?.message || err));
+      }
+
       // Remove from connected sync providers
       const syncSettings = resolverSyncSettingsRef.current;
       if (window.electron?.sync) {
@@ -15016,7 +15070,10 @@ ${trackListXml}
             })
             .catch(err => console.warn('[Sync] Failed to remove track from Spotify:', err.message));
         }
-        // Apple Music: API doesn't support removal, but log for awareness
+        // Apple Music: API doesn't support removal. The tombstone
+        // written above is the only durable record — every sync will
+        // see the track still on AM remote, but the tombstone filter
+        // (parachord#864) blocks the re-import.
       }
 
       const newTracks = prev.tracks.filter(t => t.id !== matchId);
@@ -15026,7 +15083,7 @@ ${trackListXml}
       showToast(`Removed ${track.title} from Collection`);
       return newData;
     });
-  }, [saveCollection, showToast]);
+  }, [saveCollection, showToast, deriveTombstoneEntries]);
 
   // Add album to collection
   const addAlbumToCollection = useCallback((album) => {

--- a/main.js
+++ b/main.js
@@ -5512,6 +5512,19 @@ function healImportedSyncedFromMismatch() {
 }
 healImportedSyncedFromMismatch();
 
+// Prune expired track tombstones at app start (parachord#864). One-shot
+// per launch; entries older than TOMBSTONE_TTL_MS (365 days) are
+// dropped. Tombstones get re-armed every time the sync filter sees the
+// remote still has the track, so this only catches "user removed,
+// never re-added, stopped syncing the provider OR remote also removed"
+// — i.e. genuinely stale state.
+try {
+  const pruned = Tombstones.pruneExpired(store);
+  if (pruned > 0) console.log(`[Tombstones] Pruned ${pruned} expired entries at startup`);
+} catch (err) {
+  console.warn('[Tombstones] Prune failed (non-fatal):', err.message);
+}
+
 ipcMain.handle('playlists-delete-from-source', async (event, providerId, externalId) => {
   console.log(`=== Delete Playlist from Source: ${providerId}/${externalId} ===`);
   try {
@@ -6004,6 +6017,7 @@ ipcMain.handle('sync-settings:set-provider', async (event, providerId, providerS
 // =============================================================================
 
 const SyncEngine = require('./sync-engine');
+const Tombstones = require('./sync-engine/tombstones');
 
 // Track active sync operations
 const activeSyncs = new Map();
@@ -6212,6 +6226,19 @@ ipcMain.handle('sync:start', async (event, providerId, options = {}) => {
       console.log('[Sync] No existing collection, starting fresh');
     }
 
+    // Tombstone filter (parachord#864) — drops remote tracks the user
+    // previously removed from Collection, so the diff doesn't see them
+    // as toAdd and silently undo the removal. Each filter hit also
+    // re-arms the tombstone's TTL inside the helper. Only wired for
+    // tracks today (album-level tombstones tracked separately).
+    const filterTrackTombstones = (remoteItems) => {
+      const { filtered, dropped } = Tombstones.filterRemoteByTombstones(store, remoteItems, providerId);
+      if (dropped > 0) {
+        console.log(`[Sync] Tombstone filter dropped ${dropped} re-import attempt(s) for ${providerId}`);
+      }
+      return filtered;
+    };
+
     // Sync tracks
     if (settings.syncTracks !== false && provider.capabilities.tracks) {
       sendProgress({ phase: 'fetching', type: 'tracks', message: 'Fetching liked songs...' });
@@ -6223,7 +6250,8 @@ ipcMain.handle('sync:start', async (event, providerId, options = {}) => {
         collection.tracks || [],
         (p) => sendProgress({ phase: 'fetching', type: 'tracks', ...p }),
         refreshToken,
-        isCancelled  // parachord#820: poll between paginated pages
+        isCancelled,  // parachord#820: poll between paginated pages
+        { filterRemote: filterTrackTombstones }  // parachord#864
       );
       console.log(`[Sync] Track sync complete. Output: ${trackResult.data.length} tracks. Stats:`, trackResult.stats);
       collection.tracks = trackResult.data;
@@ -7727,6 +7755,36 @@ ipcMain.handle('sync:save-albums', async (event, providerId, albumIds) => {
   } catch (error) {
     return { success: false, error: error.message };
   }
+});
+
+// ── Track tombstones (parachord#864) ─────────────────────────────
+//
+// Renderer-side `removeTrackFromCollection` writes tombstones for
+// every (providerId, externalId) on the removed track. Renderer-side
+// `addTrackToCollection` clears them when the user re-adds a track.
+// `sync:start` filters remote items against the tombstone list before
+// diffing. App start runs `pruneExpired` once.
+
+ipcMain.handle('sync:tombstones:add-batch', async (event, entries) => {
+  try {
+    const written = Tombstones.addTombstones(store, entries);
+    return { success: true, written };
+  } catch (err) {
+    return { success: false, error: err.message };
+  }
+});
+
+ipcMain.handle('sync:tombstones:clear-batch', async (event, entries) => {
+  try {
+    const cleared = Tombstones.clearTombstones(store, entries);
+    return { success: true, cleared };
+  } catch (err) {
+    return { success: false, error: err.message };
+  }
+});
+
+ipcMain.handle('sync:tombstones:list', async () => {
+  return store.get(Tombstones.TOMBSTONE_KEY) || {};
 });
 
 // Remove tracks from sync provider library

--- a/preload.js
+++ b/preload.js
@@ -396,6 +396,16 @@ contextBridge.exposeInMainWorld('electron', {
     remove: (localPlaylistId, providerId) => ipcRenderer.invoke('sync-links:remove', localPlaylistId, providerId)
   },
 
+  // Track-level tombstones (parachord#864) — durable "user removed
+  // this on purpose" markers that prevent the next sync from re-adding
+  // a track whose remote-remove failed silently (or for AM, was never
+  // attempted). Keyed by (providerId, externalId).
+  tombstones: {
+    addBatch: (entries) => ipcRenderer.invoke('sync:tombstones:add-batch', entries),
+    clearBatch: (entries) => ipcRenderer.invoke('sync:tombstones:clear-batch', entries),
+    list: () => ipcRenderer.invoke('sync:tombstones:list')
+  },
+
   // Playback window operations (for Bandcamp, etc. with autoplay)
   playbackWindow: {
     open: (url, options) => ipcRenderer.invoke('open-playback-window', url, options),

--- a/sync-engine/index.js
+++ b/sync-engine/index.js
@@ -166,7 +166,7 @@ const applyDiff = (collectionItems, diff) => {
  * `isCancelled()` check in `sync:start` then routes to `finalizeCancelled`
  * and the run exits without applying a partial diff. See parachord#820.
  */
-const syncDataType = async (provider, token, dataType, localData, onProgress, refreshToken, isCancelled) => {
+const syncDataType = async (provider, token, dataType, localData, onProgress, refreshToken, isCancelled, options = {}) => {
   // Count how many local items came from this provider (for incremental check)
   const syncedItems = localData.filter(item => item.syncSources?.[provider.id]);
   const localSyncedCount = syncedItems.length;
@@ -204,6 +204,16 @@ const syncDataType = async (provider, token, dataType, localData, onProgress, re
       data: localData,
       stats: { added: 0, removed: 0, updated: 0, unchanged: localSyncedCount }
     };
+  }
+
+  // Apply caller-supplied remote-side filter BEFORE diffing. The track
+  // tombstone path (parachord#864) uses this to drop items the user
+  // previously removed locally — without the filter, the diff would
+  // see them as `toAdd` and silently undo the user's removal. Generic
+  // hook so future filters (provider-specific blocklists, etc.) plug
+  // in here too.
+  if (typeof options.filterRemote === 'function') {
+    remoteData = options.filterRemote(remoteData);
   }
 
   // Calculate diff

--- a/sync-engine/tombstones.js
+++ b/sync-engine/tombstones.js
@@ -1,0 +1,196 @@
+/**
+ * Track Tombstones — durable "user removed this on purpose" markers.
+ *
+ * Addresses parachord#864. The sync diff (`calculateDiff` in this
+ * directory's index.js) only knows two cases: "remote has it, local
+ * doesn't → add" and "local has it, remote doesn't → remove." Without
+ * a tombstone, the diff cannot distinguish "the user never had this"
+ * from "the user deleted this," so any remote-remove failure
+ * (transient or structural — Apple Music has no remove API at all)
+ * results in the user's removal being silently undone by the next
+ * sync. The reported symptom is "tracks I removed keep coming back."
+ *
+ * This module is the per-track analog of `suppressSync(providerId,
+ * externalId)` for playlists (app.js ~L7966). Keyed by
+ * (providerId, externalId), TTL'd, with re-arm on every sync that
+ * confirms the remote still has the track.
+ *
+ * The module is pure functions taking a store-like object — main.js
+ * passes electron-store; tests inject an in-memory fake. No I/O
+ * beyond the store interface.
+ *
+ * Storage shape (electron-store key `removed_track_tombstones`):
+ *   {
+ *     [providerId]: {
+ *       [externalId]: { removedAt: number }
+ *     }
+ *   }
+ *
+ * Cleanup invariants:
+ *   - Re-add via UI (addTrackToCollection) should call
+ *     `clearTombstones` for every (provider, externalId) on the
+ *     re-added track shape.
+ *   - App start should call `pruneExpired` once.
+ *   - Every sync:start should call `filterRemoteByTombstones` BEFORE
+ *     passing remote tracks to `calculateDiff`. On any hit the
+ *     tombstone's TTL is re-armed automatically — proves the remote
+ *     still has the track, so the tombstone stays durable for the
+ *     full TTL window after every confirmation.
+ */
+
+const TOMBSTONE_KEY = 'removed_track_tombstones';
+const TOMBSTONE_TTL_MS = 365 * 24 * 60 * 60 * 1000; // 365 days
+
+const _isValidStr = (v) => typeof v === 'string' && v.length > 0;
+const _read = (store) => store.get(TOMBSTONE_KEY) || {};
+const _write = (store, data) => store.set(TOMBSTONE_KEY, data);
+
+/**
+ * Add (or refresh) a tombstone for (providerId, externalId).
+ * Idempotent — same key updates `removedAt`. Returns true on write.
+ */
+const addTombstone = (store, providerId, externalId, now = Date.now()) => {
+  if (!_isValidStr(providerId) || !_isValidStr(externalId)) return false;
+  const all = _read(store);
+  if (!all[providerId]) all[providerId] = {};
+  all[providerId][externalId] = { removedAt: now };
+  _write(store, all);
+  return true;
+};
+
+/**
+ * Batch variant — writes once for multiple entries. Returns the
+ * count of valid entries written. Invalid entries are silently
+ * skipped (don't reject the whole batch).
+ */
+const addTombstones = (store, entries, now = Date.now()) => {
+  if (!Array.isArray(entries) || entries.length === 0) return 0;
+  const all = _read(store);
+  let written = 0;
+  for (const e of entries) {
+    if (!e || !_isValidStr(e.providerId) || !_isValidStr(e.externalId)) continue;
+    if (!all[e.providerId]) all[e.providerId] = {};
+    all[e.providerId][e.externalId] = { removedAt: now };
+    written++;
+  }
+  if (written > 0) _write(store, all);
+  return written;
+};
+
+/**
+ * Read a single tombstone. Returns `{removedAt}` or `null`.
+ */
+const getTombstone = (store, providerId, externalId) => {
+  const all = _read(store);
+  return all[providerId]?.[externalId] || null;
+};
+
+/**
+ * Remove a single tombstone. Returns true if it existed.
+ */
+const clearTombstone = (store, providerId, externalId) => {
+  const all = _read(store);
+  if (!all[providerId]?.[externalId]) return false;
+  delete all[providerId][externalId];
+  if (Object.keys(all[providerId]).length === 0) delete all[providerId];
+  _write(store, all);
+  return true;
+};
+
+/**
+ * Batch clear — used by re-add paths where we want to wipe every
+ * (providerId, externalId) on a re-added track. Returns the count
+ * of entries that existed and were removed.
+ */
+const clearTombstones = (store, entries) => {
+  if (!Array.isArray(entries) || entries.length === 0) return 0;
+  const all = _read(store);
+  let cleared = 0;
+  for (const e of entries) {
+    if (!e || !all[e.providerId]?.[e.externalId]) continue;
+    delete all[e.providerId][e.externalId];
+    if (Object.keys(all[e.providerId]).length === 0) delete all[e.providerId];
+    cleared++;
+  }
+  if (cleared > 0) _write(store, all);
+  return cleared;
+};
+
+/**
+ * Sweep entries older than TTL. Also removes corrupt entries
+ * lacking `removedAt`. Returns the count pruned.
+ */
+const pruneExpired = (store, ttlMs = TOMBSTONE_TTL_MS, now = Date.now()) => {
+  const all = _read(store);
+  let pruned = 0;
+  for (const providerId of Object.keys(all)) {
+    const bucket = all[providerId];
+    for (const externalId of Object.keys(bucket)) {
+      const entry = bucket[externalId];
+      const removedAt = entry && typeof entry.removedAt === 'number' ? entry.removedAt : null;
+      if (removedAt === null || (now - removedAt) > ttlMs) {
+        delete bucket[externalId];
+        pruned++;
+      }
+    }
+    if (Object.keys(bucket).length === 0) delete all[providerId];
+  }
+  if (pruned > 0) _write(store, all);
+  return pruned;
+};
+
+/**
+ * Filter remote items by tombstones. Items with an `externalId`
+ * present in the tombstone bucket for `providerId` are dropped.
+ *
+ * Side effect by design: every hit re-arms the tombstone's
+ * `removedAt` to `now`, extending its TTL. This keeps the user's
+ * intent durable for as long as the remote keeps the track AND the
+ * user keeps syncing the provider — the tombstone only expires after
+ * a full TTL window with no further sync hits, which usually means
+ * the remote no longer has it OR the user has stopped using this
+ * client.
+ *
+ * Returns `{filtered, dropped}`. Returns the input unchanged (with
+ * dropped=0) if items is empty/null or the provider has no
+ * tombstones.
+ */
+const filterRemoteByTombstones = (store, items, providerId, now = Date.now()) => {
+  if (!Array.isArray(items) || items.length === 0) {
+    return { filtered: items, dropped: 0 };
+  }
+  if (!_isValidStr(providerId)) {
+    return { filtered: items, dropped: 0 };
+  }
+  const all = _read(store);
+  const providerMap = all[providerId];
+  if (!providerMap) return { filtered: items, dropped: 0 };
+
+  const filtered = [];
+  let dropped = 0;
+  let touched = false;
+  for (const item of items) {
+    const ext = item?.externalId;
+    if (ext && providerMap[ext]) {
+      providerMap[ext] = { removedAt: now };
+      touched = true;
+      dropped++;
+    } else {
+      filtered.push(item);
+    }
+  }
+  if (touched) _write(store, all);
+  return { filtered, dropped };
+};
+
+module.exports = {
+  TOMBSTONE_KEY,
+  TOMBSTONE_TTL_MS,
+  addTombstone,
+  addTombstones,
+  getTombstone,
+  clearTombstone,
+  clearTombstones,
+  pruneExpired,
+  filterRemoteByTombstones
+};

--- a/tests/sync/sync-engine.test.js
+++ b/tests/sync/sync-engine.test.js
@@ -1471,6 +1471,98 @@ describe('syncDataType isCancelled propagation (parachord#820)', () => {
   });
 });
 
+describe('syncDataType remote filter callback (tombstones — parachord#864)', () => {
+  // Minimal provider stub that returns a fixed remote set.
+  const makeProvider = (trackData) => ({
+    id: 'spotify',
+    fetchTracks: jest.fn(async () => trackData)
+  });
+
+  const remote = (externalId, title) => ({
+    id: `track-${externalId}`,
+    externalId,
+    title: title || `t-${externalId}`,
+    artist: 'a',
+    album: 'A'
+  });
+
+  test('filterRemote callback is called with the raw remote list', async () => {
+    const provider = makeProvider([remote('1'), remote('2'), remote('3')]);
+    const filterRemote = jest.fn((items) => items);
+
+    await syncDataType(
+      provider, 'token', 'tracks', [], () => {}, null, null,
+      { filterRemote }
+    );
+
+    expect(filterRemote).toHaveBeenCalledWith(
+      [remote('1'), remote('2'), remote('3')]
+    );
+  });
+
+  test('items dropped by filterRemote do not enter toAdd', async () => {
+    const provider = makeProvider([remote('1'), remote('2'), remote('3')]);
+    // Filter drops externalId="2"
+    const filterRemote = (items) => items.filter(i => i.externalId !== '2');
+
+    const result = await syncDataType(
+      provider, 'token', 'tracks', [], () => {}, null, null,
+      { filterRemote }
+    );
+
+    expect(result.stats.added).toBe(2);
+    expect(result.data.map(t => t.externalId).sort()).toEqual(['1', '3']);
+  });
+
+  test('omitting filterRemote is backward-compatible', async () => {
+    const provider = makeProvider([remote('1'), remote('2')]);
+    const result = await syncDataType(
+      provider, 'token', 'tracks', [], () => {}, null, null
+    );
+    expect(result.stats.added).toBe(2);
+  });
+
+  test('filterRemote that drops everything yields empty add list', async () => {
+    const provider = makeProvider([remote('1'), remote('2')]);
+    const result = await syncDataType(
+      provider, 'token', 'tracks', [], () => {}, null, null,
+      { filterRemote: () => [] }
+    );
+    expect(result.stats.added).toBe(0);
+    expect(result.data).toEqual([]);
+  });
+
+  test('filterRemote runs before mass-removal safeguard and diff', async () => {
+    // 5 local items synced, remote returns only 2 (would trigger mass removal
+    // safeguard at 60% removal). After filter drops one of those 2, the
+    // mass-removal threshold logic still operates on the post-filter count.
+    const localSourced = (id) => ({
+      id, title: `t${id}`, artist: 'a', album: 'A',
+      syncSources: { spotify: { syncedAt: 100 } }
+    });
+    const local = [
+      localSourced('track-1'), localSourced('track-2'),
+      localSourced('track-3'), localSourced('track-4'),
+      localSourced('track-5')
+    ];
+    const provider = makeProvider([
+      { id: 'track-6', externalId: '6', title: 't6', artist: 'a', album: 'A' },
+      { id: 'track-7', externalId: '7', title: 't7', artist: 'a', album: 'A' }
+    ]);
+    // Filter drops 6 from being added
+    const filterRemote = (items) => items.filter(i => i.externalId !== '6');
+
+    const result = await syncDataType(
+      provider, 'token', 'tracks', local, () => {}, null, null,
+      { filterRemote }
+    );
+
+    // Only track-7 should have been added (track-6 was tombstoned by filter).
+    expect(result.data.find(t => t.id === 'track-7')).toBeDefined();
+    expect(result.data.find(t => t.id === 'track-6')).toBeUndefined();
+  });
+});
+
 describe('areOrderedIdListsEquivalent (updatePlaylistTracks short-circuit helper)', () => {
   test('returns true for identical ordered lists', () => {
     expect(areOrderedIdListsEquivalent(['a', 'b', 'c'], ['a', 'b', 'c'])).toBe(true);

--- a/tests/sync/track-tombstones.test.js
+++ b/tests/sync/track-tombstones.test.js
@@ -1,0 +1,295 @@
+/**
+ * Track Tombstones — pure module tests.
+ *
+ * The tombstone module persists "user removed this track on purpose"
+ * markers so that subsequent syncs from the same provider don't undo
+ * the user's removal by re-adding the still-present remote track.
+ *
+ * Addresses parachord#864. Mirrors the per-playlist `suppressSync`
+ * pattern at the track level, keyed by (providerId, externalId).
+ *
+ * The module is pure functions that take a store-like object — the
+ * tests inject an in-memory fake. Main-process integration (IPC,
+ * sync:start filter, app-start prune) is exercised in app-level tests
+ * separately.
+ */
+
+const {
+  addTombstone,
+  addTombstones,
+  getTombstone,
+  clearTombstone,
+  clearTombstones,
+  pruneExpired,
+  filterRemoteByTombstones,
+  TOMBSTONE_KEY,
+  TOMBSTONE_TTL_MS
+} = require('../../sync-engine/tombstones');
+
+const makeStore = (initial = {}) => {
+  const data = { ...initial };
+  return {
+    get: (k) => data[k],
+    set: (k, v) => { data[k] = v; },
+    _peek: () => data
+  };
+};
+
+describe('Track Tombstones', () => {
+  describe('addTombstone', () => {
+    it('writes a new entry under (providerId, externalId)', () => {
+      const store = makeStore();
+      const ok = addTombstone(store, 'spotify', 'abc123', 1000);
+      expect(ok).toBe(true);
+      expect(getTombstone(store, 'spotify', 'abc123')).toEqual({ removedAt: 1000 });
+    });
+
+    it('refreshes removedAt when called twice for the same key', () => {
+      const store = makeStore();
+      addTombstone(store, 'spotify', 'abc123', 1000);
+      addTombstone(store, 'spotify', 'abc123', 2000);
+      expect(getTombstone(store, 'spotify', 'abc123')).toEqual({ removedAt: 2000 });
+    });
+
+    it('keeps providers independent', () => {
+      const store = makeStore();
+      addTombstone(store, 'spotify', 'abc', 1000);
+      addTombstone(store, 'applemusic', 'abc', 2000);
+      expect(getTombstone(store, 'spotify', 'abc')).toEqual({ removedAt: 1000 });
+      expect(getTombstone(store, 'applemusic', 'abc')).toEqual({ removedAt: 2000 });
+    });
+
+    it('rejects empty providerId', () => {
+      const store = makeStore();
+      expect(addTombstone(store, '', 'abc', 1000)).toBe(false);
+      expect(store._peek()[TOMBSTONE_KEY]).toBeUndefined();
+    });
+
+    it('rejects empty externalId', () => {
+      const store = makeStore();
+      expect(addTombstone(store, 'spotify', '', 1000)).toBe(false);
+      expect(store._peek()[TOMBSTONE_KEY]).toBeUndefined();
+    });
+
+    it('rejects non-string providerId or externalId', () => {
+      const store = makeStore();
+      expect(addTombstone(store, null, 'abc', 1000)).toBe(false);
+      expect(addTombstone(store, 'spotify', null, 1000)).toBe(false);
+      expect(addTombstone(store, 42, 'abc', 1000)).toBe(false);
+    });
+  });
+
+  describe('getTombstone', () => {
+    it('returns null for missing keys', () => {
+      const store = makeStore();
+      expect(getTombstone(store, 'spotify', 'never-existed')).toBeNull();
+    });
+
+    it('returns null for missing provider bucket', () => {
+      const store = makeStore();
+      addTombstone(store, 'spotify', 'abc', 1000);
+      expect(getTombstone(store, 'applemusic', 'abc')).toBeNull();
+    });
+  });
+
+  describe('addTombstones (batch)', () => {
+    it('writes multiple entries in one store write', () => {
+      const store = makeStore();
+      const written = addTombstones(store, [
+        { providerId: 'spotify', externalId: 'a' },
+        { providerId: 'spotify', externalId: 'b' },
+        { providerId: 'applemusic', externalId: 'c' }
+      ], 1000);
+      expect(written).toBe(3);
+      expect(getTombstone(store, 'spotify', 'a')).toEqual({ removedAt: 1000 });
+      expect(getTombstone(store, 'spotify', 'b')).toEqual({ removedAt: 1000 });
+      expect(getTombstone(store, 'applemusic', 'c')).toEqual({ removedAt: 1000 });
+    });
+
+    it('skips invalid entries without rejecting the whole batch', () => {
+      const store = makeStore();
+      const written = addTombstones(store, [
+        { providerId: 'spotify', externalId: 'a' },
+        { providerId: '', externalId: 'b' },
+        { providerId: 'spotify', externalId: 'c' }
+      ], 1000);
+      expect(written).toBe(2);
+      expect(getTombstone(store, 'spotify', 'a')).not.toBeNull();
+      expect(getTombstone(store, 'spotify', 'c')).not.toBeNull();
+    });
+
+    it('returns 0 for empty input without touching the store', () => {
+      const store = makeStore();
+      expect(addTombstones(store, [])).toBe(0);
+      expect(addTombstones(store, null)).toBe(0);
+      expect(store._peek()[TOMBSTONE_KEY]).toBeUndefined();
+    });
+  });
+
+  describe('clearTombstone', () => {
+    it('removes a single entry', () => {
+      const store = makeStore();
+      addTombstone(store, 'spotify', 'abc', 1000);
+      expect(clearTombstone(store, 'spotify', 'abc')).toBe(true);
+      expect(getTombstone(store, 'spotify', 'abc')).toBeNull();
+    });
+
+    it('cleans up empty provider buckets', () => {
+      const store = makeStore();
+      addTombstone(store, 'spotify', 'only', 1000);
+      clearTombstone(store, 'spotify', 'only');
+      expect(store._peek()[TOMBSTONE_KEY].spotify).toBeUndefined();
+    });
+
+    it('returns false when nothing to clear', () => {
+      const store = makeStore();
+      expect(clearTombstone(store, 'spotify', 'nope')).toBe(false);
+    });
+  });
+
+  describe('clearTombstones (batch)', () => {
+    it('clears multiple entries across providers', () => {
+      const store = makeStore();
+      addTombstone(store, 'spotify', 'a', 1000);
+      addTombstone(store, 'applemusic', 'b', 1000);
+      addTombstone(store, 'spotify', 'c', 1000);
+      const cleared = clearTombstones(store, [
+        { providerId: 'spotify', externalId: 'a' },
+        { providerId: 'applemusic', externalId: 'b' }
+      ]);
+      expect(cleared).toBe(2);
+      expect(getTombstone(store, 'spotify', 'a')).toBeNull();
+      expect(getTombstone(store, 'applemusic', 'b')).toBeNull();
+      expect(getTombstone(store, 'spotify', 'c')).not.toBeNull();
+    });
+
+    it('silently skips missing entries', () => {
+      const store = makeStore();
+      const cleared = clearTombstones(store, [
+        { providerId: 'spotify', externalId: 'never-existed' }
+      ]);
+      expect(cleared).toBe(0);
+    });
+  });
+
+  describe('pruneExpired', () => {
+    it('removes entries older than TTL', () => {
+      const store = makeStore();
+      addTombstone(store, 'spotify', 'old', 0);
+      addTombstone(store, 'spotify', 'recent', TOMBSTONE_TTL_MS / 2);
+      const pruned = pruneExpired(store, TOMBSTONE_TTL_MS, TOMBSTONE_TTL_MS + 1);
+      expect(pruned).toBe(1);
+      expect(getTombstone(store, 'spotify', 'old')).toBeNull();
+      expect(getTombstone(store, 'spotify', 'recent')).not.toBeNull();
+    });
+
+    it('cleans up empty provider buckets after pruning', () => {
+      const store = makeStore();
+      addTombstone(store, 'spotify', 'only', 0);
+      pruneExpired(store, TOMBSTONE_TTL_MS, TOMBSTONE_TTL_MS + 1);
+      expect(store._peek()[TOMBSTONE_KEY]?.spotify).toBeUndefined();
+    });
+
+    it('returns 0 when nothing expired', () => {
+      const store = makeStore();
+      addTombstone(store, 'spotify', 'recent', 1000);
+      expect(pruneExpired(store, TOMBSTONE_TTL_MS, 2000)).toBe(0);
+    });
+
+    it('removes corrupt entries lacking removedAt', () => {
+      const store = makeStore();
+      // Inject manually-corrupt entry
+      store.set(TOMBSTONE_KEY, { spotify: { bad: {} } });
+      const pruned = pruneExpired(store, TOMBSTONE_TTL_MS, 1000);
+      expect(pruned).toBe(1);
+      expect(getTombstone(store, 'spotify', 'bad')).toBeNull();
+    });
+  });
+
+  describe('filterRemoteByTombstones', () => {
+    it('drops items whose externalId is tombstoned for the same provider', () => {
+      const store = makeStore();
+      addTombstone(store, 'spotify', 'abc', 1000);
+      const items = [
+        { externalId: 'abc', title: 'tombstoned' },
+        { externalId: 'def', title: 'kept' }
+      ];
+      const { filtered, dropped } = filterRemoteByTombstones(store, items, 'spotify');
+      expect(filtered.map(i => i.title)).toEqual(['kept']);
+      expect(dropped).toBe(1);
+    });
+
+    it('re-arms TTL on tombstone hit (proves remote still has it)', () => {
+      const store = makeStore();
+      addTombstone(store, 'spotify', 'abc', 1000);
+      filterRemoteByTombstones(store, [{ externalId: 'abc' }], 'spotify', 5000);
+      expect(getTombstone(store, 'spotify', 'abc')).toEqual({ removedAt: 5000 });
+    });
+
+    it('does not touch tombstones from other providers', () => {
+      const store = makeStore();
+      addTombstone(store, 'applemusic', 'abc', 1000);
+      const { filtered, dropped } = filterRemoteByTombstones(
+        store,
+        [{ externalId: 'abc' }],
+        'spotify'
+      );
+      expect(filtered).toHaveLength(1);
+      expect(dropped).toBe(0);
+      // Other-provider tombstone untouched
+      expect(getTombstone(store, 'applemusic', 'abc').removedAt).toBe(1000);
+    });
+
+    it('handles empty or missing items list', () => {
+      const store = makeStore();
+      addTombstone(store, 'spotify', 'abc', 1000);
+      expect(filterRemoteByTombstones(store, [], 'spotify')).toEqual({ filtered: [], dropped: 0 });
+      expect(filterRemoteByTombstones(store, null, 'spotify')).toEqual({ filtered: null, dropped: 0 });
+    });
+
+    it('handles items without externalId (pass through unchanged)', () => {
+      const store = makeStore();
+      addTombstone(store, 'spotify', 'abc', 1000);
+      const items = [
+        { title: 'no-ext-id' },
+        { externalId: null },
+        { externalId: 'abc' }
+      ];
+      const { filtered, dropped } = filterRemoteByTombstones(store, items, 'spotify');
+      expect(filtered).toHaveLength(2);
+      expect(dropped).toBe(1);
+    });
+  });
+
+  describe('module integration', () => {
+    it('add → filter → clear → filter — end-to-end happy path', () => {
+      const store = makeStore();
+      // User removes a Spotify-synced track
+      addTombstone(store, 'spotify', 'track1', 1000);
+
+      // Next sync sees the track on Spotify → filter drops it
+      const sync1 = filterRemoteByTombstones(
+        store,
+        [{ externalId: 'track1', title: 'foo' }],
+        'spotify',
+        2000
+      );
+      expect(sync1.dropped).toBe(1);
+      // TTL re-armed
+      expect(getTombstone(store, 'spotify', 'track1').removedAt).toBe(2000);
+
+      // User re-adds the track via UI
+      clearTombstones(store, [{ providerId: 'spotify', externalId: 'track1' }]);
+
+      // Next sync now lets it through
+      const sync2 = filterRemoteByTombstones(
+        store,
+        [{ externalId: 'track1', title: 'foo' }],
+        'spotify',
+        3000
+      );
+      expect(sync2.dropped).toBe(0);
+      expect(sync2.filtered).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
Closes #864.

## What

Track-level analog of the per-playlist `suppressSync` pattern. Persists \"user removed this on purpose\" markers keyed by `(providerId, externalId)`, TTL'd at 365 days, re-armed on every sync that confirms the remote still has the track.

Pure module `sync-engine/tombstones.js` (26 unit tests). Wired into `syncDataType` via a generic `options.filterRemote` callback (5 unit tests). Renderer-side `removeTrackFromCollection` writes tombstones; `addTrackToCollection` clears them.

## Why

The diff in `calculateDiff` cannot distinguish \"never had this\" from \"deleted this\" — both look like \"local missing.\" Every remote-remove failure silently undid the user's removal. For Apple Music, removal has no public API at all (per CLAUDE.md, library DELETE returns 401), so every AM-sourced removal was reverted on the next sync forever. For Spotify, transient failures (network blip, scope drift, missing top-level `spotifyId` on the local row) hit the same regression more rarely.

## Failure modes addressed

| Scenario | Before | After |
|---|---|---|
| Spotify remote-remove succeeds | ✓ stays removed | ✓ stays removed |
| Spotify remote-remove fails silently | re-imported next sync | tombstone blocks re-import |
| AM removal — no remote API | re-imported every sync forever | tombstone blocks re-import |
| Multi-source track (e.g. Spotify+AM both have it) | one source's re-add succeeds | tombstones for both sources block re-add |
| User re-adds a removed track | n/a | tombstone cleared on add |

## Cleanup invariants

- Re-add via UI clears tombstones for every `(providerId, externalId)` derivable from the re-added track shape.
- App start prunes entries older than 365 days.
- Every sync that sees the remote still has a tombstoned track **re-arms** the TTL — entries only fully expire after 365 days with NO further sync hits.

## Surface

| Layer | Change |
|---|---|
| `sync-engine/tombstones.js` | New pure module: `add`, `addBatch`, `get`, `clear`, `clearBatch`, `pruneExpired`, `filterRemoteByTombstones` |
| `sync-engine/index.js` | `syncDataType` accepts `options.filterRemote` — applied between fetch and diff |
| `main.js` | `Tombstones` import + 3 IPC handlers + app-start prune + `sync:start` wires the filter for tracks |
| `preload.js` | `window.electron.tombstones.{addBatch, clearBatch, list}` |
| `app.js` | `deriveTombstoneEntries(track)` helper, `removeTrackFromCollection` writes, `addTrackToCollection` clears |

## Tests

- New `tests/sync/track-tombstones.test.js` — 26 unit tests on the pure module (add / batch / get / clear / batch clear / prune / filter / re-arm / invalid-input rejection / end-to-end integration).
- Augmented `tests/sync/sync-engine.test.js` — 5 tests on the `filterRemote` callback.
- Full suite: **1680/1680 passing**.

## Out of scope

- **Album / artist tombstones** — same architectural shape but a different match key. Less commonly hit in practice (CLAUDE.md notes artist follow/unfollow round-trips cleanly via provider APIs). Hold for a future report.
- **Wizard \"clear remove history\" UI** — polish; not blocking.
- **Mobile mirror** — tracked at [Parachord/parachord-mobile#172](https://github.com/Parachord/parachord-mobile/issues/172). The same architectural gap exists on mobile; this PR's schema/TTL/cleanup decisions are what the mobile ticket waits on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)