### PR TITLE
feat(plugins): loading skeleton grid instead of "Loading plug-ins..." text

### DIFF
--- a/app.js
+++ b/app.js
@@ -53505,10 +53505,42 @@ useEffect(() => {
                 )
               ),
 
-              // Loading state
+              // Loading state — skeleton grid that mirrors the ResolverCard
+              // layout (120×120 rounded-16 card + name bar below) in the same
+              // grid columns, so the page doesn't reflow when real cards land.
+              // Uses the shared shimmer-light + animate-shimmer classes with a
+              // staggered delay (matches the search-page skeletons).
               marketplaceLoading && React.createElement('div', {
-                className: 'text-center py-12 text-gray-500'
-              }, 'Loading plug-ins...'),
+                className: 'grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6'
+              },
+                ...Array(10).fill(null).map((_, i) =>
+                  React.createElement('div', {
+                    key: `plugin-skeleton-${i}`,
+                    className: 'flex flex-col items-center'
+                  },
+                    React.createElement('div', {
+                      className: 'shimmer-light animate-shimmer',
+                      style: {
+                        width: '120px',
+                        height: '120px',
+                        borderRadius: '16px',
+                        backgroundSize: '200% 100%',
+                        animationDelay: `${i * 80}ms`
+                      }
+                    }),
+                    React.createElement('div', {
+                      className: 'shimmer-light animate-shimmer rounded',
+                      style: {
+                        width: '64px',
+                        height: '13px',
+                        marginTop: '10px',
+                        backgroundSize: '200% 100%',
+                        animationDelay: `${i * 80 + 50}ms`
+                      }
+                    })
+                  )
+                )
+              ),
 
               // Content Resolvers Section
               !marketplaceLoading && React.createElement('div', { style: { marginBottom: '40px' } },


### PR DESCRIPTION
## What

The Plugins page showed a centered **"Loading plug-ins..."** string while the marketplace manifest loaded, then snapped into the card grid — a jarring reflow. Replaced with a skeleton grid that mirrors the real layout.

- 10 placeholder cards in the **same** grid classes as the resolver grid (`grid-cols-2 md:3 lg:4 xl:5`, `gap-6`).
- Each skeleton matches a `ResolverCard`: a 120×120 rounded-16 shimmer square + a 64×13 name bar below at `marginTop: 10px` — same dimensions as the card and its name label, so real cards drop in without shifting anything.
- Reuses the shared `shimmer-light` + `animate-shimmer` classes (same as the search-page artist/song skeletons), with an 80ms-per-card staggered `animationDelay`. Theme-aware via the `--shimmer-*` CSS variables.

## Test plan

- [ ] Open Plugins with a cold marketplace cache (or throttle): skeleton grid shimmers in place of the old text, then real cards replace it with no layout shift.
- [ ] Dark mode: shimmer uses the dark `--shimmer-*` values.
- [ ] Fast cache: skeleton flashes briefly or not at all — no worse than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)