### PR TITLE
feat(listenbrainz): add isrc to additional_info on every listen submission

### DIFF
--- a/scrobbler-loader.js
+++ b/scrobbler-loader.js
@@ -426,6 +426,18 @@ class ListenBrainzScrobbler extends BaseScrobbler {
       if (valid.length > 0) out.artist_mbids = valid;
     }
 
+    // Group 4: ISRC. Recognized `additional_info` field on LB — server
+    // preserves and surfaces it on the listen. Once the listen carries
+    // the ISRC, Achordion's reader matches the play to the exact
+    // recording directly, no fuzzy artist/title hop. Resolution reuses
+    // window.pickTrackIsrc (parachord#894) — top-level then sources walk,
+    // canonical regex + uppercase normalization — so byte-equivalent to
+    // what the achordion track-links submit (parachord#892) sends.
+    if (typeof window !== 'undefined' && typeof window.pickTrackIsrc === 'function') {
+      const isrc = window.pickTrackIsrc(track);
+      if (isrc) out.isrc = isrc;
+    }
+
     return out;
   }
 
@@ -445,7 +457,7 @@ class ListenBrainzScrobbler extends BaseScrobbler {
           additional_info: {
             media_player: 'Parachord',
             submission_client: 'Parachord',
-            submission_client_version: '1.0.0',
+            submission_client_version: '1.1.0',
             duration_ms: track.duration ? track.duration * 1000 : undefined,
             ...this._deriveSourceEnrichment(track)
           }
@@ -486,7 +498,7 @@ class ListenBrainzScrobbler extends BaseScrobbler {
           additional_info: {
             media_player: 'Parachord',
             submission_client: 'Parachord',
-            submission_client_version: '1.0.0',
+            submission_client_version: '1.1.0',
             duration_ms: track.duration ? track.duration * 1000 : undefined,
             ...this._deriveSourceEnrichment(track)
           }


### PR DESCRIPTION
## Why

We already attach ISRC to the Achordion track-links submit ([parachord#892](https://github.com/Parachord/parachord/pull/892)). The listen we send to ListenBrainz is a separate payload and currently omits it — so when Achordion's reader picks up a mapper-less scrobble on the LB side it has to fall back to a fuzzy artist+title search instead of going straight to the exact recording. Add the field here.

\`isrc\` is a recognized \`additional_info\` field on LB — the server preserves and surfaces it on the listen, so once we send it the reader sees it.

## What

- \`_deriveSourceEnrichment\` gains a "Group 4" pickup that calls \`window.pickTrackIsrc(track)\` (the helper from [#894](https://github.com/Parachord/parachord/pull/894) — top-level \`track.isrc\` then walk \`track.sources[*].isrc\`, canonical regex validation, trim + uppercase). When the helper returns a valid ISRC it goes onto \`out.isrc\`; otherwise the field is **omitted entirely** (no \`null\`, no \`""\`, no malformed value — per the task spec).
- Both \`updateNowPlaying\` and \`scrobble\` already spread \`_deriveSourceEnrichment\` into \`additional_info\`, so this one edit covers both submission sites.
- \`submission_client_version\` bumped \`1.0.0 → 1.1.0\` on both paths so we can tell pre-ISRC scrobbles from post-ISRC ones on listenbrainz.org without grepping for the field.

Resolution is byte-equivalent to what the Achordion track-links submit sends — same \`window.pickTrackIsrc\` helper, same precedence, same regex. A track resolved via Spotify ([#893](https://github.com/Parachord/parachord/pull/893)), Apple Music native MusicKit (pre-existing top-level \`isrc\`), or local files ([#895](https://github.com/Parachord/parachord/pull/895)) all flow through the same picker.

Track-links submit untouched — that path already sends ISRC correctly.

## Test plan

- [x] \`node --check\` passes
- [x] Both \`submission_client_version\` bumps applied (grep confirms 2 occurrences of \`'1.1.0'\`)
- [x] \`window.pickTrackIsrc\` typeof-guarded so a missing helper doesn't break the scrobble
- [ ] Play a track with a known ISRC, then \`GET https://api.listenbrainz.org/1/user/<username>/listens?count=1\` and confirm \`payload.listens[0].track_metadata.additional_info.isrc\` is the 12-char ISRC
- [ ] Confirm \`submission_client_version\` on the same listen is \`"1.1.0"\`
- [ ] Confirm tracks without a resolvable ISRC submit fine (no field, no \`null\`, no error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)