### PR TITLE
fix(applemusic): late re-injection of user token on Linux/Windows (#882)

### DIFF
--- a/musickit-web.js
+++ b/musickit-web.js
@@ -12,6 +12,11 @@ class MusicKitWeb {
     this.isAuthorized = false;
     this.developerToken = null;
     this.loadPromise = null;
+    // Tracks the token value most recently used in a late re-injection
+    // attempt (see getAuthStatus). One attempt per distinct token keeps
+    // us from looping if the SDK truly won't honor injection, while
+    // still letting a fresh post-reauth token try once.
+    this._lastLateInjectionToken = null;
   }
 
   /**
@@ -256,6 +261,49 @@ class MusicKitWeb {
     // this.isAuthorized, which can become stale if the user's session expires
     // or authorization is revoked externally (e.g. via System Settings).
     if (this.musicKit) {
+      // Late re-injection (parachord#882). On Linux and Windows the
+      // CDN-loaded MusicKit JS v3 bundle frequently reports
+      // isAuthorized=false after configure even though the three injection
+      // paths (musicUserToken setter / setMusicUserToken / setUserToken)
+      // ran cleanly, leaving the .axe play path to fall through to the 30s
+      // preview. If we still have a stored user token from the auth-window
+      // cookie handoff, try the same three paths again right now — at
+      // play time (every play calls getAuthStatus first), the SDK's
+      // internal state is fully initialized in a way configure-time
+      // injection sometimes raced ahead of. Keyed on the token value so
+      // we retry once per distinct token (a fresh post-reauth token gets
+      // its own attempt) without looping when the SDK genuinely won't
+      // honor injection.
+      if (!this.musicKit.isAuthorized && typeof localStorage !== 'undefined') {
+        let storedToken = null;
+        try { storedToken = localStorage.getItem('musickit_user_token'); } catch (_e) { /* ignore */ }
+        if (storedToken && storedToken !== this._lastLateInjectionToken) {
+          this._lastLateInjectionToken = storedToken;
+          console.log('[MusicKitWeb] Late re-injection: SDK reports not authorized but stored token present');
+          try {
+            this.musicKit.musicUserToken = storedToken;
+            console.log(`[MusicKitWeb] After late .musicUserToken =, isAuthorized: ${this.musicKit.isAuthorized}`);
+          } catch (e) {
+            console.warn('[MusicKitWeb] Late .musicUserToken = threw:', e && e.message ? e.message : e);
+          }
+          try {
+            if (typeof this.musicKit.setMusicUserToken === 'function') {
+              this.musicKit.setMusicUserToken(storedToken);
+              console.log(`[MusicKitWeb] After late setMusicUserToken(), isAuthorized: ${this.musicKit.isAuthorized}`);
+            }
+          } catch (e) {
+            console.warn('[MusicKitWeb] Late setMusicUserToken() threw:', e && e.message ? e.message : e);
+          }
+          try {
+            if (typeof this.musicKit.setUserToken === 'function') {
+              this.musicKit.setUserToken(storedToken);
+              console.log(`[MusicKitWeb] After late setUserToken(), isAuthorized: ${this.musicKit.isAuthorized}`);
+            }
+          } catch (e) {
+            console.warn('[MusicKitWeb] Late setUserToken() threw:', e && e.message ? e.message : e);
+          }
+        }
+      }
       this.isAuthorized = this.musicKit.isAuthorized;
     }
     return {


### PR DESCRIPTION
Closes (probably) [parachord#882](https://github.com/Parachord/parachord/issues/882) — Apple Music subscription playback fell back to 30s preview on Linux/Windows even after a successful auth-window sign-in.

## What's going on

The auth-window flow (#843) harvests `media-user-token` from the music.apple.com cookies and writes it to localStorage as `musickit_user_token`. On boot, `musickit-web.js`'s `configure()` reads that token and runs **three** injection paths against the CDN-loaded MusicKit JS v3 bundle:

```js
instance.musicUserToken = userToken;
instance.setMusicUserToken(userToken);
instance.setUserToken(userToken);
```

On macOS this works. On Linux and Windows, all three run cleanly (no throws) but `instance.isAuthorized` stays `false`. The Apple Music `.axe` plugin's play path then sees `status.authorized === false` in its pre-play check and falls through to the 30s preview branch — never even reaching `musicKitWeb.play()`.

## Fix

`getAuthStatus()` is the gate. Every play call (and every sync-job auth check) goes through it. When it sees the SDK still in the unauthorized state **and** we have a stored token, retry the three configure-time injections right there. Keyed on the token value so the same token only gets one shot per session, but a fresh post-reauth token gets its own attempt.

Each injection step logs its resulting `isAuthorized` so moop250's next terminal trace gives a definitive answer:

- **Late injection flips `isAuthorized=true` → bug fixed** for everyone on the affected CDN bundle; subsequent plays stream the full track.
- **All three late attempts still report `false` → SDK fundamentally won't honor injection on this bundle**; next move is escalating to a long-lived hidden `BrowserWindow` at beta.music.apple.com as a playback host (Cider's approach — Path C from the issue body).
- **Path not reached** (no `musickit_user_token` in localStorage) → auth-window cookie handoff itself didn't write the slot, which is a separate bug to chase.

Defensive: every setter is in its own try/catch so a throw in one doesn't skip the next.

## Test plan

- [ ] moop250 (Arch Linux, AM subscription via auth-window) — relaunch, click play on a full track, capture terminal trace for the `[MusicKitWeb] Late re-injection:` lines.
- [ ] Mac path is unchanged — native MusicKit still wins, MusicKit JS path is a no-op for play (configure-time injection already worked).
- [ ] No regression on the "already-authorized" cold path: with `_lastLateInjectionToken === storedToken`, the retry block is a no-op on every subsequent call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)