### PR TITLE
fix(spotify): handle invalid_grant on token refresh — discard + re-auth

### DIFF
--- a/app.js
+++ b/app.js
@@ -16220,6 +16220,38 @@ ${trackListXml}
     };
   }, []);
 
+  // Listen for Spotify reauth-required signals from the main process.
+  //
+  // Fired when a token refresh returns invalid_grant — i.e. the refresh
+  // token expired or was revoked. As of Spotify's June 2026 policy,
+  // refresh tokens expire after six months (effective 2026-07-20), so
+  // this will start happening to long-running installs. Main has already
+  // discarded the stored token by the time this fires; the renderer just
+  // needs to reflect the disconnected state and let the user re-auth.
+  //
+  // Toast (not a modal like Apple Music) because the Spotify fix is a
+  // single click — there's no system-level revoke dance; the OAuth
+  // sign-in flow re-issues a fresh token directly.
+  useEffect(() => {
+    const unsubscribe = window.electron?.spotify?.onReauthRequired?.((data) => {
+      console.warn('[Spotify] Reauth required:', data);
+      // Reflect the actually-disconnected state (main already cleared the
+      // stored token). Without this the UI still shows "Connected" and the
+      // Connect button no-ops because it thinks we're authed.
+      setSpotifyToken(null);
+      setSpotifyConnected(false);
+      showToast(
+        'Spotify session expired — sign in again to keep streaming',
+        'warning',
+        { label: 'Reconnect', onClick: () => connectSpotify() },
+        { duration: 12000 }
+      );
+    });
+    return () => {
+      if (typeof unsubscribe === 'function') unsubscribe();
+    };
+  }, []);
+
   // Cider-style auth-window cookie handoff (parachord#834). When the user
   // signs in through the dedicated auth BrowserWindow opened by main's
   // `applemusic:open-auth-window` handler, main harvests the apple.com auth

--- a/main.js
+++ b/main.js
@@ -2502,6 +2502,72 @@ function getSpotifyCredentials() {
 }
 
 /**
+ * Clear all persisted Spotify user-token state. Shared by the
+ * spotify-disconnect IPC and the invalid_grant terminal-failure path so
+ * both wipe exactly the same keys. Does NOT touch credentials
+ * (spotify_client_id) — only the per-user token set.
+ */
+function clearSpotifyTokens() {
+  store.delete('spotify_token');
+  store.delete('spotify_refresh_token');
+  store.delete('spotify_token_expiry');
+  store.delete('spotify_token_scopes');
+}
+
+// Throttle so a burst of concurrent failed refreshes (e.g. 20 tracks
+// resolving at once when the token just died) only prompts re-auth once.
+let lastSpotifyReauthPromptAt = 0;
+
+/**
+ * Broadcast `spotify:reauth-required` to the renderer so it can flip to
+ * the disconnected state and prompt the user to sign in again. Mirrors
+ * the Apple Music `applemusic:reauth-required` pattern.
+ */
+function emitSpotifyReauthRequired(reason) {
+  const now = Date.now();
+  if (now - lastSpotifyReauthPromptAt < 30_000) return;
+  lastSpotifyReauthPromptAt = now;
+  try {
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (win && !win.isDestroyed()) {
+        win.webContents.send('spotify:reauth-required', { reason });
+      }
+    }
+    console.warn(`[Spotify] Emitted spotify:reauth-required (reason=${reason})`);
+  } catch (err) {
+    console.warn('[Spotify] Could not emit reauth prompt:', err && err.message);
+  }
+}
+
+/**
+ * Classify a Spotify token-refresh response.
+ *   - 'ok'       — refresh succeeded (caller reads the body for the new token)
+ *   - 'terminal' — invalid_grant / invalid_client: the refresh token is dead.
+ *                  Discard stored tokens and prompt re-auth. Do NOT retry.
+ *   - 'transient'— 429 / 5xx / network: keep the stored token, fail this
+ *                  attempt only, retry on the next call.
+ *
+ * Per Spotify's June 2026 notice: refresh tokens expire after six months,
+ * and an expired one returns HTTP 400 `{ "error": "invalid_grant" }`. The
+ * required handling is: discard the token (don't retry) + re-auth. We treat
+ * invalid_grant/invalid_client as terminal; everything else as transient so
+ * a server blip or rate-limit never logs the user out.
+ */
+function classifySpotifyRefresh(status, body) {
+  if (status >= 200 && status < 300) return 'ok';
+  const err = body && typeof body.error === 'string' ? body.error : null;
+  if (status === 400 && (err === 'invalid_grant' || err === 'invalid_client')) {
+    return 'terminal';
+  }
+  // 401/403 with invalid_grant/invalid_client are also terminal (some
+  // Spotify edges return 401 for a revoked grant).
+  if ((status === 401 || status === 403) && (err === 'invalid_grant' || err === 'invalid_client')) {
+    return 'terminal';
+  }
+  return 'transient';
+}
+
+/**
  * Ensure we have a valid (non-expired) Spotify access token.
  * Refreshes automatically if the stored token is expired.
  * Returns the valid access token string, or null if unavailable.
@@ -2533,12 +2599,25 @@ async function ensureValidSpotifyToken(force = false) {
         })
       });
 
-      if (!response.ok) {
-        console.error('❌ [Sync] Token refresh failed:', response.status);
+      let data = null;
+      try { data = await response.json(); } catch (_e) { /* non-JSON error body */ }
+      const verdict = classifySpotifyRefresh(response.status, data);
+
+      if (verdict === 'terminal') {
+        // Refresh token is dead (expired/revoked). Discard it — do NOT
+        // retry — and prompt the user to sign in again.
+        console.error('❌ [Sync] Spotify refresh token invalid (invalid_grant) — discarding and prompting re-auth');
+        clearSpotifyTokens();
+        emitSpotifyReauthRequired('invalid_grant');
+        return null;
+      }
+      if (verdict === 'transient' || !data || !data.access_token) {
+        // Server blip / rate-limit / network — keep the stored token,
+        // fail this attempt, retry on the next call.
+        console.error('❌ [Sync] Token refresh failed (transient):', response.status);
         return null;
       }
 
-      const data = await response.json();
       const newExpiry = Date.now() + ((data.expires_in || 3600) * 1000);
 
       store.set('spotify_token', data.access_token);
@@ -2556,7 +2635,8 @@ async function ensureValidSpotifyToken(force = false) {
       console.log('✅ [Sync] Token refreshed, expires:', new Date(newExpiry).toISOString());
       return data.access_token;
     } catch (error) {
-      console.error('❌ [Sync] Token refresh error:', error.message);
+      // Network error reaching Spotify — transient, keep the token.
+      console.error('❌ [Sync] Token refresh error (transient):', error.message);
       return null;
     }
   }
@@ -3195,12 +3275,26 @@ ipcMain.handle('spotify-check-token', async (event, { force = false } = {}) => {
         })
       });
 
-      if (!response.ok) {
-        console.error('❌ Token refresh failed:', response.status, response.statusText);
+      let data = null;
+      try { data = await response.json(); } catch (_e) { /* non-JSON error body */ }
+      const verdict = classifySpotifyRefresh(response.status, data);
+
+      if (verdict === 'terminal') {
+        // Refresh token expired/revoked (invalid_grant). Per Spotify's
+        // June 2026 policy: discard the token, do NOT retry, prompt the
+        // user to re-authorize. Return a structured signal so the
+        // renderer can distinguish "you must sign in again" from a
+        // transient failure (where it keeps the stale token).
+        console.error('❌ Spotify refresh token invalid (invalid_grant) — discarding and prompting re-auth');
+        clearSpotifyTokens();
+        emitSpotifyReauthRequired('invalid_grant');
+        return { reauthRequired: true };
+      }
+      if (verdict === 'transient' || !data || !data.access_token) {
+        console.error('❌ Token refresh failed (transient):', response.status, response.statusText);
         throw new Error(`Token refresh failed: ${response.status}`);
       }
 
-      const data = await response.json();
       console.log('✅ Token refreshed successfully');
 
       // Calculate expiry time (tokens typically last 1 hour)
@@ -3226,8 +3320,8 @@ ipcMain.handle('spotify-check-token', async (event, { force = false } = {}) => {
 
       return { token: data.access_token, expiresAt: newExpiry };
     } catch (error) {
-      console.error('Failed to refresh token:', error);
-      // Fall through to return null
+      console.error('Failed to refresh token (transient):', error);
+      // Fall through to return null — token left intact for retry.
     }
   }
 
@@ -3444,10 +3538,7 @@ ipcMain.handle('soundcloud-check-token', async () => {
 // Disconnect SoundCloud (clear tokens)
 ipcMain.handle('spotify-disconnect', async () => {
   console.log('=== Spotify Disconnect ===');
-  store.delete('spotify_token');
-  store.delete('spotify_refresh_token');
-  store.delete('spotify_token_expiry');
-  store.delete('spotify_token_scopes');
+  clearSpotifyTokens();
   console.log('Spotify tokens cleared');
   return { success: true };
 });

--- a/preload.js
+++ b/preload.js
@@ -62,6 +62,17 @@ contextBridge.exposeInMainWorld('electron', {
       return () => ipcRenderer.removeListener('spotify-auth-error', handler);
     },
 
+    // Listen for "your Spotify session expired, sign in again" — emitted
+    // by main when a token refresh returns invalid_grant (Spotify's
+    // 6-month refresh-token expiry, effective 2026-07-20). The stored
+    // token has already been discarded main-side; the renderer should
+    // flip to disconnected and prompt re-auth.
+    onReauthRequired: (callback) => {
+      const handler = (event, data) => callback(data);
+      ipcRenderer.on('spotify:reauth-required', handler);
+      return () => ipcRenderer.removeListener('spotify:reauth-required', handler);
+    },
+
     // Main process polling controls (background-safe)
     polling: {
       start: (params) => ipcRenderer.invoke('spotify-polling-start', params),


### PR DESCRIPTION
## Why

Spotify's June 2026 notice: user refresh tokens expire after six months starting **2026-07-20**. An expired token returns HTTP 400 `{ "error": "invalid_grant" }` on refresh. Required handling: (1) handle invalid_grant, (2) discard the token without retrying, (3) send the user back through sign-in.

Both our refresh paths got this wrong — and not only for the new expiry. On **any** failed refresh they logged, returned `null`, and **left the dead refresh token in the store**. So once a token went bad, every `checkToken` retried the same dead token forever, the renderer fell back to a stale access token (per its "don't discard a working token" comment), and Spotify silently died until the user manually disconnected + reconnected. No re-auth prompt.

## Changes

**main.js**
- `classifySpotifyRefresh(status, body)` → `'ok' | 'terminal' | 'transient'`. Terminal = 400/401/403 with `invalid_grant`/`invalid_client`. Transient = 429/5xx/network/unparseable. **The split is the point:** a Spotify hiccup must not log everyone out — only a genuinely-dead grant clears state.
- `clearSpotifyTokens()` — shared key-clear, now used by both `spotify-disconnect` and the terminal path.
- `emitSpotifyReauthRequired(reason)` — broadcasts `spotify:reauth-required`, 30s-throttled (mirrors `applemusic:reauth-required`).
- Both refresh sites (`ensureValidSpotifyToken` for sync, the `spotify-check-token` IPC for renderer/resolver) now parse the body, classify, and on terminal → clear tokens + emit reauth + stop (no retry). Transient keeps the token and fails the single attempt. The IPC returns `{ reauthRequired: true }` on terminal.

**preload.js** — `spotify.onReauthRequired(cb)` bridges the event.

**app.js** — `useEffect` listens for `spotify:reauth-required` → `setSpotifyConnected(false)`, `setSpotifyToken(null)`, and a "Spotify session expired — **Reconnect**" toast whose action runs `connectSpotify()`. Toast (not a modal like Apple Music) because the Spotify fix is a single OAuth click — no system-level revoke dance.

## Test plan

- [x] `classifySpotifyRefresh` unit-tested: invalid_grant/invalid_client (400/401/403) → terminal; 429/5xx/invalid_request/unparseable → transient.
- [x] `node --check` on all three files.
- [ ] **Force the invalid_grant path before July 20:** corrupt the stored refresh token (DevTools: `await window.electron.store.set('spotify_refresh_token', 'broken')`), then trigger a refresh (play a Spotify track or force `checkToken({force:true})`). Expect: tokens cleared, "Spotify session expired" toast with Reconnect, clicking it runs the OAuth flow and restores streaming.
- [ ] Transient check: simulate a 503 (or pull network) during refresh → token is NOT cleared, no reauth toast, retries succeed once Spotify is back.
- [ ] Normal refresh (valid token near expiry) still refreshes silently.

## Mobile parity

The Android client has its own Spotify refresh path and the same six-month expiry applies. Filing a parachord-mobile parity ticket once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)