### PR TITLE
fix(fresh-drops): drop release-groups more than 2 weeks out

### DIFF
--- a/app.js
+++ b/app.js
@@ -345,23 +345,68 @@ const unsupportedAudioMessage = (ext) => {
   return `This ${e ? e.toUpperCase() : 'audio'} file uses an unsupported format. Try converting to MP3 or 16-bit FLAC.`;
 };
 
+// Exact ISRC → recording-MBID lookup via MusicBrainz core (/ws/2/isrc/{isrc}).
+// Mobile parity (parachord-mobile@51c6cc1, design doc
+// `docs/plans/2026-06-16-isrc-mbid-fallback.md` in that repo) — added after
+// `mapper.listenbrainz.org` returned 502 for 2+ days (2026-06-14/15) and
+// scrobble-time MBID enrichment stopped covering Achordion submits even
+// for trivially-mappable tracks like "Radiohead – Creep".
+//
+// MusicBrainz core is independent infrastructure from the LB mapper, so
+// /ws/2/isrc/ keeps returning 200s during a mapper outage. ISRC identifies
+// the SPECIFIC recording the user streamed — no fuzzy-match risk of
+// returning a live/remix variant the way a Lucene title+artist search can.
+// Returns the recording MBID or null. ISRC format per spec:
+// 2-letter country code + 3-char alphanumeric registrant + 7-digit numeric.
+//
+// Callers MUST NOT cache this result the same way they cache mapper hits:
+// /ws/2/isrc/ returns only the recording itself (no canonical artist/release
+// MBIDs, no canonical names), so a cached ISRC-only entry would block a
+// richer mapper entry once the mapper recovers (parachord#887).
+window.resolveMbidViaIsrc = async (isrc) => {
+  if (!isrc || typeof isrc !== 'string') return null;
+  const trimmed = isrc.trim().toUpperCase();
+  if (!/^[A-Z]{2}[A-Z0-9]{3}\d{7}$/.test(trimmed)) return null;
+  try {
+    const url = `https://musicbrainz.org/ws/2/isrc/${encodeURIComponent(trimmed)}?fmt=json`;
+    const resp = await fetch(url, {
+      headers: {
+        'User-Agent': 'Parachord/0.9.3 (https://github.com/Parachord/parachord)',
+        'Accept': 'application/json',
+      },
+    });
+    if (!resp.ok) return null;
+    const data = await resp.json();
+    const recordings = Array.isArray(data?.recordings) ? data.recordings : [];
+    if (recordings.length === 0) return null;
+    const id = recordings[0]?.id;
+    if (typeof id === 'string' && /^[a-f0-9-]{36}$/i.test(id)) return id;
+    return null;
+  } catch (e) {
+    return null;
+  }
+};
+
 // Resolve a track to a recording MBID for ListenBrainz love submission.
-// Three tiers:
+// Four tiers:
 //   1. Cached track.mbid (instant)
 //   2. MBID Mapper at mapper.listenbrainz.org (~4ms, broad coverage)
-//   3. Direct MusicBrainz recording search (~200-500ms, slower but works
+//   3. Exact ISRC → MBID via MusicBrainz core (parachord#887) — runs only
+//      when track.isrc is present. Exact-match guarantee (vs tier 4's
+//      fuzzy Lucene), and crucially keeps working when the mapper is down
+//      (independent infrastructure).
+//   4. Direct MusicBrainz recording search (~200-500ms, slower but works
 //      when the mapper is down OR hasn't yet indexed a newly-released
 //      recording — the "Starting Line – All Them Witches" case where
 //      the mapper was returning 502 AND the recording was only days old)
 // Returns the MBID string or null. See
 // docs/plans/2026-05-03-loved-tracks-scrobbler-push-design.md.
 //
-// Tier 3 only fires when tier 2 either errored (5xx, network) or returned
-// no high-confidence match — safety net for transient mapper outages and
-// freshly-released recordings the mapper hasn't ingested. pushLoveToScrobblers
-// queues retries when even tier 3 returns null, so love-pushes that fail
-// today eventually catch up when either the mapper comes back or MB
-// ingests the new recording.
+// Tier 4 only fires when tiers 2 and 3 both come up empty — safety net
+// for transient mapper outages and freshly-released recordings the mapper
+// hasn't ingested. pushLoveToScrobblers queues retries when even tier 4
+// returns null, so love-pushes that fail today eventually catch up when
+// the mapper comes back or MB ingests the new recording.
 window.resolveMbidForLove = async (track) => {
   if (track?.mbid && /^[a-f0-9-]{36}$/i.test(track.mbid)) return track.mbid;
   if (!track?.artist || !track?.title) return null;
@@ -383,7 +428,19 @@ window.resolveMbidForLove = async (track) => {
     // Mapper network error — fall through to tier 3.
   }
 
-  // Tier 3: Direct MusicBrainz recording search.
+  // Tier 3: Exact ISRC → MBID. Only fires when track.isrc is present
+  // (Spotify and Apple Music capture it at resolution time; SoundCloud /
+  // local files / iTunes no-auth search don't). Runs against MB core,
+  // which stays up when mapper.listenbrainz.org doesn't.
+  if (track.isrc) {
+    const isrcMbid = await window.resolveMbidViaIsrc(track.isrc);
+    if (isrcMbid) {
+      console.log(`[resolveMbidForLove] ISRC fallback resolved "${track.artist} – ${track.title}" via ${track.isrc}`);
+      return isrcMbid;
+    }
+  }
+
+  // Tier 4: Direct MusicBrainz recording search.
   // MB's /ws/2/recording/?query=... returns recordings sorted by Lucene
   // score (0-100). We require ≥ 90, roughly equivalent to the mapper's
   // 0.7 confidence floor — "this is almost certainly the right recording."
@@ -9621,6 +9678,23 @@ const Parachord = () => {
       track.mbid = result.recording_mbid;
       track.artistMbids = result.artist_credit_mbids;
       if (result.release_mbid) track.releaseMbid = result.release_mbid;
+      return;
+    }
+    // Mapper miss / outage. Try exact ISRC → MBID against MB core so
+    // streaming-link enrichment (Achordion submit on scrobble, love push)
+    // still gets a recording MBID when mapper.listenbrainz.org is 502 or
+    // hasn't indexed the recording yet. Parachord-mobile shipped the same
+    // fallback at @51c6cc1 (parachord#887). Deliberately NOT written to
+    // mbidMapperCache: the ISRC endpoint returns only recording_mbid (no
+    // artist/release MBIDs, no canonical names), so caching it would
+    // block a richer mapper entry once the mapper recovers. Track-level
+    // mutation alone is enough — `if (track.mbid) return` above short-
+    // circuits on the next call for the same track.
+    if (track.isrc && window.resolveMbidViaIsrc) {
+      const isrcMbid = await window.resolveMbidViaIsrc(track.isrc);
+      if (isrcMbid) {
+        track.mbid = isrcMbid;
+      }
     }
   };
 

--- a/app.js
+++ b/app.js
@@ -22569,9 +22569,16 @@ ${trackListXml}
 
       // Load new releases cache and show instantly on Home
       if (newReleasesData && newReleasesData.releases && newReleasesData.timestamp != null) {
-        // Filter out broadcasts that may have been cached before the filter was added
+        // Filter out broadcasts that may have been cached before the filter was
+        // added, and drop releases dated more than 2 weeks out — pre-existing
+        // caches written before the +14d upper bound (fetchReleasesForArtists)
+        // may carry months-out announcements that the user doesn't want to see.
+        const upperFuture = new Date();
+        upperFuture.setDate(upperFuture.getDate() + 14);
+        const upperCutoffDate = upperFuture.toISOString().split('T')[0];
         const filteredReleases = newReleasesData.releases.filter(r =>
           r.releaseType !== 'broadcast' && !(r.secondaryTypes || []).includes('broadcast')
+          && (!r.date || r.date <= upperCutoffDate)
         );
         const now = Date.now();
         if (now - newReleasesData.timestamp < CACHE_TTL.newReleases) {
@@ -29121,6 +29128,16 @@ ${tracks}
     let artistsProcessed = 0;
     const mbHeaders = { 'User-Agent': 'Parachord/1.0.0 (https://parachord.app)' };
 
+    // Upper bound: drop release-groups dated more than 2 weeks out. MB
+    // ingests pre-announcement release-groups months ahead (album reveals,
+    // pre-orders) — without this cap, Fresh Drops became a "future
+    // announcement feed" that pushed actually-fresh releases off the top.
+    // 2 weeks is enough to surface upcoming drops the user might want to
+    // pre-save without including reveals for things 6 months out.
+    const upperFuture = new Date();
+    upperFuture.setDate(upperFuture.getDate() + 14);
+    const upperCutoffDate = upperFuture.toISOString().split('T')[0];
+
     // Fetch with a timeout to prevent a single hanging request from stalling the loop
     const fetchWithTimeout = (url, options, timeoutMs = 10000) => {
       const controller = new AbortController();
@@ -29196,7 +29213,7 @@ ${tracks}
 
           releaseGroups.forEach(rg => {
             const releaseDate = rg['first-release-date'] || '';
-            if (releaseDate && releaseDate >= cutoffDate) {
+            if (releaseDate && releaseDate >= cutoffDate && releaseDate <= upperCutoffDate) {
               const primaryType = (rg['primary-type'] || '').toLowerCase();
               const secondaryTypes = (rg['secondary-types'] || []).map(t => t.toLowerCase());
 

--- a/index.html
+++ b/index.html
@@ -506,64 +506,37 @@
       to   { opacity: 1; transform: translateY(0) scale(1); }
     }
 
-    /* Shimmer cascade — each letter pops up and lights up with a brand-red
-       glow as the wave passes through. Per-letter animation-delays (below)
-       stagger the pops left-to-right, so the visual effect is a wave of
-       energy travelling across the wordmark every cycle. Triggered AFTER
-       the letter reveal: pop-in (0–1.0s) → settle (~0.6s) → continuous
-       shimmer. Asymmetric timing (peak at 35%, fully settled by 70%)
-       gives a quick rise + softer landing per letter. */
-    @keyframes loadingLetterShimmer {
-      0%, 100% {
-        transform: translateY(0) scale(1);
-        filter: drop-shadow(0 0 0 rgba(225, 41, 73, 0));
-      }
-      35% {
-        transform: translateY(-6px) scale(1.12);
-        filter: drop-shadow(0 0 14px rgba(225, 41, 73, 0.7));
-      }
-      70% {
-        transform: translateY(0) scale(1);
-        filter: drop-shadow(0 0 0 rgba(225, 41, 73, 0));
-      }
-    }
-
     .loading-wordmark-svg {
       height: 72px;
       width: auto;
       color: #1a1a1a;
-      /* Allow letter transforms (lift + scale) and drop-shadow glow to
-         render outside the viewBox. Without this, the play-triangle
-         accent on the "d" gets clipped at the top edge when letter-9
-         lifts during the shimmer cascade, and the feather descender on
-         the "p" clips at the bottom (parachord#878). */
-      overflow: visible;
     }
 
     .dark .loading-wordmark-svg {
       color: #f9fafb;
     }
 
+    /* Letter-by-letter reveal only. The original splash had a continuous
+       shimmer cascade with a brand-red drop-shadow glow, designed for the
+       multi-second load window before cacheLoaded flipped (#879, #883).
+       Cache load now finishes in well under a second on warm starts, so
+       the shimmer either flashed once awkwardly or never played at all —
+       removed it in favor of the cleaner pop-in cascade. */
     .loading-wordmark-svg .letter {
       opacity: 0;
       transform-box: fill-box;
       transform-origin: center;
-      animation:
-        loadingLetterPopIn 0.32s cubic-bezier(0.22, 1.2, 0.36, 1) forwards,
-        loadingLetterShimmer 2.6s ease-in-out infinite;
+      animation: loadingLetterPopIn 0.32s cubic-bezier(0.22, 1.2, 0.36, 1) forwards;
     }
-    /* Two delays per letter: (1) pop-in entrance — 90ms cascade right;
-       (2) shimmer kickoff — starts ~0.7s after the reveal completes
-       (which is at 1.04s = 0.72 + 0.32), then cascades again. */
-    .loading-wordmark-svg .letter-1 { animation-delay: 0.00s, 1.7s; }
-    .loading-wordmark-svg .letter-2 { animation-delay: 0.09s, 1.8s; }
-    .loading-wordmark-svg .letter-3 { animation-delay: 0.18s, 1.9s; }
-    .loading-wordmark-svg .letter-4 { animation-delay: 0.27s, 2.0s; }
-    .loading-wordmark-svg .letter-5 { animation-delay: 0.36s, 2.1s; }
-    .loading-wordmark-svg .letter-6 { animation-delay: 0.45s, 2.2s; }
-    .loading-wordmark-svg .letter-7 { animation-delay: 0.54s, 2.3s; }
-    .loading-wordmark-svg .letter-8 { animation-delay: 0.63s, 2.4s; }
-    .loading-wordmark-svg .letter-9 { animation-delay: 0.72s, 2.5s; }
+    .loading-wordmark-svg .letter-1 { animation-delay: 0.00s; }
+    .loading-wordmark-svg .letter-2 { animation-delay: 0.09s; }
+    .loading-wordmark-svg .letter-3 { animation-delay: 0.18s; }
+    .loading-wordmark-svg .letter-4 { animation-delay: 0.27s; }
+    .loading-wordmark-svg .letter-5 { animation-delay: 0.36s; }
+    .loading-wordmark-svg .letter-6 { animation-delay: 0.45s; }
+    .loading-wordmark-svg .letter-7 { animation-delay: 0.54s; }
+    .loading-wordmark-svg .letter-8 { animation-delay: 0.63s; }
+    .loading-wordmark-svg .letter-9 { animation-delay: 0.72s; }
 
     /* Queue icon pulse animation */
     @keyframes queue-pulse {

--- a/musickit-web.js
+++ b/musickit-web.js
@@ -12,6 +12,11 @@ class MusicKitWeb {
     this.isAuthorized = false;
     this.developerToken = null;
     this.loadPromise = null;
+    // Tracks the token value most recently used in a late re-injection
+    // attempt (see getAuthStatus). One attempt per distinct token keeps
+    // us from looping if the SDK truly won't honor injection, while
+    // still letting a fresh post-reauth token try once.
+    this._lastLateInjectionToken = null;
   }
 
   /**
@@ -256,6 +261,49 @@ class MusicKitWeb {
     // this.isAuthorized, which can become stale if the user's session expires
     // or authorization is revoked externally (e.g. via System Settings).
     if (this.musicKit) {
+      // Late re-injection (parachord#882). On Linux and Windows the
+      // CDN-loaded MusicKit JS v3 bundle frequently reports
+      // isAuthorized=false after configure even though the three injection
+      // paths (musicUserToken setter / setMusicUserToken / setUserToken)
+      // ran cleanly, leaving the .axe play path to fall through to the 30s
+      // preview. If we still have a stored user token from the auth-window
+      // cookie handoff, try the same three paths again right now — at
+      // play time (every play calls getAuthStatus first), the SDK's
+      // internal state is fully initialized in a way configure-time
+      // injection sometimes raced ahead of. Keyed on the token value so
+      // we retry once per distinct token (a fresh post-reauth token gets
+      // its own attempt) without looping when the SDK genuinely won't
+      // honor injection.
+      if (!this.musicKit.isAuthorized && typeof localStorage !== 'undefined') {
+        let storedToken = null;
+        try { storedToken = localStorage.getItem('musickit_user_token'); } catch (_e) { /* ignore */ }
+        if (storedToken && storedToken !== this._lastLateInjectionToken) {
+          this._lastLateInjectionToken = storedToken;
+          console.log('[MusicKitWeb] Late re-injection: SDK reports not authorized but stored token present');
+          try {
+            this.musicKit.musicUserToken = storedToken;
+            console.log(`[MusicKitWeb] After late .musicUserToken =, isAuthorized: ${this.musicKit.isAuthorized}`);
+          } catch (e) {
+            console.warn('[MusicKitWeb] Late .musicUserToken = threw:', e && e.message ? e.message : e);
+          }
+          try {
+            if (typeof this.musicKit.setMusicUserToken === 'function') {
+              this.musicKit.setMusicUserToken(storedToken);
+              console.log(`[MusicKitWeb] After late setMusicUserToken(), isAuthorized: ${this.musicKit.isAuthorized}`);
+            }
+          } catch (e) {
+            console.warn('[MusicKitWeb] Late setMusicUserToken() threw:', e && e.message ? e.message : e);
+          }
+          try {
+            if (typeof this.musicKit.setUserToken === 'function') {
+              this.musicKit.setUserToken(storedToken);
+              console.log(`[MusicKitWeb] After late setUserToken(), isAuthorized: ${this.musicKit.isAuthorized}`);
+            }
+          } catch (e) {
+            console.warn('[MusicKitWeb] Late setUserToken() threw:', e && e.message ? e.message : e);
+          }
+        }
+      }
       this.isAuthorized = this.musicKit.isAuthorized;
     }
     return {


### PR DESCRIPTION
## Summary

- MusicBrainz includes pre-announcement release-groups months ahead of the actual release date (album reveals, pre-orders). Fresh Drops was surfacing announcements 6+ months out and pushing actually-fresh releases off the top.
- Add an upper bound of today+14 days at both filter sites: the live MB fetch and the cache hydration on load.
- Pre-existing caches written before this fix get cleaned on next launch — users don't have to wait for the next live fetch to see the change.
- Date-less legacy cache entries are preserved (don't filter what we can't evaluate).

## Test plan

- [ ] Cold launch with an existing cache containing future-dated releases → those drop out of the Fresh Drops feed.
- [ ] Live refresh → only releases dated within \[today − 6mo, today + 14d\] appear.
- [ ] An album dated 13 days from now still shows; one dated 15 days from now doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)