### PR TITLE
feat(splash): inline SVG wordmark with letter pop-in + shimmer cascade

### DIFF
--- a/index.html
+++ b/index.html
@@ -490,38 +490,80 @@
     .loading-dot:nth-child(2) { animation: loadingDotPulse 1.4s ease-in-out 0.15s infinite; }
     .loading-dot:nth-child(3) { animation: loadingDotPulse 1.4s ease-in-out 0.3s infinite; }
 
-    /* Wordmark animation (parachord#878). Gentle breathing — slow opacity
-       + scale pulse on the whole wordmark, keeping the brand mark fully
-       visible (including the red play-triangle accent on the "d"). The
-       wordmark IS the loading indicator. Composed with the initial
-       fade-in-up entrance so the splash settles in then begins breathing.
-       Subtle by design: 0.7→1 opacity range and 1→1.018 scale, both
-       eased so the motion reads as "alive" not "distracting." */
-    @keyframes loadingWordmarkBreath {
+    /* Wordmark animation (parachord#878). True per-letter pop-in using the
+       inline SVG wordmark (paths grouped by letter via <g class="letter-N">).
+       Each letter fades + scales from 0.92 → 1 with a 90ms stagger; total
+       reveal completes in ~1.1s. Once revealed, the whole wordmark begins
+       gentle breathing as the "still loading" indicator while the user
+       waits for app.js parse to finish.
+
+       Theme support via `currentColor` on all paths — sets color via CSS
+       (#1a1a1a in light, #f9fafb in dark) instead of two PNG variants.
+       Crisper rendering than the previous PNG approach + saves ~150KB at
+       splash time. */
+    @keyframes loadingLetterPopIn {
+      from { opacity: 0; transform: translateY(6px) scale(0.92); }
+      to   { opacity: 1; transform: translateY(0) scale(1); }
+    }
+
+    /* Shimmer cascade — each letter pops up and lights up with a brand-red
+       glow as the wave passes through. Per-letter animation-delays (below)
+       stagger the pops left-to-right, so the visual effect is a wave of
+       energy travelling across the wordmark every cycle. Triggered AFTER
+       the letter reveal: pop-in (0–1.0s) → settle (~0.6s) → continuous
+       shimmer. Asymmetric timing (peak at 35%, fully settled by 70%)
+       gives a quick rise + softer landing per letter. */
+    @keyframes loadingLetterShimmer {
       0%, 100% {
-        opacity: 0.85;
-        transform: scale(1);
+        transform: translateY(0) scale(1);
+        filter: drop-shadow(0 0 0 rgba(225, 41, 73, 0));
       }
-      50% {
-        opacity: 1;
-        transform: scale(1.018);
+      35% {
+        transform: translateY(-6px) scale(1.12);
+        filter: drop-shadow(0 0 14px rgba(225, 41, 73, 0.7));
+      }
+      70% {
+        transform: translateY(0) scale(1);
+        filter: drop-shadow(0 0 0 rgba(225, 41, 73, 0));
       }
     }
 
-    .loading-wordmark-img {
+    .loading-wordmark-svg {
       height: 72px;
       width: auto;
-      transform-origin: center;
-      animation: loadingFadeInUp 0.7s cubic-bezier(0.16, 1, 0.3, 1) backwards,
-                 loadingWordmarkBreath 2.6s ease-in-out 0.7s infinite;
+      color: #1a1a1a;
+      /* Allow letter transforms (lift + scale) and drop-shadow glow to
+         render outside the viewBox. Without this, the play-triangle
+         accent on the "d" gets clipped at the top edge when letter-9
+         lifts during the shimmer cascade, and the feather descender on
+         the "p" clips at the bottom (parachord#878). */
+      overflow: visible;
     }
 
-    /* Theme-aware wordmark variant swap. Both images are pre-loaded so the
-       swap on .dark toggle is instant. ~75KB each, negligible at splash
-       time. */
-    .loading-wordmark-img-dark { display: none; }
-    .dark .loading-wordmark-img-light { display: none; }
-    .dark .loading-wordmark-img-dark { display: block; }
+    .dark .loading-wordmark-svg {
+      color: #f9fafb;
+    }
+
+    .loading-wordmark-svg .letter {
+      opacity: 0;
+      transform-box: fill-box;
+      transform-origin: center;
+      animation:
+        loadingLetterPopIn 0.32s cubic-bezier(0.22, 1.2, 0.36, 1) forwards,
+        loadingLetterShimmer 2.6s ease-in-out infinite;
+    }
+    /* Two delays per letter: (1) pop-in entrance — 90ms cascade right;
+       (2) shimmer kickoff — starts ~0.7s after the reveal completes
+       (which is at 1.04s = 0.72 + 0.32), then cascades again. */
+    .loading-wordmark-svg .letter-1 { animation-delay: 0.00s, 1.7s; }
+    .loading-wordmark-svg .letter-2 { animation-delay: 0.09s, 1.8s; }
+    .loading-wordmark-svg .letter-3 { animation-delay: 0.18s, 1.9s; }
+    .loading-wordmark-svg .letter-4 { animation-delay: 0.27s, 2.0s; }
+    .loading-wordmark-svg .letter-5 { animation-delay: 0.36s, 2.1s; }
+    .loading-wordmark-svg .letter-6 { animation-delay: 0.45s, 2.2s; }
+    .loading-wordmark-svg .letter-7 { animation-delay: 0.54s, 2.3s; }
+    .loading-wordmark-svg .letter-8 { animation-delay: 0.63s, 2.4s; }
+    .loading-wordmark-svg .letter-9 { animation-delay: 0.72s, 2.5s; }
 
     /* Queue icon pulse animation */
     @keyframes queue-pulse {
@@ -1005,10 +1047,49 @@
       is the markup that actually uses it.
     -->
     <div class="loading-screen" style="position: fixed; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 10000;">
-      <div class="loading-wordmark">
-        <img class="loading-wordmark-img loading-wordmark-img-light" src="assets/logo-wordmark.png" alt="Parachord" />
-        <img class="loading-wordmark-img loading-wordmark-img-dark" src="assets/icons/logo-wordmark-white.png" alt="Parachord" />
-      </div>
+      <svg class="loading-wordmark-svg" viewBox="0 0 1046 273" fill="none" xmlns="http://www.w3.org/2000/svg" aria-label="Parachord">
+        <g class="letter letter-1">
+          <path d="M115.5 102.5C139.725 102.5 160.5 123.346 160.5 150.5C160.5 177.654 139.725 198.5 115.5 198.5C91.2754 198.5 70.5 177.654 70.5 150.5C70.5 123.346 91.2754 102.5 115.5 102.5Z" stroke="currentColor" stroke-width="27"/>
+          <rect x="57" y="148" width="25" height="108.261" fill="currentColor"/>
+          <path d="M82 256.261L57 272.5L57 255.66L57 238.819L82 256.261Z" fill="currentColor"/>
+          <path fill-rule="evenodd" clip-rule="evenodd" d="M7.29194 100.001C7.32449 100.03 7.16169 101.377 6.90132 102.986C6.08765 108.341 5.46898 114.633 5.14351 121.363C4.16715 140.559 7.45444 156.098 14.3544 165.316C18.3253 170.612 26.072 175.44 40.8486 181.878C49.0502 185.448 52.3379 187.262 56.2109 190.334L58.8476 192.412V186.211H63.4043C63.4041 257.673 63.3388 265.772 62.8837 266.359C62.5258 266.827 62.0696 267.002 61.1259 267.002C59.0103 267.002 58.8476 266.534 58.8476 260.477V255.238L57.1875 252.722C54.0629 247.923 51.0032 244.411 46.5117 240.373C41.6948 236.042 38.3425 233.818 32.6142 231.126C26.3002 228.112 22.6871 225.742 18.5537 221.821C8.39888 212.194 2.14945 198.528 0.261671 181.761C-0.226521 177.518 0.0335781 163.501 0.684523 158.994C1.0425 156.39 1.07508 155.512 0.684523 153.288C0.0336106 149.542 -0.226209 135.731 0.229445 130.902C1.01061 122.738 3.06059 113.081 5.8271 104.215C6.57471 101.848 7.22547 99.9476 7.29194 100.001ZM5.66499 172.338C6.28338 178.015 7.8456 184.628 9.53804 188.871C12.4673 196.187 16.0803 200.635 22.3945 204.673C27.8298 208.184 31.7356 210.145 44.2011 215.588C46.6096 216.641 49.7671 218.222 51.1992 219.07C52.6312 219.89 54.9417 221.587 56.3085 222.757L58.8476 224.952V223.986C58.8475 223.372 58.2943 222.143 57.3505 220.651C51.492 211.433 42.7362 203.649 33.1347 199.113C30.9543 198.089 28.1881 196.656 26.9511 195.924C18.4889 190.891 11.8166 183.341 6.5439 172.777L5.43648 170.582L5.66499 172.338Z" fill="#767575"/>
+          <path d="M59 260.805L59 242.676M59 203.856L59 224.803" stroke="white" stroke-width="0.2" stroke-linecap="round"/>
+        </g>
+        <g class="letter letter-2">
+          <path d="M237.5 102.5C261.725 102.5 282.5 123.347 282.5 150.5C282.5 177.654 261.725 198.5 237.5 198.5C213.275 198.5 192.5 177.654 192.5 150.5C192.5 123.347 213.275 102.5 237.5 102.5Z" stroke="currentColor" stroke-width="27"/>
+          <rect x="271" y="89.0005" width="25" height="123" fill="currentColor"/>
+        </g>
+        <g class="letter letter-3">
+          <rect x="307" y="152" width="27" height="60" fill="currentColor"/>
+          <path d="M307 152C307 117.207 333.191 89.0005 365.5 89.0005C365.667 89.0005 365.833 89.0029 366 89.0044L366 116.008C365.833 116.005 365.667 116 365.5 116C350.195 116 334.499 129.759 334.012 150.984L334 152L307 152Z" fill="currentColor"/>
+        </g>
+        <g class="letter letter-4">
+          <path d="M424.5 102.5C448.725 102.5 469.5 123.347 469.5 150.5C469.5 177.654 448.725 198.5 424.5 198.5C400.275 198.5 379.5 177.654 379.5 150.5C379.5 123.347 400.275 102.5 424.5 102.5Z" stroke="currentColor" stroke-width="27"/>
+          <rect x="458" y="89.0005" width="25" height="123" fill="currentColor"/>
+        </g>
+        <g class="letter letter-5">
+          <path d="M547.5 92.0005C565.823 92.0005 582.177 100.857 592.903 114.719L569.128 128.445C563.289 122.472 555.491 119 547.5 119C531.36 119 516 133.158 516 153.5C516 173.843 531.36 188 547.5 188C554.915 188 562.163 185.011 567.835 179.808L591.812 193.651C581.084 206.724 565.212 215 547.5 215C515.191 215 489 187.466 489 153.5C489 119.535 515.191 92.0005 547.5 92.0005Z" fill="currentColor"/>
+        </g>
+        <g class="letter letter-6">
+          <rect x="597" y="45.8784" width="25" height="165" fill="currentColor"/>
+          <path d="M622 38.0005V50.5005L597 45.8784L622 38.0005Z" fill="currentColor"/>
+          <path d="M648.702 96.0005C675.533 96.0005 698.054 122.271 700.898 156H675.816C673.171 131.764 657.459 121 648.702 121C640.176 121 624.661 131.504 622.075 156H597C599.787 122.271 621.871 96.0005 648.702 96.0005Z" fill="currentColor"/>
+          <rect x="676" y="152" width="25" height="60" fill="currentColor"/>
+        </g>
+        <g class="letter letter-7">
+          <path d="M764.5 102.5C788.725 102.5 809.5 123.347 809.5 150.5C809.5 177.654 788.725 198.5 764.5 198.5C740.275 198.5 719.5 177.654 719.5 150.5C719.5 123.347 740.275 102.5 764.5 102.5Z" stroke="currentColor" stroke-width="27"/>
+        </g>
+        <g class="letter letter-8">
+          <rect x="828" y="152" width="27" height="60" fill="currentColor"/>
+          <path d="M828 152C828 117.207 854.191 89.0005 886.5 89.0005C886.667 89.0005 886.833 89.0029 887 89.0044L887 116.008C886.833 116.005 886.667 116 886.5 116C871.195 116 855.499 129.759 855.012 150.984L855 152L828 152Z" fill="currentColor"/>
+        </g>
+        <g class="letter letter-9">
+          <path d="M945.5 102.5C969.725 102.5 990.5 123.347 990.5 150.5C990.5 177.654 969.725 198.5 945.5 198.5C921.275 198.5 900.5 177.654 900.5 150.5C900.5 123.347 921.275 102.5 945.5 102.5Z" stroke="currentColor" stroke-width="27"/>
+          <path d="M945.5 102.5C969.725 102.5 990.5 123.347 990.5 150.5C990.5 177.654 969.725 198.5 945.5 198.5C921.275 198.5 900.5 177.654 900.5 150.5C900.5 123.347 921.275 102.5 945.5 102.5Z" stroke="currentColor" stroke-opacity="0.2" stroke-width="27"/>
+          <rect x="1004.01" y="151.398" width="25" height="100.266" transform="rotate(-180 1004.01 151.398)" fill="currentColor"/>
+          <path d="M1039.72 33.8887C1042.39 35.348 1042.43 39.1612 1039.8 40.6846L984.893 72.4893C982.313 73.9831 979.08 72.1478 979.039 69.167L978.192 6.85254C978.152 3.86673 981.345 1.94449 983.965 3.37793L1039.72 33.8887Z" fill="#E12949" stroke="white" stroke-width="0.2"/>
+        </g>
+      </svg>
     </div>
   </div>
   


### PR DESCRIPTION
Follow-up to #879. Replaces the static PNG wordmark splash with an inline SVG composed of the canonical brand paths, grouped per letter, so each letter animates independently.

## Visual sequence

1. **Letter pop-in cascade** (0 → 1.04s): each of the 9 letters fades + scales from 0.92 → 1 with a 90ms stagger, left-to-right
2. **Settle pause** (~0.65s)
3. **Continuous shimmer cascade**: each letter lifts 6px + scales 1.12 + bursts a brand-red drop-shadow glow at its peak, then settles back. 100ms stagger per letter, 2.6s cycle. Infinite loop while the user waits for app.js parse to finish.

The shimmer's brand-red glow uses the same \`#E12949\` as the play-triangle accent on the \"d\" — feels brand-aligned without being garish.

## Implementation notes

- **Canonical brand paths** from the source SVG: black letterforms via \`currentColor\` (theme-switches with \`.dark\`), \`#767575\` grey feather descender, \`#E12949\` red play-triangle, plus the subtle 0.2-opacity duplicate stroke on the \"d\" circle.
- **Letter grouping**: 9 \`<g class=\"letter letter-N\">\` wrappers around the paths that compose each letter. Mapping is by x-coordinate (paths in the source SVG aren't in left-to-right document order).
- **\`transform-box: fill-box\` + \`transform-origin: center\`** so per-letter scale animates around each letter's own center instead of the SVG origin.
- **\`overflow: visible\` on the SVG element**: without this, the play-triangle on the \"d\" clips at the viewBox top during the lift + scale phase. The feather descender on the \"p\" would similarly clip at the bottom.

## Replaces

The previous PNG-based splash from #879 used two \`<img>\` tags swapped via \`.dark\` class. Inline SVG is crisper at any DPI, themes via \`currentColor\` (no double-asset preload), and is the only path that supports true per-letter animation. ~3KB inline vs ~150KB across two PNGs.

The PNG assets (\`assets/logo-wordmark.png\`, \`assets/icons/logo-wordmark-white.png\`) stay in place since they're referenced in other parts of the app.

## Verified

- Both light + dark themes render correctly via a static HTTP server preview
- Pop-in cascade times correctly (1.04s end)
- Shimmer cascade visible across all 9 letters with brand-red glow
- Play-triangle no longer clipped at peak (\`overflow: visible\` fix)
- 1680/1680 tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)