### PR TITLE
fix(splash): remove home hero PNG, restore splash to viewport center

### DIFF
--- a/app.js
+++ b/app.js
@@ -45198,22 +45198,16 @@ useEffect(() => {
                 backgroundImage: 'url("data:image/svg+xml,%3Csvg width=\'100\' height=\'100\' viewBox=\'0 0 100 100\' xmlns=\'http://www.w3.org/2000/svg\'%3E%3Cg fill=\'%23ffffff\'%3E%3Ccircle cx=\'50\' cy=\'50\' r=\'40\' fill=\'none\' stroke=\'%23fff\' stroke-width=\'2\'/%3E%3Ccircle cx=\'50\' cy=\'50\' r=\'25\' fill=\'none\' stroke=\'%23fff\' stroke-width=\'1.5\'/%3E%3Ccircle cx=\'50\' cy=\'50\' r=\'10\' fill=\'none\' stroke=\'%23fff\' stroke-width=\'1\'/%3E%3C/g%3E%3C/svg%3E")'
               }
             }),
-            // EXPANDED STATE
+            // EXPANDED STATE — title + subtitle only. The Parachord
+            // wordmark img used to render above the title here but was
+            // removed: it sat at a different Y position than the splash
+            // SVG and the user saw a "wordmark jump" as the splash
+            // faded into it. Keeping the home hero without a second
+            // wordmark lets the splash stay viewport-centered and just
+            // fade away cleanly with no competing element.
             !homeHeaderCollapsed && React.createElement('div', {
               className: 'absolute inset-0 flex flex-col items-center justify-center text-center px-6 z-10'
             },
-              // Parachord wordmark centered above title. The splash
-              // overlay's SVG wordmark is positioned + sized to overlay
-              // this img exactly (see #parachord-splash CSS in
-              // index.html), so when the splash fades the dark splash
-              // SVG dissolves into this white PNG at the identical
-              // viewport coordinates — no perceived jump.
-              React.createElement('img', {
-                src: 'assets/icons/logo-wordmark-white.png',
-                alt: 'Parachord',
-                className: 'mb-4',
-                style: { height: '38px', width: 'auto' }
-              }),
               // Title (matching other page headers)
               React.createElement('h1', {
                 className: 'text-5xl font-light text-white',
@@ -45230,9 +45224,10 @@ useEffect(() => {
                 style: { textShadow: '0 1px 10px rgba(0,0,0,0.3)' }
               }, `${collectionData.albums.length} albums · ${collectionData.artists.length} artists · ${playlists.length} playlists`)
             ),
-            // COLLAPSED STATE
+            // COLLAPSED STATE — title only (right-side wordmark img
+            // removed for consistency with the expanded variant).
             homeHeaderCollapsed && React.createElement('div', {
-              className: 'absolute inset-0 flex items-center justify-between px-6 z-10'
+              className: 'absolute inset-0 flex items-center px-6 z-10'
             },
               React.createElement('h1', {
                 className: 'text-2xl font-light text-white',
@@ -45242,18 +45237,7 @@ useEffect(() => {
                   textTransform: 'uppercase'
                 },
                 onContextMenu: copyParachordLink
-              }, 'HOME'),
-              // Parachord wordmark on the right (collapsed-header
-              // variant — cold launch always lands on the expanded
-              // variant, so this one isn't position-matched to the
-              // splash SVG; it only matters once the user has
-              // collapsed the header by scrolling, well after splash
-              // dismissal).
-              React.createElement('img', {
-                src: 'assets/icons/logo-wordmark-white.png',
-                alt: 'Parachord',
-                style: { height: '26px', width: 'auto' }
-              })
+              }, 'HOME')
             )
           ),
 

--- a/index.html
+++ b/index.html
@@ -501,36 +501,20 @@
        (#1a1a1a in light, #f9fafb in dark) instead of two PNG variants.
        Crisper rendering than the previous PNG approach + saves ~150KB at
        splash time. */
-    /* Position + size the splash wordmark to overlay the home view's
-       hero PNG wordmark EXACTLY. When the splash fades, the home view
-       underneath has its own <img> wordmark at the hero's flex-centered
-       position; before this change the splash SVG sat at viewport
-       center and the PNG sat ~200px higher inside the 280px hero, so
-       the eye saw both at different positions during the fade and
-       read it as the wordmark "jumping up". Matching coordinates +
-       size means the dark splash SVG dissolves into the white PNG at
-       identical pixel positions — visually a single wordmark whose
-       color crossfades during the splash dismissal.
-
-       Coordinates:
-         - left: calc(50vw + 128px). Sidebar is w-64 (256px) on the
-           left; content area is the rest. Content-area horizontal
-           center = 256 + (100vw - 256) / 2 = 128 + 50vw.
-         - top: ~87px. Home hero header is 280px tall (expanded — cold
-           launch's default state, not persisted). Inside is a flex
-           column centering {wordmark, mb-4 (16px), HOME h1 (~48px
-           text-5xl line-box), mt-6 (24px), subtitle p (~18px)} =
-           ~144px stack. Stack starts at (280-144)/2 = 68px from
-           hero top, wordmark top at 68px, wordmark center at
-           68 + 19 = 87px.
-         - height: 38px. Matches the PNG <img height='38px'>.
-       Translate(-50%, -50%) keeps top/left meaning "wordmark center". */
+    /* Pin the wordmark to viewport center. The earlier home-PNG-match
+       attempt (parachord#901) tried to overlay the home hero's PNG
+       wordmark at identical coordinates, but that pushed the splash
+       off-center during the entire cold-launch window — bad trade.
+       The home hero PNG is removed in the same change as this revert,
+       so there's no second wordmark to compete with anymore; the
+       splash can go back to being viewport-centered with its original
+       72px size. */
     .loading-wordmark-svg {
       position: fixed;
-      top: 87px;
-      left: calc(50vw + 128px);
+      top: 50%;
+      left: 50%;
       transform: translate(-50%, -50%);
-      height: 38px;
+      height: 72px;
       width: auto;
       color: #1a1a1a;
       display: block;


### PR DESCRIPTION
You picked option (a) — kill the home hero PNG. This PR does that and reverts [#901](https://github.com/Parachord/parachord/pull/901)'s position-match in the same change since there's no second wordmark left to overlay.

## What changes

- **app.js, home hero expanded variant**: \`<img>\` wordmark removed. Hero now shows just the \"HOME\" title + subtitle stats, flex-centered in the 280px gradient.
- **app.js, home hero collapsed variant**: right-side \`<img>\` wordmark also removed for consistency. Switched the flex container from \`justify-between\` to default \`justify-start\` since there's only one child now.
- **index.html splash CSS**: reverts to viewport-centered, 72px high (undoes #901's position/size). Stays \`display: block\` + \`position: fixed\` + \`will-change: opacity, transform\` from #898/#899 — those weren't the cause and aren't worth re-litigating.

## Visual result

Splash pulses at viewport center → splash fades over the home hero gradient → no second wordmark anywhere → splash element removed. One visual event, no jump.

## Test plan

- [ ] Cold launch on home: splash centered, pulses, fades. Home view appears underneath with title + stats, no wordmark above the title. No jump.
- [ ] Cold launch on a non-home view: same splash behavior, no jump.
- [ ] Dark mode: same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)