### PR TITLE
feat(localfiles): capture ID3 TSRC frame into sources.localfiles.isrc

### DIFF
--- a/local-files/database.js
+++ b/local-files/database.js
@@ -38,6 +38,7 @@ class LocalFilesDatabase {
         year INTEGER,
         genre TEXT,
         duration REAL,
+        isrc TEXT,
 
         format TEXT,
         bitrate INTEGER,
@@ -72,6 +73,15 @@ class LocalFilesDatabase {
       CREATE INDEX IF NOT EXISTS idx_tracks_album ON tracks(album_normalized);
       CREATE INDEX IF NOT EXISTS idx_tracks_file_path ON tracks(file_path);
     `);
+
+    // Idempotent migration for existing DBs created before the `isrc`
+    // column existed. CREATE TABLE IF NOT EXISTS above is a no-op for
+    // them, so the column has to be added explicitly. PRAGMA check
+    // keeps this safe to run on every startup.
+    const columns = this.db.prepare("PRAGMA table_info(tracks)").all();
+    if (!columns.some(c => c.name === 'isrc')) {
+      this.db.exec("ALTER TABLE tracks ADD COLUMN isrc TEXT");
+    }
   }
 
   normalize(str) {
@@ -124,7 +134,7 @@ class LocalFilesDatabase {
       INSERT OR REPLACE INTO tracks (
         file_path, file_hash, modified_at,
         title, artist, album, album_artist,
-        track_number, disc_number, year, genre, duration,
+        track_number, disc_number, year, genre, duration, isrc,
         format, bitrate, sample_rate,
         has_embedded_art, folder_art_path,
         indexed_at,
@@ -132,7 +142,7 @@ class LocalFilesDatabase {
       ) VALUES (
         ?, ?, ?,
         ?, ?, ?, ?,
-        ?, ?, ?, ?, ?,
+        ?, ?, ?, ?, ?, ?,
         ?, ?, ?,
         ?, ?,
         ?,
@@ -142,7 +152,7 @@ class LocalFilesDatabase {
     return stmt.run(
       track.filePath, track.fileHash, track.modifiedAt,
       track.title, track.artist, track.album, track.albumArtist,
-      track.trackNumber, track.discNumber, track.year, track.genre, track.duration,
+      track.trackNumber, track.discNumber, track.year, track.genre, track.duration, track.isrc || null,
       track.format, track.bitrate, track.sampleRate,
       track.hasEmbeddedArt ? 1 : 0, track.folderArtPath,
       Date.now(),

--- a/local-files/index.js
+++ b/local-files/index.js
@@ -190,7 +190,8 @@ class LocalFilesService {
           filePath: track.file_path,
           fileUrl: `file://${track.file_path}`,
           confidence: track.confidence || 1.0,
-          duration: track.duration
+          duration: track.duration,
+          isrc: track.isrc || null
         }
       }
     };

--- a/local-files/metadata-reader.js
+++ b/local-files/metadata-reader.js
@@ -42,6 +42,19 @@ class MetadataReader {
       year: metadata.common.year || null,
       genre: metadata.common.genre?.[0] || null,
       duration,
+      // music-metadata returns ISRC as common.isrc (array of strings — a
+      // recording can technically have multiple registered ISRCs; the first
+      // is the canonical one used everywhere downstream). Normalize to
+      // upper-case once at capture so the renderer-side helpers don't have
+      // to. Validates the canonical format so a malformed tag doesn't
+      // poison the source record (resolveMbidViaIsrc would just no-op on a
+      // bad value anyway, but explicit-skip is clearer).
+      isrc: (() => {
+        const raw = metadata.common.isrc?.[0];
+        if (typeof raw !== 'string' || !raw) return null;
+        const norm = raw.trim().toUpperCase();
+        return /^[A-Z]{2}[A-Z0-9]{3}\d{7}$/.test(norm) ? norm : null;
+      })(),
 
       // Format info
       format: path.extname(filePath).slice(1).toLowerCase(),


### PR DESCRIPTION
## Why

\`music-metadata\`'s \`common.isrc\` field exposes whatever the format's ISRC-equivalent frame carries — TSRC for ID3v2, the \`©isr\` atom in MP4, the ISRC field in Vorbis comments and FLAC tags. But local-files \`metadata-reader.js\` was discarding it. So locally-ripped files with properly-tagged ISRCs — everything imported from the iTunes catalog, every CD ripped via dBpoweramp / XLD with "include ISRC" enabled, every Bandcamp WAV bought through their catalog feed — couldn't contribute their ISRC to the [#888](https://github.com/Parachord/parachord/pull/888) ISRC→MBID fallback or [#892](https://github.com/Parachord/parachord/pull/892)'s achordion submit once that lands.

## What

Three coordinated changes through the local-files pipeline:

- **metadata-reader.js** — read \`common.isrc[0]\` (music-metadata returns an array; a recording can technically have multiple registered ISRCs but the first is the canonical one), trim + uppercase, validate against the canonical \`/^[A-Z]{2}[A-Z0-9]{3}\d{7}$/\` regex before accepting. Malformed tags get dropped rather than poisoning the source record.
- **database.js** — new \`isrc TEXT\` column on the \`tracks\` table. Idempotent PRAGMA-gated \`ALTER TABLE\` migration so existing databases pick the column up on next startup without a forced re-scan. \`insertTrack\` writes it.
- **index.js \`formatTrackForRenderer\`** — surface as \`track.sources.localfiles.isrc\`, matching the Spotify \`sources.spotify.isrc\` shape from [#893](https://github.com/Parachord/parachord/pull/893) and the precedence walk in \`window.pickTrackIsrc\` from [#894](https://github.com/Parachord/parachord/pull/894).

Tracks already in the database before this change pick up their ISRCs naturally on the next foreground rescan (file modification) or via the 5-minute background polling rescan. No forced re-scan needed at cold launch — the Achordion + love-push pickups gradually fill in.

## Test plan

- [x] All three files pass \`node --check\`
- [x] Migration logic verified by inspection (PRAGMA check is the standard idempotent-ALTER pattern)
- [ ] Live test: drop a FLAC with a known TSRC into a watch folder, confirm DB row has \`isrc\` populated, confirm renderer's \`track.sources.localfiles.isrc\` is set
- [ ] Live test: launch on a pre-existing local-files DB, confirm no crash + column gets added silently
- [ ] Live test: re-launch after migration runs once, confirm migration is a no-op (PRAGMA check correctly skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)