### PR TITLE
perf(startup): unblock cacheLoaded from GitHub release-notes fetch

### DIFF
--- a/app.js
+++ b/app.js
@@ -23073,20 +23073,33 @@ ${trackListXml}
         setFirstRunTutorial(prev => ({ ...prev, open: true }));
       }
 
-      // Load What's New dismissed version, current app version, and release highlights
+      // Load What's New dismissed version, current app version, and release
+      // highlights. The version + highlights fetches are fire-and-forget
+      // — they USED to be awaited inline here, which silently gated
+      // setCacheLoaded(true) on a GitHub network roundtrip with up to two
+      // 5-second timeouts. Users on slow / offline networks waited up to
+      // ~10s before the loader gave way (parachord#878 follow-up). The
+      // What's New modal isn't time-critical — it populates whenever the
+      // data arrives, which is usually before the user clicks to open it.
       if (dismissedVersion) {
         setWhatsNewDismissedVersion(dismissedVersion);
       }
       if (window.electron?.updater?.getVersion) {
-        const version = await window.electron.updater.getVersion();
-        setAppVersion(version);
-        console.log(`📦 App version: ${version}, What's New dismissed for: ${dismissedVersion || 'never'}`);
+        window.electron.updater.getVersion()
+          .then(version => {
+            setAppVersion(version);
+            console.log(`📦 App version: ${version}, What's New dismissed for: ${dismissedVersion || 'never'}`);
+          })
+          .catch(() => {});
       }
       if (window.electron?.releaseNotes?.get) {
-        const result = await window.electron.releaseNotes.get();
-        if (result.success && result.highlights.length > 0) {
-          setWhatsNewHighlights(result.highlights);
-        }
+        window.electron.releaseNotes.get()
+          .then(result => {
+            if (result?.success && result.highlights?.length > 0) {
+              setWhatsNewHighlights(result.highlights);
+            }
+          })
+          .catch(() => {});
       }
 
       // In-app announcements: hydrate cached banner items + dismissed-id list
@@ -23103,7 +23116,7 @@ ${trackListXml}
       // Mark cache as loaded — resolver auth checks may still be in-flight (non-blocking).
       // resolverSettingsLoaded is set by the auth check callback above (or immediately if no resolvers).
       setCacheLoaded(true);
-      console.log('📦 Cache loaded from persistent storage (resolver auth checks may still be completing)');
+      console.log(`📦 Cache loaded in ${Math.round(performance.now() - t0)}ms (resolver auth checks may still be completing)`);
     } catch (error) {
       console.error('Failed to load cache from store:', error);
       // Even on error, mark as loaded so app can function


### PR DESCRIPTION
Reported on cold launch: React-tree loader \"sits for many seconds\" before home view renders.

## Root cause

\`loadCacheFromStore\` awaits two IPC calls inline before firing \`setCacheLoaded(true)\`:

1. \`window.electron.updater.getVersion()\` — fast (\`app.getVersion()\`, no I/O, no concern).
2. \`window.electron.releaseNotes.get()\` — does **up to two GitHub API fetches** (\`/releases/tags/v<version>\` then \`/releases?per_page=1\` fallback), each with a 5-second AbortSignal timeout. **Worst case blocks for ~10 seconds** before falling back to bundled \`RELEASE_NOTES.md\`.

When GitHub is slow, the user is offline, or the AbortSignal fires for any reason (rate limit, DNS, network blip), the cache-loaded gate blocks on network I/O that has nothing to do with cache loading.

## Fix

Convert both IPC calls to fire-and-forget. The data populates \`appVersion\` and \`whatsNewHighlights\` state when the network responds (usually before the user clicks to open the What's New modal). Neither is gated on \`cacheLoaded\` the other direction, so removing the \`await\` is clean.

Also added a \`📦 Cache loaded in Xms\` console log so total cache-load time is measurable — future slowness diagnoseable from terminal output.

## Result

Cold-launch sequence on slow / offline networks: \`setCacheLoaded(true)\` now fires as soon as the critical IPC payload is processed (~hundreds of ms instead of up to 10 seconds). Mac / Linux / Windows all benefit. Combined with #883 (in-React loader matches splash design), the cold-launch flow is now visually continuous AND short.

## Tests

1680/1680 pass. The change is behavior-provable: removing two \`await\`s from a synchronous-ish code path with no other dependents strictly shortens the time to \`setCacheLoaded(true)\`, regardless of network conditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)