### PR TITLE
fix(splash): smooth splash → app handoff via body-level overlay + rAF-gated fade

### DIFF
--- a/app.js
+++ b/app.js
@@ -2105,72 +2105,12 @@ chatgpt: React.createElement('svg', { viewBox: '0 0 24 24', className: 'w-16 h-1
   )
 };
 
-// Parachord wordmark logo component
-// Animated loading wordmark for the post-mount cacheLoaded==false loader.
-// Renders the exact same letter-grouped SVG as the pre-mount splash in
-// index.html so the user gets a continuous animation across the React
-// mount boundary — without this, the pre-mount splash plays its
-// letter-by-letter cascade then gets replaced by an unrelated dots loader
-// for many seconds (parachord#878 follow-up). Class names match the CSS
-// selectors in index.html: `.loading-wordmark-svg .letter`.
-const AnimatedLoadingWordmark = () => React.createElement('svg', {
-  className: 'loading-wordmark-svg',
-  viewBox: '0 0 1046 273',
-  fill: 'none',
-  xmlns: 'http://www.w3.org/2000/svg',
-  'aria-label': 'Parachord'
-},
-  // letter-1: p (5 paths — circle, descender rect, descender triangle, feather flourish, tiny detail line)
-  React.createElement('g', { className: 'letter letter-1' },
-    React.createElement('path', { d: 'M115.5 102.5C139.725 102.5 160.5 123.346 160.5 150.5C160.5 177.654 139.725 198.5 115.5 198.5C91.2754 198.5 70.5 177.654 70.5 150.5C70.5 123.346 91.2754 102.5 115.5 102.5Z', stroke: 'currentColor', strokeWidth: 27 }),
-    React.createElement('rect', { x: 57, y: 148, width: 25, height: 108.261, fill: 'currentColor' }),
-    React.createElement('path', { d: 'M82 256.261L57 272.5L57 255.66L57 238.819L82 256.261Z', fill: 'currentColor' }),
-    React.createElement('path', { fillRule: 'evenodd', clipRule: 'evenodd', d: 'M7.29194 100.001C7.32449 100.03 7.16169 101.377 6.90132 102.986C6.08765 108.341 5.46898 114.633 5.14351 121.363C4.16715 140.559 7.45444 156.098 14.3544 165.316C18.3253 170.612 26.072 175.44 40.8486 181.878C49.0502 185.448 52.3379 187.262 56.2109 190.334L58.8476 192.412V186.211H63.4043C63.4041 257.673 63.3388 265.772 62.8837 266.359C62.5258 266.827 62.0696 267.002 61.1259 267.002C59.0103 267.002 58.8476 266.534 58.8476 260.477V255.238L57.1875 252.722C54.0629 247.923 51.0032 244.411 46.5117 240.373C41.6948 236.042 38.3425 233.818 32.6142 231.126C26.3002 228.112 22.6871 225.742 18.5537 221.821C8.39888 212.194 2.14945 198.528 0.261671 181.761C-0.226521 177.518 0.0335781 163.501 0.684523 158.994C1.0425 156.39 1.07508 155.512 0.684523 153.288C0.0336106 149.542 -0.226209 135.731 0.229445 130.902C1.01061 122.738 3.06059 113.081 5.8271 104.215C6.57471 101.848 7.22547 99.9476 7.29194 100.001ZM5.66499 172.338C6.28338 178.015 7.8456 184.628 9.53804 188.871C12.4673 196.187 16.0803 200.635 22.3945 204.673C27.8298 208.184 31.7356 210.145 44.2011 215.588C46.6096 216.641 49.7671 218.222 51.1992 219.07C52.6312 219.89 54.9417 221.587 56.3085 222.757L58.8476 224.952V223.986C58.8475 223.372 58.2943 222.143 57.3505 220.651C51.492 211.433 42.7362 203.649 33.1347 199.113C30.9543 198.089 28.1881 196.656 26.9511 195.924C18.4889 190.891 11.8166 183.341 6.5439 172.777L5.43648 170.582L5.66499 172.338Z', fill: '#767575' }),
-    React.createElement('path', { d: 'M59 260.805L59 242.676M59 203.856L59 224.803', stroke: 'white', strokeWidth: 0.2, strokeLinecap: 'round' })
-  ),
-  // letter-2: a (first, 2 paths)
-  React.createElement('g', { className: 'letter letter-2' },
-    React.createElement('path', { d: 'M237.5 102.5C261.725 102.5 282.5 123.347 282.5 150.5C282.5 177.654 261.725 198.5 237.5 198.5C213.275 198.5 192.5 177.654 192.5 150.5C192.5 123.347 213.275 102.5 237.5 102.5Z', stroke: 'currentColor', strokeWidth: 27 }),
-    React.createElement('rect', { x: 271, y: 89.0005, width: 25, height: 123, fill: 'currentColor' })
-  ),
-  // letter-3: r (first, 2 paths)
-  React.createElement('g', { className: 'letter letter-3' },
-    React.createElement('rect', { x: 307, y: 152, width: 27, height: 60, fill: 'currentColor' }),
-    React.createElement('path', { d: 'M307 152C307 117.207 333.191 89.0005 365.5 89.0005C365.667 89.0005 365.833 89.0029 366 89.0044L366 116.008C365.833 116.005 365.667 116 365.5 116C350.195 116 334.499 129.759 334.012 150.984L334 152L307 152Z', fill: 'currentColor' })
-  ),
-  // letter-4: a (second, 2 paths)
-  React.createElement('g', { className: 'letter letter-4' },
-    React.createElement('path', { d: 'M424.5 102.5C448.725 102.5 469.5 123.347 469.5 150.5C469.5 177.654 448.725 198.5 424.5 198.5C400.275 198.5 379.5 177.654 379.5 150.5C379.5 123.347 400.275 102.5 424.5 102.5Z', stroke: 'currentColor', strokeWidth: 27 }),
-    React.createElement('rect', { x: 458, y: 89.0005, width: 25, height: 123, fill: 'currentColor' })
-  ),
-  // letter-5: c (1 path)
-  React.createElement('g', { className: 'letter letter-5' },
-    React.createElement('path', { d: 'M547.5 92.0005C565.823 92.0005 582.177 100.857 592.903 114.719L569.128 128.445C563.289 122.472 555.491 119 547.5 119C531.36 119 516 133.158 516 153.5C516 173.843 531.36 188 547.5 188C554.915 188 562.163 185.011 567.835 179.808L591.812 193.651C581.084 206.724 565.212 215 547.5 215C515.191 215 489 187.466 489 153.5C489 119.535 515.191 92.0005 547.5 92.0005Z', fill: 'currentColor' })
-  ),
-  // letter-6: h (4 paths)
-  React.createElement('g', { className: 'letter letter-6' },
-    React.createElement('rect', { x: 597, y: 45.8784, width: 25, height: 165, fill: 'currentColor' }),
-    React.createElement('path', { d: 'M622 38.0005V50.5005L597 45.8784L622 38.0005Z', fill: 'currentColor' }),
-    React.createElement('path', { d: 'M648.702 96.0005C675.533 96.0005 698.054 122.271 700.898 156H675.816C673.171 131.764 657.459 121 648.702 121C640.176 121 624.661 131.504 622.075 156H597C599.787 122.271 621.871 96.0005 648.702 96.0005Z', fill: 'currentColor' }),
-    React.createElement('rect', { x: 676, y: 152, width: 25, height: 60, fill: 'currentColor' })
-  ),
-  // letter-7: o (1 path)
-  React.createElement('g', { className: 'letter letter-7' },
-    React.createElement('path', { d: 'M764.5 102.5C788.725 102.5 809.5 123.347 809.5 150.5C809.5 177.654 788.725 198.5 764.5 198.5C740.275 198.5 719.5 177.654 719.5 150.5C719.5 123.347 740.275 102.5 764.5 102.5Z', stroke: 'currentColor', strokeWidth: 27 })
-  ),
-  // letter-8: r (second, 2 paths)
-  React.createElement('g', { className: 'letter letter-8' },
-    React.createElement('rect', { x: 828, y: 152, width: 27, height: 60, fill: 'currentColor' }),
-    React.createElement('path', { d: 'M828 152C828 117.207 854.191 89.0005 886.5 89.0005C886.667 89.0005 886.833 89.0029 887 89.0044L887 116.008C886.833 116.005 886.667 116 886.5 116C871.195 116 855.499 129.759 855.012 150.984L855 152L828 152Z', fill: 'currentColor' })
-  ),
-  // letter-9: d (4 paths — circle, faint duplicate outline, stem, red play-triangle accent)
-  React.createElement('g', { className: 'letter letter-9' },
-    React.createElement('path', { d: 'M945.5 102.5C969.725 102.5 990.5 123.347 990.5 150.5C990.5 177.654 969.725 198.5 945.5 198.5C921.275 198.5 900.5 177.654 900.5 150.5C900.5 123.347 921.275 102.5 945.5 102.5Z', stroke: 'currentColor', strokeWidth: 27 }),
-    React.createElement('path', { d: 'M945.5 102.5C969.725 102.5 990.5 123.347 990.5 150.5C990.5 177.654 969.725 198.5 945.5 198.5C921.275 198.5 900.5 177.654 900.5 150.5C900.5 123.347 921.275 102.5 945.5 102.5Z', stroke: 'currentColor', strokeOpacity: 0.2, strokeWidth: 27 }),
-    React.createElement('rect', { x: 1004.01, y: 151.398, width: 25, height: 100.266, transform: 'rotate(-180 1004.01 151.398)', fill: 'currentColor' }),
-    React.createElement('path', { d: 'M1039.72 33.8887C1042.39 35.348 1042.43 39.1612 1039.8 40.6846L984.893 72.4893C982.313 73.9831 979.08 72.1478 979.039 69.167L978.192 6.85254C978.152 3.86673 981.345 1.94449 983.965 3.37793L1039.72 33.8887Z', fill: '#E12949', stroke: 'white', strokeWidth: 0.2 })
-  )
-);
+// The post-mount React-tree loader (AnimatedLoadingWordmark) used to live
+// here, with a duplicate copy of the index.html splash SVG so the React
+// tree could keep showing the wordmark while cache loaded. It was removed
+// when the splash moved to a body-level overlay (#parachord-splash in
+// index.html) that survives React mount — the overlay is now the only
+// loader visual; the React tree renders null underneath until cacheLoaded.
 
 const ParachordWordmark = ({ fill = 'black', height = 40 }) => React.createElement('svg', {
   viewBox: '0 0 1046 273',
@@ -9526,6 +9466,36 @@ const Parachord = () => {
   // Cache for album art URLs (releaseId -> { url, timestamp })
   const albumArtCache = useRef({});
   const [cacheLoaded, setCacheLoaded] = useState(false); // Track when persistent cache is loaded
+
+  // Fade out the body-level splash overlay (#parachord-splash, in
+  // index.html) once cacheLoaded flips. Two requestAnimationFrame ticks
+  // hold the fade until after the home-page React commit has painted,
+  // otherwise the splash would fade over an unpainted/half-painted home
+  // page — visually choppier than the cold "splash → app" cut it
+  // replaces. Removes the element from the DOM after the 350ms CSS
+  // transition completes so it doesn't continue capturing any (already
+  // disabled via pointer-events: none) hit-testing or paint cycles.
+  useEffect(() => {
+    if (!cacheLoaded) return;
+    const splash = typeof document !== 'undefined' && document.getElementById('parachord-splash');
+    if (!splash) return;
+    let removeTimer = null;
+    const raf1 = requestAnimationFrame(() => {
+      const raf2Id = requestAnimationFrame(() => {
+        splash.classList.add('fade-out');
+        removeTimer = setTimeout(() => {
+          if (splash.parentNode) splash.parentNode.removeChild(splash);
+        }, 400);
+      });
+      // Stash the inner rAF id so cleanup can cancel it too.
+      splash._raf2 = raf2Id;
+    });
+    return () => {
+      cancelAnimationFrame(raf1);
+      if (splash._raf2) cancelAnimationFrame(splash._raf2);
+      if (removeTimer) clearTimeout(removeTimer);
+    };
+  }, [cacheLoaded]);
 
   // Viewport-prioritized album art loading
   const visibleAlbumIds = useRef(new Set());      // Currently in viewport
@@ -39008,19 +38978,18 @@ useEffect(() => {
       )
     ),
 
-    // Show loading state until cache is loaded (prevents flash of default
-    // view). Uses the same letter-grouped SVG + CSS animations as the
-    // pre-mount splash in index.html — so the cold-launch sequence is
-    // visually continuous: pre-mount splash plays during app.js parse,
-    // React mounts, this loader inherits the same animation while cache
-    // loads. Without the unified design, users on slow caches saw a
-    // discontinuous "new splash then old splash for many seconds"
-    // experience (parachord#878 follow-up).
-    !cacheLoaded ? React.createElement('div', {
-      className: 'flex-1 flex flex-col items-center justify-center loading-screen'
-    },
-      React.createElement(AnimatedLoadingWordmark)
-    ) :
+    // While the bulk-cache IPC is in flight, render nothing in the main
+    // content slot. The body-level #parachord-splash overlay in index.html
+    // is on top (z-index 10000) and covers the entire viewport, so the
+    // user sees the wordmark uninterrupted from HTML-parse through cache-
+    // loaded. When cacheLoaded flips, the home page mounts under the
+    // overlay; a useEffect below fades the overlay out via the .fade-out
+    // class once the home page has painted. This replaces the prior
+    // inside-#root React-tree loader, whose CSS pop-in cascade re-played
+    // from frame 1 on mount (because the React tree is fresh DOM nodes,
+    // not the same nodes the pre-mount splash painted into), producing a
+    // visible flicker right at the splash → React handoff.
+    !cacheLoaded ? null :
 
     // Search Page - Full page search view
     activeView === 'search' ? (

--- a/app.js
+++ b/app.js
@@ -9468,31 +9468,33 @@ const Parachord = () => {
   const [cacheLoaded, setCacheLoaded] = useState(false); // Track when persistent cache is loaded
 
   // Fade out the body-level splash overlay (#parachord-splash, in
-  // index.html) once cacheLoaded flips. Two requestAnimationFrame ticks
-  // hold the fade until after the home-page React commit has painted,
-  // otherwise the splash would fade over an unpainted/half-painted home
-  // page — visually choppier than the cold "splash → app" cut it
-  // replaces. Removes the element from the DOM after the 350ms CSS
-  // transition completes so it doesn't continue capturing any (already
-  // disabled via pointer-events: none) hit-testing or paint cycles.
+  // index.html) once cacheLoaded flips. Earlier iteration used rAF×2
+  // (~32ms) to hold the fade until after the home-page React commit
+  // painted, but the home tree's initial commit + layout + paint takes
+  // closer to ~150-200ms — the splash was already half-faded by the
+  // time the cards/sidebar finished laying out, so the user saw the
+  // home page popping in mid-fade. Now: one rAF (yields to the
+  // browser so the React commit can flush + paint) then a 200ms
+  // setTimeout (covers the home page's first round of async data
+  // resolution). 500ms fade matches the longer transition in
+  // index.html's CSS; element is removed 550ms after fade starts.
   useEffect(() => {
     if (!cacheLoaded) return;
     const splash = typeof document !== 'undefined' && document.getElementById('parachord-splash');
     if (!splash) return;
+    let fadeTimer = null;
     let removeTimer = null;
-    const raf1 = requestAnimationFrame(() => {
-      const raf2Id = requestAnimationFrame(() => {
+    const rafId = requestAnimationFrame(() => {
+      fadeTimer = setTimeout(() => {
         splash.classList.add('fade-out');
         removeTimer = setTimeout(() => {
           if (splash.parentNode) splash.parentNode.removeChild(splash);
-        }, 400);
-      });
-      // Stash the inner rAF id so cleanup can cancel it too.
-      splash._raf2 = raf2Id;
+        }, 550);
+      }, 200);
     });
     return () => {
-      cancelAnimationFrame(raf1);
-      if (splash._raf2) cancelAnimationFrame(splash._raf2);
+      cancelAnimationFrame(rafId);
+      if (fadeTimer) clearTimeout(fadeTimer);
       if (removeTimer) clearTimeout(removeTimer);
     };
   }, [cacheLoaded]);

--- a/app.js
+++ b/app.js
@@ -9502,7 +9502,9 @@ const Parachord = () => {
         removeTimer = setTimeout(() => {
           if (splash.parentNode) splash.parentNode.removeChild(splash);
         }, 550);
-      }, 400);
+      }, 900);  // Long enough for the entrance cascade to complete
+                // (last letter ends at 0.56s + 0.32s ≈ 0.88s after
+                // visibilitychange) before we start fading.
     };
     if (document.visibilityState === 'visible') {
       startFade();

--- a/app.js
+++ b/app.js
@@ -9502,9 +9502,10 @@ const Parachord = () => {
         removeTimer = setTimeout(() => {
           if (splash.parentNode) splash.parentNode.removeChild(splash);
         }, 550);
-      }, 900);  // Long enough for the entrance cascade to complete
-                // (last letter ends at 0.56s + 0.32s ≈ 0.88s after
-                // visibilitychange) before we start fading.
+      }, 450);  // Post-visibility hold so the wordmark is on screen
+                // long enough to read as a splash (not a single-frame
+                // flash) before the fade starts. The CSS pulse is
+                // continuous, so there's no entrance to finish first.
     };
     if (document.visibilityState === 'visible') {
       startFade();

--- a/app.js
+++ b/app.js
@@ -9468,34 +9468,56 @@ const Parachord = () => {
   const [cacheLoaded, setCacheLoaded] = useState(false); // Track when persistent cache is loaded
 
   // Fade out the body-level splash overlay (#parachord-splash, in
-  // index.html) once cacheLoaded flips. Earlier iteration used rAF×2
-  // (~32ms) to hold the fade until after the home-page React commit
-  // painted, but the home tree's initial commit + layout + paint takes
-  // closer to ~150-200ms — the splash was already half-faded by the
-  // time the cards/sidebar finished laying out, so the user saw the
-  // home page popping in mid-fade. Now: one rAF (yields to the
-  // browser so the React commit can flush + paint) then a 200ms
-  // setTimeout (covers the home page's first round of async data
-  // resolution). 500ms fade matches the longer transition in
-  // index.html's CSS; element is removed 550ms after fade starts.
+  // index.html) once (a) cacheLoaded flips AND (b) the document is
+  // actually visible. The visibility gate is load-bearing: main.js
+  // creates the BrowserWindow with `show: false` and only calls
+  // mainWindow.show() on the `ready-to-show` event, which fires after
+  // the renderer has loaded all scripts and React has mounted — by
+  // which point cacheLoaded has typically already flipped true. Fading
+  // purely on cacheLoaded would tear the splash down BEFORE the window
+  // ever appears to the user, who'd then see the home page snap in
+  // with no splash at all. Waiting for visibilitychange → 'visible'
+  // (Electron fires this when show() runs) holds the splash until
+  // the window has been presented; the 400ms post-visibility delay
+  // then gives the user a moment to actually see the wordmark before
+  // the 500ms opacity transition starts. Safety timeout fires the
+  // fade unconditionally after 3s in case visibilitychange never
+  // arrives (e.g., headless Electron in a future test harness).
   useEffect(() => {
     if (!cacheLoaded) return;
     const splash = typeof document !== 'undefined' && document.getElementById('parachord-splash');
     if (!splash) return;
     let fadeTimer = null;
     let removeTimer = null;
-    const rafId = requestAnimationFrame(() => {
+    let safetyTimer = null;
+    let visListener = null;
+    const startFade = () => {
+      if (safetyTimer) { clearTimeout(safetyTimer); safetyTimer = null; }
+      if (visListener) {
+        document.removeEventListener('visibilitychange', visListener);
+        visListener = null;
+      }
       fadeTimer = setTimeout(() => {
         splash.classList.add('fade-out');
         removeTimer = setTimeout(() => {
           if (splash.parentNode) splash.parentNode.removeChild(splash);
         }, 550);
-      }, 200);
-    });
+      }, 400);
+    };
+    if (document.visibilityState === 'visible') {
+      startFade();
+    } else {
+      visListener = () => {
+        if (document.visibilityState === 'visible') startFade();
+      };
+      document.addEventListener('visibilitychange', visListener);
+      safetyTimer = setTimeout(startFade, 3000);
+    }
     return () => {
-      cancelAnimationFrame(rafId);
       if (fadeTimer) clearTimeout(fadeTimer);
       if (removeTimer) clearTimeout(removeTimer);
+      if (safetyTimer) clearTimeout(safetyTimer);
+      if (visListener) document.removeEventListener('visibilitychange', visListener);
     };
   }, [cacheLoaded]);
 

--- a/index.html
+++ b/index.html
@@ -538,6 +538,32 @@
     .loading-wordmark-svg .letter-8 { animation-delay: 0.63s; }
     .loading-wordmark-svg .letter-9 { animation-delay: 0.72s; }
 
+    /* Body-level splash overlay. Sits above the React tree (z-index 10000)
+       and is the only visual the user sees while HTML parses, scripts load,
+       app.js executes, React mounts, and the bulk cache IPC roundtrip
+       completes. Survives React mount because it lives outside #root —
+       earlier iteration put the splash inside #root, which meant
+       ReactDOM's first render replaced the splash markup with React's tree
+       and the user saw a brief re-cascade of the same wordmark in the
+       React-tree loader. Now React mounts under the overlay, so any DOM
+       work the React tree does (including its own loaders) is invisible
+       until the overlay fades. JS removes the element when cacheLoaded
+       flips and the home page has painted. */
+    #parachord-splash {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 10000;
+      opacity: 1;
+      transition: opacity 350ms ease-out;
+    }
+    #parachord-splash.fade-out {
+      opacity: 0;
+      pointer-events: none;
+    }
+
     /* Queue icon pulse animation */
     @keyframes queue-pulse {
       0% { transform: scale(1); }
@@ -1009,17 +1035,18 @@
   </style>
 </head>
 <body class="bg-gray-100 text-gray-900 no-select">
-  <div id="root">
-    <!--
-      Pre-mount splash (parachord#878). Paints during HTML parse + script
-      load + app.js parse/execute (the biggest chunk of cold-launch TTFP).
-      React.createRoot(root).render(...) replaces this entire subtree on
-      first render, so no cleanup code is needed — the React tree just
-      takes over once it mounts. CSS for .loading-screen / .loading-dot
-      / .loading-wordmark already lives in the <style> block above; this
-      is the markup that actually uses it.
-    -->
-    <div class="loading-screen" style="position: fixed; inset: 0; display: flex; align-items: center; justify-content: center; z-index: 10000;">
+  <!--
+    Pre-mount splash (parachord#878). Lives OUTSIDE #root as a body-level
+    overlay so React.createRoot(root).render(...) doesn't tear it down on
+    first render. Paints during HTML parse + script load + app.js
+    parse/execute (the biggest chunk of cold-launch TTFP), then keeps
+    covering the screen while React mounts and the bulk cache IPC
+    roundtrip resolves. The Parachord component fades it out and removes
+    it from the DOM once cacheLoaded flips AND the home page has painted
+    (rAF×2, see app.js). CSS for .loading-screen and the wordmark
+    selectors lives in the <style> block above.
+  -->
+  <div id="parachord-splash" class="loading-screen">
       <svg class="loading-wordmark-svg" viewBox="0 0 1046 273" fill="none" xmlns="http://www.w3.org/2000/svg" aria-label="Parachord">
         <g class="letter letter-1">
           <path d="M115.5 102.5C139.725 102.5 160.5 123.346 160.5 150.5C160.5 177.654 139.725 198.5 115.5 198.5C91.2754 198.5 70.5 177.654 70.5 150.5C70.5 123.346 91.2754 102.5 115.5 102.5Z" stroke="currentColor" stroke-width="27"/>
@@ -1062,10 +1089,13 @@
           <rect x="1004.01" y="151.398" width="25" height="100.266" transform="rotate(-180 1004.01 151.398)" fill="currentColor"/>
           <path d="M1039.72 33.8887C1042.39 35.348 1042.43 39.1612 1039.8 40.6846L984.893 72.4893C982.313 73.9831 979.08 72.1478 979.039 69.167L978.192 6.85254C978.152 3.86673 981.345 1.94449 983.965 3.37793L1039.72 33.8887Z" fill="#E12949" stroke="white" stroke-width="0.2"/>
         </g>
-      </svg>
-    </div>
+    </svg>
   </div>
-  
+
+  <!-- React mount point. Splash overlay above (#parachord-splash) covers
+       any partial paint until the Parachord component removes it. -->
+  <div id="root"></div>
+
   <!-- React -->
   <script src="vendor/react.production.min.js"></script>
   <script src="vendor/react-dom.production.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -511,20 +511,44 @@
       color: #f9fafb;
     }
 
-    /* No entrance animation. The earlier per-letter pop-in cascade
-       (0–1.04s total) couldn't survive cold launch: vendor + app.js
-       parse blocks the main thread for ~1s, during which the CSS
-       animation engine advances on wall-clock time but the compositor
-       can't push frames. Letter-1 painted once before the block, then
-       letters 2–9 all snapped to their final state in the first paint
-       after the block — visible as "P, pause, everything-at-once."
-       Showing the wordmark fully revealed from T=0 is the only
-       reliable option until we eliminate the main-thread block
-       altogether. The body-level splash → app crossfade in app.js
-       (see useEffect on cacheLoaded) carries the motion now. */
+    @keyframes loadingLetterPopIn {
+      from { opacity: 0; transform: translateY(6px) scale(0.92); }
+      to   { opacity: 1; transform: translateY(0) scale(1); }
+    }
+
+    /* Per-letter pop-in cascade, but JS-triggered (not via CSS
+       animation-delay). The earlier delay-driven version raced the
+       main thread during cold launch: vendor + app.js parse blocks
+       for ~1s, the CSS engine advances animations on wall-clock time,
+       so by the first post-block paint every letter past the first
+       had passed its (delay + duration) window and snapped straight
+       to the end state — visible as "P, pause, everything-at-once."
+       Fix: letters start visible by default so the splash always
+       renders content even if our trigger script never runs. When
+       the inline script just after the splash markup adds `.animate-
+       in` (on visibilitychange → 'visible', which fires when Electron
+       calls mainWindow.show() — by definition after ready-to-show,
+       so the main thread is no longer pegged), the animation engine
+       starts the cascade from that moment with `backwards` fill mode
+       holding letters at opacity:0 through their per-letter delay.
+       Cascade plays smoothly because the main thread is free. */
     .loading-wordmark-svg .letter {
       opacity: 1;
+      transform-box: fill-box;
+      transform-origin: center;
     }
+    #parachord-splash.animate-in .loading-wordmark-svg .letter {
+      animation: loadingLetterPopIn 0.32s cubic-bezier(0.22, 1.2, 0.36, 1) backwards;
+    }
+    #parachord-splash.animate-in .loading-wordmark-svg .letter-1 { animation-delay: 0.00s; }
+    #parachord-splash.animate-in .loading-wordmark-svg .letter-2 { animation-delay: 0.07s; }
+    #parachord-splash.animate-in .loading-wordmark-svg .letter-3 { animation-delay: 0.14s; }
+    #parachord-splash.animate-in .loading-wordmark-svg .letter-4 { animation-delay: 0.21s; }
+    #parachord-splash.animate-in .loading-wordmark-svg .letter-5 { animation-delay: 0.28s; }
+    #parachord-splash.animate-in .loading-wordmark-svg .letter-6 { animation-delay: 0.35s; }
+    #parachord-splash.animate-in .loading-wordmark-svg .letter-7 { animation-delay: 0.42s; }
+    #parachord-splash.animate-in .loading-wordmark-svg .letter-8 { animation-delay: 0.49s; }
+    #parachord-splash.animate-in .loading-wordmark-svg .letter-9 { animation-delay: 0.56s; }
 
     /* Body-level splash overlay. Sits above the React tree (z-index 10000)
        and is the only visual the user sees while HTML parses, scripts load,
@@ -1079,6 +1103,45 @@
         </g>
     </svg>
   </div>
+
+  <!-- Kick the splash entrance cascade once the window is actually
+       visible. Electron creates the BrowserWindow with show: false and
+       only calls mainWindow.show() on ready-to-show — which fires after
+       all <script> tags have loaded, so by the time visibilitychange
+       flips to 'visible' the main thread is no longer pegged by parse.
+       Triggering the cascade then (vs at HTML parse via CSS animation-
+       delay) is what makes it actually animate smoothly. Letters
+       default to opacity:1 in CSS, so if visibilitychange never fires
+       (headless / future test harness) the wordmark is still visible —
+       just without entrance motion. Safety: 5s force-trigger so the
+       cascade never gets indefinitely stuck. -->
+  <script>
+    (function () {
+      var splash = document.getElementById('parachord-splash');
+      if (!splash) return;
+      var triggered = false;
+      var trigger = function () {
+        if (triggered) return;
+        triggered = true;
+        splash.classList.add('animate-in');
+      };
+      if (document.visibilityState === 'visible') {
+        // Already visible (reload, warm window). One rAF so the browser
+        // has a chance to do its initial paint of the default-state
+        // wordmark before we kick the animation — otherwise the
+        // backwards-fill-mode snap to opacity:0 can read as a flicker.
+        requestAnimationFrame(trigger);
+      } else {
+        document.addEventListener('visibilitychange', function onVis() {
+          if (document.visibilityState === 'visible') {
+            document.removeEventListener('visibilitychange', onVis);
+            trigger();
+          }
+        });
+        setTimeout(trigger, 5000);
+      }
+    })();
+  </script>
 
   <!-- React mount point. Splash overlay above (#parachord-splash) covers
        any partial paint until the Parachord component removes it. -->

--- a/index.html
+++ b/index.html
@@ -501,11 +501,6 @@
        (#1a1a1a in light, #f9fafb in dark) instead of two PNG variants.
        Crisper rendering than the previous PNG approach + saves ~150KB at
        splash time. */
-    @keyframes loadingLetterPopIn {
-      from { opacity: 0; transform: translateY(6px) scale(0.92); }
-      to   { opacity: 1; transform: translateY(0) scale(1); }
-    }
-
     .loading-wordmark-svg {
       height: 72px;
       width: auto;
@@ -516,27 +511,20 @@
       color: #f9fafb;
     }
 
-    /* Letter-by-letter reveal only. The original splash had a continuous
-       shimmer cascade with a brand-red drop-shadow glow, designed for the
-       multi-second load window before cacheLoaded flipped (#879, #883).
-       Cache load now finishes in well under a second on warm starts, so
-       the shimmer either flashed once awkwardly or never played at all —
-       removed it in favor of the cleaner pop-in cascade. */
+    /* No entrance animation. The earlier per-letter pop-in cascade
+       (0–1.04s total) couldn't survive cold launch: vendor + app.js
+       parse blocks the main thread for ~1s, during which the CSS
+       animation engine advances on wall-clock time but the compositor
+       can't push frames. Letter-1 painted once before the block, then
+       letters 2–9 all snapped to their final state in the first paint
+       after the block — visible as "P, pause, everything-at-once."
+       Showing the wordmark fully revealed from T=0 is the only
+       reliable option until we eliminate the main-thread block
+       altogether. The body-level splash → app crossfade in app.js
+       (see useEffect on cacheLoaded) carries the motion now. */
     .loading-wordmark-svg .letter {
-      opacity: 0;
-      transform-box: fill-box;
-      transform-origin: center;
-      animation: loadingLetterPopIn 0.32s cubic-bezier(0.22, 1.2, 0.36, 1) forwards;
+      opacity: 1;
     }
-    .loading-wordmark-svg .letter-1 { animation-delay: 0.00s; }
-    .loading-wordmark-svg .letter-2 { animation-delay: 0.09s; }
-    .loading-wordmark-svg .letter-3 { animation-delay: 0.18s; }
-    .loading-wordmark-svg .letter-4 { animation-delay: 0.27s; }
-    .loading-wordmark-svg .letter-5 { animation-delay: 0.36s; }
-    .loading-wordmark-svg .letter-6 { animation-delay: 0.45s; }
-    .loading-wordmark-svg .letter-7 { animation-delay: 0.54s; }
-    .loading-wordmark-svg .letter-8 { animation-delay: 0.63s; }
-    .loading-wordmark-svg .letter-9 { animation-delay: 0.72s; }
 
     /* Body-level splash overlay. Sits above the React tree (z-index 10000)
        and is the only visual the user sees while HTML parses, scripts load,
@@ -557,7 +545,7 @@
       justify-content: center;
       z-index: 10000;
       opacity: 1;
-      transition: opacity 350ms ease-out;
+      transition: opacity 500ms ease-out;
     }
     #parachord-splash.fade-out {
       opacity: 0;

--- a/index.html
+++ b/index.html
@@ -511,44 +511,29 @@
       color: #f9fafb;
     }
 
-    @keyframes loadingLetterPopIn {
-      from { opacity: 0; transform: translateY(6px) scale(0.92); }
-      to   { opacity: 1; transform: translateY(0) scale(1); }
+    /* Continuous opacity pulse on the whole wordmark. Opacity-only
+       animation runs on the compositor and doesn't care if the main
+       thread is blocked — even during the worst of the vendor + app.js
+       parse window, the wordmark gently breathes. Previous attempts at
+       per-letter pop-in (CSS animation-delay AND JS-triggered .animate-
+       in via visibilitychange) both lost frames to main-thread blocks:
+       the cascade's wall-clock timeline kept advancing while the
+       compositor couldn't paint, so by the first post-block paint the
+       letters had all passed their stagger windows and snapped to the
+       final state in one frame. A continuous loop has no such
+       coordination requirement — worst case the user sees the
+       wordmark briefly at the pulse's dim point, which is still a
+       legible wordmark, not a half-broken cascade. */
+    @keyframes loadingWordmarkPulse {
+      0%, 100% { opacity: 0.55; }
+      50%      { opacity: 1; }
     }
-
-    /* Per-letter pop-in cascade, but JS-triggered (not via CSS
-       animation-delay). The earlier delay-driven version raced the
-       main thread during cold launch: vendor + app.js parse blocks
-       for ~1s, the CSS engine advances animations on wall-clock time,
-       so by the first post-block paint every letter past the first
-       had passed its (delay + duration) window and snapped straight
-       to the end state — visible as "P, pause, everything-at-once."
-       Fix: letters start visible by default so the splash always
-       renders content even if our trigger script never runs. When
-       the inline script just after the splash markup adds `.animate-
-       in` (on visibilitychange → 'visible', which fires when Electron
-       calls mainWindow.show() — by definition after ready-to-show,
-       so the main thread is no longer pegged), the animation engine
-       starts the cascade from that moment with `backwards` fill mode
-       holding letters at opacity:0 through their per-letter delay.
-       Cascade plays smoothly because the main thread is free. */
+    .loading-wordmark-svg {
+      animation: loadingWordmarkPulse 2.4s ease-in-out infinite;
+    }
     .loading-wordmark-svg .letter {
       opacity: 1;
-      transform-box: fill-box;
-      transform-origin: center;
     }
-    #parachord-splash.animate-in .loading-wordmark-svg .letter {
-      animation: loadingLetterPopIn 0.32s cubic-bezier(0.22, 1.2, 0.36, 1) backwards;
-    }
-    #parachord-splash.animate-in .loading-wordmark-svg .letter-1 { animation-delay: 0.00s; }
-    #parachord-splash.animate-in .loading-wordmark-svg .letter-2 { animation-delay: 0.07s; }
-    #parachord-splash.animate-in .loading-wordmark-svg .letter-3 { animation-delay: 0.14s; }
-    #parachord-splash.animate-in .loading-wordmark-svg .letter-4 { animation-delay: 0.21s; }
-    #parachord-splash.animate-in .loading-wordmark-svg .letter-5 { animation-delay: 0.28s; }
-    #parachord-splash.animate-in .loading-wordmark-svg .letter-6 { animation-delay: 0.35s; }
-    #parachord-splash.animate-in .loading-wordmark-svg .letter-7 { animation-delay: 0.42s; }
-    #parachord-splash.animate-in .loading-wordmark-svg .letter-8 { animation-delay: 0.49s; }
-    #parachord-splash.animate-in .loading-wordmark-svg .letter-9 { animation-delay: 0.56s; }
 
     /* Body-level splash overlay. Sits above the React tree (z-index 10000)
        and is the only visual the user sees while HTML parses, scripts load,
@@ -1103,45 +1088,6 @@
         </g>
     </svg>
   </div>
-
-  <!-- Kick the splash entrance cascade once the window is actually
-       visible. Electron creates the BrowserWindow with show: false and
-       only calls mainWindow.show() on ready-to-show — which fires after
-       all <script> tags have loaded, so by the time visibilitychange
-       flips to 'visible' the main thread is no longer pegged by parse.
-       Triggering the cascade then (vs at HTML parse via CSS animation-
-       delay) is what makes it actually animate smoothly. Letters
-       default to opacity:1 in CSS, so if visibilitychange never fires
-       (headless / future test harness) the wordmark is still visible —
-       just without entrance motion. Safety: 5s force-trigger so the
-       cascade never gets indefinitely stuck. -->
-  <script>
-    (function () {
-      var splash = document.getElementById('parachord-splash');
-      if (!splash) return;
-      var triggered = false;
-      var trigger = function () {
-        if (triggered) return;
-        triggered = true;
-        splash.classList.add('animate-in');
-      };
-      if (document.visibilityState === 'visible') {
-        // Already visible (reload, warm window). One rAF so the browser
-        // has a chance to do its initial paint of the default-state
-        // wordmark before we kick the animation — otherwise the
-        // backwards-fill-mode snap to opacity:0 can read as a flicker.
-        requestAnimationFrame(trigger);
-      } else {
-        document.addEventListener('visibilitychange', function onVis() {
-          if (document.visibilityState === 'visible') {
-            document.removeEventListener('visibilitychange', onVis);
-            trigger();
-          }
-        });
-        setTimeout(trigger, 5000);
-      }
-    })();
-  </script>
 
   <!-- React mount point. Splash overlay above (#parachord-splash) covers
        any partial paint until the Parachord component removes it. -->


### PR DESCRIPTION
## Why

Cold launch had two visible chops:

1. **Splash → React-loader flicker.** The pre-mount splash markup lived inside \`#root\`, so \`React.createRoot(root).render()\` replaced it on first commit. The Parachord component then mounted an identical-looking loader (\`AnimatedLoadingWordmark\`) in its place — but because the new DOM nodes started fresh, the CSS pop-in cascade re-played from \`opacity: 0\` frame 1. Same wordmark, visible flicker right at the React mount boundary.
2. **cacheLoaded → app hard cut.** When cache finished loading, the centered-wordmark loader unmounted in one frame and the entire app shell (sidebar, top bar, playbar, home page) snapped in. No transition.

## What

Make the splash a body-level overlay that survives React mount, then fade it once the home page has painted.

- \`index.html\`: splash markup moves out of \`#root\` into a sibling \`<div id="parachord-splash" class="loading-screen">\` with \`position: fixed; inset: 0; z-index: 10000\` and a 350ms opacity transition. React mounts UNDERNEATH instead of replacing the splash.
- \`app.js\`: drop \`AnimatedLoadingWordmark\` (now dead, ~60 lines of duplicate SVG markup). The \`!cacheLoaded\` render branch is now just \`null\` — the overlay covers the empty center while the rest of the app shell renders underneath as soon as React mounts.
- \`app.js\`: new \`useEffect\` on \`cacheLoaded\`. Once true: \`requestAnimationFrame × 2\` (so the home-page React commit has painted first), add \`.fade-out\` to the overlay (opacity → 0 over 350ms), then \`removeChild\` 400ms later. Cleanup cancels the rAFs + timer if the effect re-runs.

Net effect: pre-mount splash plays once, holds steady while React mounts and bulk cache loads, fades smoothly over the painted home page. No re-cascade, no hard cut.

## Test plan

- [ ] Cold launch: wordmark pop-in plays once, holds, fades over the home page. No mid-cascade replay.
- [ ] Warm launch (fast cache): brief splash, smooth fade.
- [ ] Dark mode: splash background matches the dark gradient.
- [ ] DOM inspector after the fade: \`#parachord-splash\` is gone (not lingering with \`pointer-events: none\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)