### PR TITLE
fix(splash): overlay the home hero PNG position+size instead of viewport center

### DIFF
--- a/app.js
+++ b/app.js
@@ -9507,14 +9507,6 @@ const Parachord = () => {
   // Cache for album art URLs (releaseId -> { url, timestamp })
   const albumArtCache = useRef({});
   const [cacheLoaded, setCacheLoaded] = useState(false); // Track when persistent cache is loaded
-  // Flips true after the body-level #parachord-splash overlay is fully
-  // removed from the DOM. Gates the home view's hero wordmark img — see
-  // the home hero render block for why: without this, the wordmark
-  // visibly "jumps" from the splash's viewport-center position up to
-  // the hero's centered-inside-280px-header position right as the splash
-  // fades, because both wordmarks are momentarily visible at different Y
-  // coordinates and the eye tracks between them.
-  const [splashRemoved, setSplashRemoved] = useState(false);
 
   // Fade out the body-level splash overlay (#parachord-splash, in
   // index.html) once (a) cacheLoaded flips AND (b) the document is
@@ -9550,7 +9542,6 @@ const Parachord = () => {
         splash.classList.add('fade-out');
         removeTimer = setTimeout(() => {
           if (splash.parentNode) splash.parentNode.removeChild(splash);
-          setSplashRemoved(true);
         }, 550);
       }, 450);  // Post-visibility hold so the wordmark is on screen
                 // long enough to read as a splash (not a single-frame
@@ -45211,26 +45202,17 @@ useEffect(() => {
             !homeHeaderCollapsed && React.createElement('div', {
               className: 'absolute inset-0 flex flex-col items-center justify-center text-center px-6 z-10'
             },
-              // Parachord wordmark centered above title.
-              // opacity is gated on splashRemoved to avoid a perceived
-              // "wordmark jump" right when the splash fades: the splash
-              // SVG sits at viewport center, but this img sits at the
-              // hero's centered-inside-280px-header position (much
-              // higher), so both being visible during the fade reads
-              // as the wordmark jumping up. Holding this at opacity 0
-              // until the splash overlay is fully gone — then fading
-              // in over 350ms — gives the eye a single visual event
-              // instead of a track-between-two.
+              // Parachord wordmark centered above title. The splash
+              // overlay's SVG wordmark is positioned + sized to overlay
+              // this img exactly (see #parachord-splash CSS in
+              // index.html), so when the splash fades the dark splash
+              // SVG dissolves into this white PNG at the identical
+              // viewport coordinates — no perceived jump.
               React.createElement('img', {
                 src: 'assets/icons/logo-wordmark-white.png',
                 alt: 'Parachord',
                 className: 'mb-4',
-                style: {
-                  height: '38px',
-                  width: 'auto',
-                  opacity: splashRemoved ? 1 : 0,
-                  transition: 'opacity 350ms ease-out'
-                }
+                style: { height: '38px', width: 'auto' }
               }),
               // Title (matching other page headers)
               React.createElement('h1', {
@@ -45261,18 +45243,16 @@ useEffect(() => {
                 },
                 onContextMenu: copyParachordLink
               }, 'HOME'),
-              // Parachord wordmark on the right. Same splashRemoved
-              // gate as the expanded-header variant — see the longer
-              // comment up there for why.
+              // Parachord wordmark on the right (collapsed-header
+              // variant — cold launch always lands on the expanded
+              // variant, so this one isn't position-matched to the
+              // splash SVG; it only matters once the user has
+              // collapsed the header by scrolling, well after splash
+              // dismissal).
               React.createElement('img', {
                 src: 'assets/icons/logo-wordmark-white.png',
                 alt: 'Parachord',
-                style: {
-                  height: '26px',
-                  width: 'auto',
-                  opacity: splashRemoved ? 1 : 0,
-                  transition: 'opacity 350ms ease-out'
-                }
+                style: { height: '26px', width: 'auto' }
               })
             )
           ),

--- a/index.html
+++ b/index.html
@@ -501,30 +501,36 @@
        (#1a1a1a in light, #f9fafb in dark) instead of two PNG variants.
        Crisper rendering than the previous PNG approach + saves ~150KB at
        splash time. */
-    /* Pin the wordmark to viewport center via fixed positioning +
-       translate. Earlier attempts using flex centering inside the
-       splash overlay (#898) didn't kill a ~20px vertical jump the user
-       still sees right before fade — 20px is too large for a font-
-       baseline computation, so the root cause must be flex-container
-       or parent-layout recompute somewhere in the React-mount window
-       (Tailwind's preflight reset arriving, the body's line-height
-       changing, etc), not a text-baseline shift.
+    /* Position + size the splash wordmark to overlay the home view's
+       hero PNG wordmark EXACTLY. When the splash fades, the home view
+       underneath has its own <img> wordmark at the hero's flex-centered
+       position; before this change the splash SVG sat at viewport
+       center and the PNG sat ~200px higher inside the 280px hero, so
+       the eye saw both at different positions during the fade and
+       read it as the wordmark "jumping up". Matching coordinates +
+       size means the dark splash SVG dissolves into the white PNG at
+       identical pixel positions — visually a single wordmark whose
+       color crossfades during the splash dismissal.
 
-       Cutting the dependency entirely: the SVG positions itself
-       independently of the splash container's layout. position:fixed
-       + transform: translate(-50%, -50%) anchors it to the viewport
-       directly. The splash container (#parachord-splash) no longer
-       flex-centers anything — it just hosts the gradient background
-       and the fade-out opacity transition. will-change promotes the
-       SVG to its own compositor layer so the transform can't be
-       invalidated by main-thread layout work either. The position
-       computation now depends on viewport dimensions alone. */
+       Coordinates:
+         - left: calc(50vw + 128px). Sidebar is w-64 (256px) on the
+           left; content area is the rest. Content-area horizontal
+           center = 256 + (100vw - 256) / 2 = 128 + 50vw.
+         - top: ~87px. Home hero header is 280px tall (expanded — cold
+           launch's default state, not persisted). Inside is a flex
+           column centering {wordmark, mb-4 (16px), HOME h1 (~48px
+           text-5xl line-box), mt-6 (24px), subtitle p (~18px)} =
+           ~144px stack. Stack starts at (280-144)/2 = 68px from
+           hero top, wordmark top at 68px, wordmark center at
+           68 + 19 = 87px.
+         - height: 38px. Matches the PNG <img height='38px'>.
+       Translate(-50%, -50%) keeps top/left meaning "wordmark center". */
     .loading-wordmark-svg {
       position: fixed;
-      top: 50%;
-      left: 50%;
+      top: 87px;
+      left: calc(50vw + 128px);
       transform: translate(-50%, -50%);
-      height: 72px;
+      height: 38px;
       width: auto;
       color: #1a1a1a;
       display: block;


### PR DESCRIPTION
## What you asked for

> "Why don't you just move the animation up so that it overlays the same size/location as the home png?"

Doing exactly that.

## Why the previous approach didn't work

[#900](https://github.com/Parachord/parachord/pull/900) hid the home PNG during the splash fade and then faded it in 350ms after the splash was gone. The intent was "no two wordmarks visible at once → no jump." But even with that gate, the user still saw two visual events at two positions:

1. Splash SVG fades out at viewport center
2. 350ms later, PNG fades in 200px higher in the hero

The eye still tracked between them. The problem wasn't simultaneity — it was different positions.

## What this PR does

Drops the gate, repositions + resizes the splash SVG to overlay the home PNG **at the exact pixel coordinates and size it'll occupy after the fade**:

- \`left: calc(50vw + 128px)\` — horizontal center of (viewport − 256px sidebar)
- \`top: 87px\` — 68px stack top inside the 280px hero + 19px (half of 38px wordmark)
- \`height: 38px\` — matches \`<img height='38px'>\` exactly

When the splash fades, the dark splash SVG dissolves into the white PNG at identical viewport coordinates. Visually it's a single wordmark whose color crossfades during dismissal. No two visual events, no jump.

## Reverts

Removes everything from [#900](https://github.com/Parachord/parachord/pull/900): \`splashRemoved\` state, the \`setSplashRemoved(true)\` call, and the opacity gates on both PNG variants.

## Caveats

- Cold launch on a non-home view: the splash wordmark sits at the home-PNG coordinates, which no actual wordmark occupies in those views. But since there's no second wordmark to compete with, the splash just disappears without any perceived jump.
- During HTML parse before React mounts: the wordmark sits at the home-PNG coordinates with the splash gradient covering the full viewport. It looks slightly off-center (because the sidebar area isn't yet visible). Tradeoff for killing the jump.
- Collapsed-header PNG (26px, right side) isn't position-matched — cold launch always lands on the expanded variant, so the collapsed variant only appears after the user scrolls, well after splash dismissal.

## Test plan

- [ ] Cold launch on home (default): splash → fade → no apparent wordmark movement. Position and size identical before and after.
- [ ] Cold launch on a non-home view: splash → fade → view appears. No jump (no competing wordmark).
- [ ] Dark mode: same behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)