### PR TITLE
fix(mcp): extract stdio bridge to stable user-data path (#866)

### DIFF
--- a/main.js
+++ b/main.js
@@ -1573,6 +1573,35 @@ app.whenReady().then(() => {
   // Begin periodic in-app announcements fetch
   startAnnouncementsPolling();
 
+  // Extract mcp-stdio.js to a stable user-data path (parachord#866).
+  //
+  // AppImage mounts itself at /tmp/.mount_<RANDOMSUFFIX>/ via FUSE on
+  // every launch — the suffix is regenerated per run, so resolving the
+  // stdio bridge via __dirname produces a path that goes stale the
+  // next time Parachord restarts. The MCP client config the user
+  // copies from Settings then breaks on next launch.
+  //
+  // Fix: extract to app.getPath('userData')/mcp-stdio.js — XDG-conformant
+  // on Linux (~/.config/Parachord/mcp-stdio.js), stable per-user on
+  // every platform, independent of how Parachord was installed
+  // (AppImage / .deb / source / Mac / Windows). Cheap — the bridge is a
+  // few-KB Node script with no dependencies.
+  //
+  // Re-copies on every launch so the on-disk file always matches the
+  // bundled version (handles upgrades automatically without a version
+  // check).
+  try {
+    const sourceBase = app.isPackaged ? __dirname.replace('app.asar', 'app.asar.unpacked') : __dirname;
+    const stdioSource = path.join(sourceBase, 'mcp-stdio.js');
+    const stdioDest = path.join(app.getPath('userData'), 'mcp-stdio.js');
+    fs.copyFileSync(stdioSource, stdioDest);
+    console.log(`[MCP] Extracted stdio bridge to ${stdioDest}`);
+  } catch (err) {
+    // Non-fatal — Settings UI will fall back to __dirname-based path.
+    // Logged so we know when this path silently degrades.
+    console.warn('[MCP] Failed to extract stdio bridge to userData:', err.message);
+  }
+
   // Register as default handler for parachord:// protocol
   if (process.defaultApp) {
     if (process.argv.length >= 2) {
@@ -5793,12 +5822,27 @@ ipcMain.handle('mcp-response', (event, { requestId, data }) => {
   handleRendererResponse(requestId, data);
 });
 
-// MCP server info - expose path for Claude Desktop config UI
+// MCP server info — expose path for Claude Desktop config UI.
+//
+// Returns the user-data extracted copy (parachord#866). The asarUnpacked
+// path inside `__dirname` would also work on Mac/Windows, but it's
+// unstable on Linux AppImage (the /tmp/.mount_<RANDOM>/ FUSE mount
+// regenerates per launch). Uniform userData path across platforms keeps
+// the code simple and the on-disk location predictable for users.
+//
+// Falls back to the __dirname-derived path if the userData copy is
+// missing for any reason (extraction errored at startup) so the IPC
+// still returns something usable.
 ipcMain.handle('mcp-get-info', () => {
-  // In packaged builds, mcp-stdio.js is asarUnpacked so external processes can access it
-  const basePath = app.isPackaged ? __dirname.replace('app.asar', 'app.asar.unpacked') : __dirname;
+  const stableStdioPath = path.join(app.getPath('userData'), 'mcp-stdio.js');
+  let stdioPath = stableStdioPath;
+  if (!fs.existsSync(stableStdioPath)) {
+    const fallbackBase = app.isPackaged ? __dirname.replace('app.asar', 'app.asar.unpacked') : __dirname;
+    stdioPath = path.join(fallbackBase, 'mcp-stdio.js');
+    console.warn(`[MCP] Stable stdio path missing, falling back to ${stdioPath}`);
+  }
   return {
-    stdioPath: path.join(basePath, 'mcp-stdio.js'),
+    stdioPath,
     port: 9421
   };
 });


### PR DESCRIPTION
Closes #866. Reported by @theli-ua.

## Bug

On Linux AppImage builds, the MCP `stdioPath` returned by `mcp-get-info` (and displayed in the Settings UI for copy-paste into the user's MCP client config) was unstable across launches:

```json
{ \"command\": \"node\", \"args\": [\"/tmp/.mount_ParachegjsYJ/resources/app.asar.unpacked/mcp-stdio.js\"] }
```

AppImage mounts at `/tmp/.mount_<RANDOMSUFFIX>/` via FUSE on every launch and the suffix is regenerated per run. `mcp-get-info` was resolving the bridge via `__dirname`, which inherited that ephemeral mount path. User's saved MCP config went stale on every Parachord restart.

## Fix

Extract `mcp-stdio.js` to `app.getPath('userData')/mcp-stdio.js` on every `app.whenReady()`:

- Linux: `~/.config/Parachord/mcp-stdio.js`
- macOS: `~/Library/Application Support/Parachord/mcp-stdio.js`
- Windows: `%APPDATA%\\Parachord\\mcp-stdio.js`

`mcp-get-info` returns this stable path. Fallback to the `__dirname`-derived path if extraction errored.

## Why uniform across platforms

Mac/Windows already had stable paths under `app.asar.unpacked`, so technically the fix could be Linux-only. But:

- The userData path works correctly everywhere
- Single code path simpler than `if (process.platform === 'linux')`
- Predictable docs and tooling target (`%appdata%/Parachord/mcp-stdio.js` is more discoverable than asar-unpacked path traversal)
- Re-extracting per launch handles app upgrades automatically with no version check

Mac/Windows users will see the displayed path change in Settings. Their existing MCP client configs continue working (old paths still exist in bundle); change only affects fresh config copies.

## Cost

`mcp-stdio.js` is a few-KB Node script with no dependencies (only the built-in `http` module). Per-launch `fs.copyFileSync` is negligible — runs once at startup, never on the hot path.

## Verification

- `node --check` on main.js — clean
- `npx jest` — 1680/1680 still passing
- Manual verification needed on next build by a Linux/AppImage user (theli-ua already triaged the bug): launch, check `~/.config/Parachord/mcp-stdio.js` exists, copy Settings config, restart, confirm config still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)