### PR TITLE
fix(mpris): use `new` on Player constructor + init shuffle/loop (#848)

### DIFF
--- a/mpris-player.js
+++ b/mpris-player.js
@@ -105,7 +105,14 @@ function createMprisPlayer({ onControl } = {}) {
 
   let player;
   try {
-    player = MprisPlayer({
+    // @jellybrick/mpris-service exports a Player class (not a factory).
+    // Forgetting `new` here used to throw `TypeError: Class constructor
+    // Player cannot be invoked without 'new'`, which the catch below
+    // silently swallowed — the service registered nothing on DBus and
+    // moop250's KDE Plasma widget was reading metadata from a different
+    // player entirely (e.g. Spotify desktop). Initial v0.9.4 ship had
+    // this bug; #848 follow-up.
+    player = new MprisPlayer({
       name: 'parachord',
       identity: 'Parachord',
       supportedUriSchemes: ['parachord', 'spotify', 'file', 'https'],
@@ -131,10 +138,24 @@ function createMprisPlayer({ onControl } = {}) {
   player.canGoPrevious = true;
   player.canControl = true;
 
+  // Initialize shuffle + loop properties explicitly so DE widgets see
+  // them as supported. The MPRIS spec has no canShuffle / canLoop
+  // capability flag, so widgets infer support from whether the
+  // properties have been written. Without these writes, KDE Plasma
+  // greys out the shuffle and repeat controls (parachord#848 follow-
+  // up). Parachord has no app-level loop mode today, so loopStatus
+  // stays 'None'; updateLoop() is a no-op until that ships.
+  player.shuffle = false;
+  player.loopStatus = 'None';
+
   // ── Inbound: forward DE control events to renderer ───────────────
   // Each event is forwarded as a structured object so the renderer-side
-  // switch can route by action name.
+  // switch can route by action name. Logs every received event for
+  // remote-debug-friendliness — Linux-only feature with limited local
+  // verification, so external testers' terminal output is the main
+  // diagnostic surface.
   const safeControl = (event) => {
+    console.log(`[MPRIS] received control: ${event?.action || JSON.stringify(event)}`);
     try { onControl(event); }
     catch (err) { console.warn('[MPRIS] onControl threw:', err.message); }
   };


### PR DESCRIPTION
Three Linux-only MPRIS bugs in v0.9.4 surfaced by @moop250's test report on #848.

## 1. Silent init failure (the big one)

\`@jellybrick/mpris-service\` exports a class. v0.9.4's code called it without \`new\`:

\`\`\`js
player = MprisPlayer({...});   // ❌ throws TypeError silently
\`\`\`

The surrounding try/catch caught the \`Class constructor Player cannot be invoked without 'new'\` error, logged a non-fatal warning, and returned null. The MPRIS service registered nothing on DBus.

Moop's \"widgets look correct in KDE Plasma\" was actually a different player (likely Spotify desktop) populating the widget; clicking the widget's controls did nothing because there was no \`org.mpris.MediaPlayer2.parachord\` to control.

Verified by running \`MprisPlayer({...})\` in Node — reproduces the TypeError exactly.

\`\`\`js
player = new MprisPlayer({...});   // ✓
\`\`\`

## 2. Shuffle / loop greyed out

MPRIS has no \`canShuffle\` / \`canLoop\` capability flag — DE widgets infer support from whether the properties have been written. Now explicitly initialized at startup:

\`\`\`js
player.shuffle = false;
player.loopStatus = 'None';
\`\`\`

Parachord has no app-level loop mode today, so \`loopStatus\` stays 'None' (the spec value for \"loop off\"). \`updateLoop()\` is a no-op until that ships.

## 3. No diagnostic logging on control events

Linux is the only platform where MPRIS exercises end-to-end and CI doesn't exercise the runtime path. Added a \`[MPRIS] received control: <action>\` log line on every event so external testers' terminal output is actionable.

## Process note

I should have run a real Linux build before shipping #872. Lesson captured for future Linux-only changes — passing tests + green CI isn't a substitute for at least one end-to-end check on the target platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)