### PR TITLE
fix(splash): hold the home hero wordmark until the splash overlay is gone

### DIFF
--- a/app.js
+++ b/app.js
@@ -9507,6 +9507,14 @@ const Parachord = () => {
   // Cache for album art URLs (releaseId -> { url, timestamp })
   const albumArtCache = useRef({});
   const [cacheLoaded, setCacheLoaded] = useState(false); // Track when persistent cache is loaded
+  // Flips true after the body-level #parachord-splash overlay is fully
+  // removed from the DOM. Gates the home view's hero wordmark img — see
+  // the home hero render block for why: without this, the wordmark
+  // visibly "jumps" from the splash's viewport-center position up to
+  // the hero's centered-inside-280px-header position right as the splash
+  // fades, because both wordmarks are momentarily visible at different Y
+  // coordinates and the eye tracks between them.
+  const [splashRemoved, setSplashRemoved] = useState(false);
 
   // Fade out the body-level splash overlay (#parachord-splash, in
   // index.html) once (a) cacheLoaded flips AND (b) the document is
@@ -9542,6 +9550,7 @@ const Parachord = () => {
         splash.classList.add('fade-out');
         removeTimer = setTimeout(() => {
           if (splash.parentNode) splash.parentNode.removeChild(splash);
+          setSplashRemoved(true);
         }, 550);
       }, 450);  // Post-visibility hold so the wordmark is on screen
                 // long enough to read as a splash (not a single-frame
@@ -45202,12 +45211,26 @@ useEffect(() => {
             !homeHeaderCollapsed && React.createElement('div', {
               className: 'absolute inset-0 flex flex-col items-center justify-center text-center px-6 z-10'
             },
-              // Parachord wordmark centered above title
+              // Parachord wordmark centered above title.
+              // opacity is gated on splashRemoved to avoid a perceived
+              // "wordmark jump" right when the splash fades: the splash
+              // SVG sits at viewport center, but this img sits at the
+              // hero's centered-inside-280px-header position (much
+              // higher), so both being visible during the fade reads
+              // as the wordmark jumping up. Holding this at opacity 0
+              // until the splash overlay is fully gone — then fading
+              // in over 350ms — gives the eye a single visual event
+              // instead of a track-between-two.
               React.createElement('img', {
                 src: 'assets/icons/logo-wordmark-white.png',
                 alt: 'Parachord',
                 className: 'mb-4',
-                style: { height: '38px', width: 'auto' }
+                style: {
+                  height: '38px',
+                  width: 'auto',
+                  opacity: splashRemoved ? 1 : 0,
+                  transition: 'opacity 350ms ease-out'
+                }
               }),
               // Title (matching other page headers)
               React.createElement('h1', {
@@ -45238,11 +45261,18 @@ useEffect(() => {
                 },
                 onContextMenu: copyParachordLink
               }, 'HOME'),
-              // Parachord wordmark on the right
+              // Parachord wordmark on the right. Same splashRemoved
+              // gate as the expanded-header variant — see the longer
+              // comment up there for why.
               React.createElement('img', {
                 src: 'assets/icons/logo-wordmark-white.png',
                 alt: 'Parachord',
-                style: { height: '26px', width: 'auto' }
+                style: {
+                  height: '26px',
+                  width: 'auto',
+                  opacity: splashRemoved ? 1 : 0,
+                  transition: 'opacity 350ms ease-out'
+                }
               })
             )
           ),


### PR DESCRIPTION
## Root cause

The home view's hero header (active by default on launch) renders a **second wordmark** — a PNG \`<img src='assets/icons/logo-wordmark-white.png'>\` centered inside the 280px-tall hero gradient. When \`cacheLoaded\` flips, both wordmarks become rendered:

- Splash SVG: viewport center, on top (still opaque)
- Hero PNG: centered inside the hero header, well above viewport center, underneath

As the splash overlay fades from opacity 1 → 0, the hero PNG becomes visible through the fade — at a different Y position than the splash SVG. The eye tracks between them and reads it as the wordmark jumping up.

This isn't a CSS position drift in either element (which is why every CSS fix I tried — display:block, position:fixed, flex centering, will-change — was orthogonal to the real cause). It's two real wordmarks at two real positions, briefly visible at the same time.

User confirmed the diagnostic by reloading from a non-home view: no jump there, because \`activeView !== 'home'\` means the hero (and its PNG wordmark) never renders.

## Fix

- New \`splashRemoved\` state, flips true inside the splash-fade useEffect right after \`splash.parentNode.removeChild\` fires.
- Both home hero wordmark img variants (expanded ~38px and collapsed ~26px) now use \`opacity: splashRemoved ? 1 : 0\` with a 350ms ease-out transition. The img stays in layout flow either way, so vertical centering of the hero doesn't shift when the wordmark appears — only opacity changes.
- Visual sequence becomes: splash pulses → splash fades over its gradient (no second wordmark anywhere) → splash element removed from DOM → 350ms later, hero wordmark fades in gently in its actual final position. Single visual event instead of two wordmarks competing for attention.

## Test plan

- [ ] Cold launch landing on home (default): pulse → smooth fade to home (with hero gradient but no wordmark visible) → hero wordmark fades in gently after the splash is gone. No jump.
- [ ] Cold launch landing on non-home view: pulse → smooth fade to the view (e.g. Settings). No jump (no hero wordmark to compete with).
- [ ] Toggling the home header expand/collapse: wordmark still fades smoothly between the 38px and 26px variants once present.
- [ ] Dark mode: same behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)