### PR TITLE
fix(applemusic): opt-in ignoreCache on fetchUserToken (#773)

### DIFF
--- a/main.js
+++ b/main.js
@@ -2474,7 +2474,12 @@ function buildAppleMusicRefreshCb(_initialToken, onTokenChanged) {
         return null;
       }
 
-      const result = await bridge.fetchUserToken(freshDevToken);
+      // ignoreCache: true (parachord#773) — this callback fires in response
+      // to an actual 401 from Apple, so we genuinely need to bust the local
+      // MusicKit token cache and pull a fresh one. Every other fetchUserToken
+      // call site (renderer-initiated startup / sync paths) intentionally uses
+      // the cached default to avoid spurious native sign-in dialogs.
+      const result = await bridge.fetchUserToken(freshDevToken, { ignoreCache: true });
       if (!result || !result.userToken) {
         emitReauthPromptOnce('bridge-returned-no-token');
         return null;

--- a/musickit-bridge.js
+++ b/musickit-bridge.js
@@ -467,9 +467,18 @@ class MusicKitBridge extends EventEmitter {
     }
   }
 
-  async fetchUserToken(developerToken) {
-    // User token fetch may require authorization, use longer timeout
-    return this.send('fetchUserToken', { developerToken }, 300000);
+  async fetchUserToken(developerToken, opts = {}) {
+    // User token fetch may require authorization, use longer timeout.
+    //
+    // opts.ignoreCache (default false) — pass true ONLY from the explicit
+    // recovery path (post-401 refresh in main.js's
+    // buildAppleMusicRefreshCb). Forcing cache-bust on every fetch was the
+    // root cause of phantom macOS native sign-in dialogs (parachord#773).
+    return this.send(
+      'fetchUserToken',
+      { developerToken, ignoreCache: !!opts.ignoreCache },
+      300000
+    );
   }
 
   async search(query, limit = 25) {

--- a/native/musickit-helper/Sources/MusicKitHelperApp.swift
+++ b/native/musickit-helper/Sources/MusicKitHelperApp.swift
@@ -168,14 +168,23 @@ class MusicKitBridge {
         ]
     }
 
-    // Fetch a Music User Token for REST API access
-    func fetchUserToken(developerToken: String) async -> [String: Any] {
+    // Fetch a Music User Token for REST API access.
+    //
+    // `ignoreCache` is opt-in (parachord#773). Default false uses MusicKit's
+    // local token cache and won't trigger a server round-trip — meaning no
+    // unexpected macOS native "Sign in to your Apple Account" dialog during
+    // routine startup / sync paths. Only callers that genuinely need to bust
+    // the cache (e.g. response to an actual 401 from Apple) should pass true.
+    // Forcing `.ignoreCache` unconditionally was the root cause of phantom
+    // re-auth dialogs reported in #773.
+    func fetchUserToken(developerToken: String, ignoreCache: Bool = false) async -> [String: Any] {
         guard isAuthorized else {
             return ["success": false, "error": "Not authorized"]
         }
         do {
             let tokenProvider = DefaultMusicTokenProvider()
-            let token = try await tokenProvider.userToken(for: developerToken, options: .ignoreCache)
+            let options: MusicTokenRequestOptions = ignoreCache ? .ignoreCache : []
+            let token = try await tokenProvider.userToken(for: developerToken, options: options)
             return ["success": true, "userToken": token]
         } catch {
             return ["success": false, "error": error.localizedDescription]
@@ -530,7 +539,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 guard let developerToken = params["developerToken"] as? String else {
                     return Response(id: request.id, success: false, data: nil, error: "Missing developerToken parameter")
                 }
-                result = await bridge.fetchUserToken(developerToken: developerToken)
+                // ignoreCache opt-in (parachord#773) — defaults to false so the
+                // common case uses MusicKit's local token cache and avoids the
+                // spurious native sign-in dialog.
+                let ignoreCache = (params["ignoreCache"] as? Bool) ?? false
+                result = await bridge.fetchUserToken(developerToken: developerToken, ignoreCache: ignoreCache)
 
             case "search":
                 guard let query = params["query"] as? String else {


### PR DESCRIPTION
Closes #773.

## Bug

The native `MusicKitHelperApp.swift`'s `fetchUserToken` was passing `options: .ignoreCache` unconditionally on every fetch. That forces MusicKit to bypass its local token cache and round-trip to Apple — which can trigger the macOS native \"Sign in to your Apple Account\" dialog during routine startup / sync paths, even when Parachord's stored state is fine.

CLAUDE.md already documents this failure mode under the AM auth section as a known regression class.

## Fix

`ignoreCache` becomes opt-in. Default `false` uses MusicKit's cached token — no server round-trip, no spurious native dialog. The sole caller that genuinely needs cache-bust is `buildAppleMusicRefreshCb` (main.js ~L2477), which fires in response to an actual 401 from Apple. Every other caller (renderer-initiated startup, sync, etc.) defaults to cached.

## Surface

| Layer | Change |
|---|---|
| Swift | `fetchUserToken` gains `ignoreCache: Bool = false` param; dispatch site reads it from `params[\"ignoreCache\"]` with safe `as? Bool ?? false` |
| `musickit-bridge.js` | `fetchUserToken` gains `opts = {}` param, threads through `ignoreCache: !!opts.ignoreCache` |
| `main.js` `buildAppleMusicRefreshCb` | Updated to pass `{ ignoreCache: true }` — the one genuine cache-bust site |
| Renderer-side callers | Unchanged. The `musickit:fetch-user-token` IPC handler (main.js:8333+) calls `bridge.fetchUserToken(developerToken)` with no opts, so all 4 app.js call sites inherit the safe cached default |

## Tests

- `node --check` on musickit-bridge.js + main.js — clean
- `npx jest` — 1680/1680 still passing
- Swift change can't be unit-tested locally; the OptionSet pattern (`ignoreCache ? .ignoreCache : []`) mirrors the existing API shape and will be validated by CI Mac builds on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)