### PR TITLE
fix(chat): auto-linkify URLs + selectable bubbles (#875)

### DIFF
--- a/app.js
+++ b/app.js
@@ -20537,7 +20537,14 @@ ${trackListXml}
         { regex: /\[([^\]]+)\]\(([^)]+)\)/g, type: 'link' },
         { regex: /\*\*([^*]+)\*\*/g, type: 'bold' },
         { regex: /\*([^*]+)\*/g, type: 'italic' },
-        { regex: /`([^`]+)`/g, type: 'code' }
+        { regex: /`([^`]+)`/g, type: 'code' },
+        // Bare http(s):// URLs become clickable links (parachord#875). The
+        // non-greedy body + lookahead stops at the first sentence-final
+        // punctuation followed by whitespace/end, so "visit https://X.com."
+        // matches https://X.com without swallowing the period. When a URL
+        // is already wrapped in [text](url) markdown, the link pattern
+        // matches first and the overlap filter below drops this match.
+        { regex: /\bhttps?:\/\/\S+?(?=[.,;:!?)\]]*(?:\s|$))/g, type: 'bareurl' }
       ];
 
       // Simple approach: process patterns in order
@@ -20715,6 +20722,22 @@ ${trackListXml}
               },
               style: { color: isUserMessage ? '#c4b5fd' : 'var(--accent-soft)', textDecoration: 'underline', cursor: 'pointer' }
             }, linkText)
+          );
+        } else if (r.type === 'bareurl') {
+          // Bare http(s):// URL — render as clickable link via shell.openExternal.
+          // The regex's lookahead already excluded trailing sentence punctuation,
+          // so the matched URL is ready to use as-is.
+          const url = r.match[0];
+          result.push(
+            React.createElement('a', {
+              key,
+              href: url,
+              onClick: (e) => {
+                e.preventDefault();
+                window.electron?.shell?.openExternal(url);
+              },
+              style: { color: isUserMessage ? '#c4b5fd' : 'var(--accent-soft)', textDecoration: 'underline', cursor: 'pointer', wordBreak: 'break-all' }
+            }, url)
           );
         } else if (r.type === 'bold') {
           result.push(React.createElement('strong', { key }, r.match[1]));
@@ -56340,8 +56363,18 @@ useEffect(() => {
                           fontSize: '14px',
                           lineHeight: '1.5',
                           whiteSpace: 'pre-wrap',
-                          wordBreak: 'break-word',
-                          overflow: 'hidden'
+                          // overflowWrap: 'anywhere' forces breaks even mid-token
+                          // so long URLs (Google error messages, etc.) wrap
+                          // cleanly without horizontal clipping. The legacy
+                          // word-break: 'break-word' alias used to be here but
+                          // isn't reliably honored by all renderers (parachord#875).
+                          overflowWrap: 'anywhere',
+                          // Explicitly opt into text selection (parachord#875).
+                          // Default behavior is usually fine but selection in
+                          // Electron + overflow:hidden containers can be flaky;
+                          // setting it explicitly is defense-in-depth.
+                          userSelect: 'text',
+                          WebkitUserSelect: 'text'
                         }
                       }, renderChatContent(msg.content, msg.role === 'user'))
                     );


### PR DESCRIPTION
Closes #875 reported by @neilio.

## What

Three small fixes to the Shuffleupagus sidebar chat bubble:

1. **Bare URLs in chat content are now clickable.** Added a bareurl pattern to \`parseInlineMarkdown\` — \`https://...\` URLs render as \`<a>\` elements routed through \`shell.openExternal\`. The lookahead-based regex avoids swallowing sentence-final punctuation: *\"visit https://X.com.\"* renders as a link to \`https://X.com\` with the period kept as plain text.
2. **Bubble no longer clips long URLs.** Replaced the non-standard \`word-break: break-word\` with the modern \`overflow-wrap: anywhere\`, and dropped \`overflow: hidden\`. Long URLs now wrap cleanly without horizontal truncation.
3. **Text is explicitly selectable.** Added \`user-select: text\` (and \`-webkit-user-select\`) on the bubble as defense-in-depth.

## Why

Neil reported a Gemini API error reading *\"Error: Gemini API has not been used in project [long number]. Enable it by visiting...\"* and cutting off. The full Google error message IS being thrown by the Gemini plugin and stored in chat state, but:

- \`overflow: hidden\` + the legacy \`word-break\` alias was clipping the URL horizontally
- The URL was plain text — even if it displayed, the user couldn't click through to fix the actual problem

Plus he flagged that text in the bubble wasn't selectable for copying.

## Regex verification

Tested the bare-URL pattern \`/\bhttps?:\/\/\S+?(?=[.,;:!?)\]]*(?:\s|$))/g\` against the Gemini error message and 7 edge cases (trailing period, parens, brackets, query strings with \`?\` and \`&\`, multiple URLs in one message, no URLs). All cases handled correctly — trailing sentence punctuation is excluded, query strings preserved, parens/brackets stripped.

## Tests

1680/1680 still pass. The change is purely renderer-side CSS + parsing logic; no main-process changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)