### PR TITLE
feat(sync): N-way key-unification pre-pass + remaster-strip identity rule (#911)

### DIFF
--- a/sync-engine/playlist-key-unify.js
+++ b/sync-engine/playlist-key-unify.js
@@ -44,6 +44,20 @@ const { validIsrc, validMbid, deriveNorm } = require('./playlist-merge');
 //   preserved (a within-list collision repeats the same repr; the merge
 //   dedups downstream).
 //
+// TODO(parachord#911): the norm-bridge guard from
+//   docs/plans/2026-06-21-nway-key-consistency-design.md is NOT implemented
+//   here — norm unifies even across tracks carrying DIFFERENT confident
+//   ISRCs/MBIDs (the doc's rule: "norm may bridge only when the stronger ids
+//   are absent or already agree; never override a confident isrc/mbid
+//   disagreement"). Two genuinely different recordings sharing `artist|title`
+//   but with different confident ISRCs would wrongly merge. ACCEPTED RISK for
+//   now: this matches the current cross-engine fixture contract (the 8
+//   key-unify fixtures don't pin the guard, so Kotlin has no guard either —
+//   we stay in byte-parity) AND N-way real-writes are OFF, so a false-merge
+//   cannot reach a remote. The guard + its fixtures must be added to BOTH
+//   engines together before real-writes are armed. (The blank-norm collapse,
+//   `norm='|'` from blank artist+title, is the same accepted residual.)
+//
 // @param {Array<Array<{isrc?:string|null, mbid?:string|null, norm:string}>>} lists
 // @returns {string[][]}
 function unifyTrackKeys(lists) {

--- a/sync-engine/playlist-key-unify.js
+++ b/sync-engine/playlist-key-unify.js
@@ -1,0 +1,144 @@
+// N-way cross-copy KEY UNIFICATION pre-pass (Phase 4 prerequisite).
+//
+// Design: docs/plans/2026-06-21-nway-key-consistency-design.md (parachord-
+// mobile). Tracker: Parachord/parachord#911.
+//
+// SYNC / CROSS-ENGINE PARITY (load-bearing): runs BEFORE the merge. Shadow
+// validation on a real 148-playlist library proved that the SAME track gets
+// different canonical keys across services (norm- vs mbid- for un-enriched
+// vs MBID-native; mbid- vs mbid- recording variance; and the confirmed
+// data-loss vector where a different recording MBID AND a drifted title left
+// only the ISRC to bridge). Exact-equality on a single key produced false
+// 'removes'. This pre-pass rewrites each copy's tracklist to canonical
+// REPRESENTATIVE keys so the same song matches across services; the
+// fixture-pinned delete-wins/order-LWW merge then runs UNCHANGED on the
+// representatives.
+//
+// The Kotlin engine (parachord-mobile shared/.../sync) implements the
+// identical algorithm; parity is proven by the shared vectors
+// tests/fixtures/nway-merge/key-unify-fixtures.json (vendored verbatim from
+// parachord-mobile docs/nway-key-unify-fixtures.json). Pure function — no
+// live sync wiring (dormant until the reconciliation redesign + no-false-
+// drop harness land; real writes stay off, matching mobile).
+
+const { validIsrc, validMbid, deriveNorm } = require('./playlist-merge');
+
+// ─────────────────────────────────────────────────────────────────────
+// unifyTrackKeys
+// ─────────────────────────────────────────────────────────────────────
+//
+// Input: `lists` = [baseline, copy1, copy2, …], each an array of tracks
+//   { isrc?, mbid?, norm } — already normalized (isrc validated+UPPER or
+//   null; mbid trim+lower or null; norm '<artist>|<title>' lower+trim,
+//   always present). Use `trackTiers()` below to derive this shape from a
+//   raw track object.
+//
+// Match: two tracks are the SAME if they share ANY tier value (isrc OR mbid
+//   OR norm), transitively (union-find).
+// Representative: per equivalence class, the strongest tier PRESENT in the
+//   class — `isrc-<v>` else `mbid-<v>` else `norm-<v>` — using the
+//   lexicographically-smallest value within that tier (deterministic
+//   regardless of input order). A singleton yields exactly its single
+//   canonical key (backward-compatible with canonicalTrackKey).
+// Output: each input list rewritten to representative keys, order + length
+//   preserved (a within-list collision repeats the same repr; the merge
+//   dedups downstream).
+//
+// @param {Array<Array<{isrc?:string|null, mbid?:string|null, norm:string}>>} lists
+// @returns {string[][]}
+function unifyTrackKeys(lists) {
+  const safe = Array.isArray(lists) ? lists : [];
+
+  // Flatten, tracking (listIdx, pos) for the rewrite.
+  const tracks = [];
+  safe.forEach((list, li) => {
+    (Array.isArray(list) ? list : []).forEach((t, pi) => {
+      tracks.push({
+        isrc: t && typeof t.isrc === 'string' && t.isrc ? t.isrc : null,
+        mbid: t && typeof t.mbid === 'string' && t.mbid ? t.mbid : null,
+        // norm is "always present" per the contract; default to '' defensively.
+        norm: t && typeof t.norm === 'string' ? t.norm : '',
+        listIdx: li,
+        pos: pi,
+      });
+    });
+  });
+
+  // Union-find over track indices.
+  const parent = tracks.map((_, i) => i);
+  const find = (x) => {
+    let r = x;
+    while (parent[r] !== r) r = parent[r];
+    while (parent[x] !== r) { const n = parent[x]; parent[x] = r; x = n; }
+    return r;
+  };
+  const union = (a, b) => {
+    const ra = find(a);
+    const rb = find(b);
+    if (ra !== rb) parent[Math.max(ra, rb)] = Math.min(ra, rb);
+  };
+
+  // Union any two tracks sharing a tier value (isrc / mbid / norm).
+  const firstByTier = new Map(); // `${tier}:${value}` -> first track index
+  tracks.forEach((t, i) => {
+    const pairs = [['isrc', t.isrc], ['mbid', t.mbid], ['norm', t.norm]];
+    for (const [tier, val] of pairs) {
+      if (val == null || val === '') continue;
+      const key = `${tier}:${val}`;
+      if (firstByTier.has(key)) union(i, firstByTier.get(key));
+      else firstByTier.set(key, i);
+    }
+  });
+
+  // Representative per class.
+  const reprByRoot = new Map();
+  const membersByRoot = new Map();
+  tracks.forEach((_, i) => {
+    const r = find(i);
+    if (!membersByRoot.has(r)) membersByRoot.set(r, []);
+    membersByRoot.get(r).push(i);
+  });
+  for (const [root, members] of membersByRoot) {
+    const isrcs = [];
+    const mbids = [];
+    const norms = [];
+    for (const i of members) {
+      if (tracks[i].isrc) isrcs.push(tracks[i].isrc);
+      if (tracks[i].mbid) mbids.push(tracks[i].mbid);
+      norms.push(tracks[i].norm);
+    }
+    let repr;
+    if (isrcs.length) repr = `isrc-${minStr(isrcs)}`;
+    else if (mbids.length) repr = `mbid-${minStr(mbids)}`;
+    else repr = `norm-${minStr(norms)}`;
+    reprByRoot.set(root, repr);
+  }
+
+  // Rewrite, preserving each list's order + length.
+  const out = safe.map(() => []);
+  tracks.forEach((t, i) => {
+    out[t.listIdx][t.pos] = reprByRoot.get(find(i));
+  });
+  return out;
+}
+
+function minStr(arr) {
+  let m = arr[0];
+  for (const s of arr) if (s < m) m = s;
+  return m;
+}
+
+// Derive the unify input tiers from a raw track object. Mirrors
+// canonicalTrackKey's tier extraction (isrc validated+UPPER, recording mbid
+// trim+lower, norm = remaster-stripped `<artist>|<title>`). This is the
+// bridge a caller uses to build the `lists` input from real tracks.
+// @returns {{isrc: string|null, mbid: string|null, norm: string}}
+function trackTiers(track) {
+  return {
+    isrc: validIsrc(track && track.isrc),
+    mbid: validMbid(track && track.recordingMbid) || validMbid(track && track.mbid),
+    norm: deriveNorm(track && track.artist, track && track.title),
+  };
+}
+
+module.exports = { unifyTrackKeys, trackTiers };

--- a/sync-engine/playlist-merge.js
+++ b/sync-engine/playlist-merge.js
@@ -58,9 +58,32 @@ function normField(value) {
   return (typeof value === 'string' ? value : '').trim().toLowerCase();
 }
 
+// Strip a trailing remaster annotation from a LOWERCASED title so the same
+// recording unifies across services when its title drifts (the ListenBrainz
+// axis: LB returns no per-track ISRC, so only `norm` can bridge there). This
+// is a CROSS-ENGINE identity rule — the Kotlin norm derivation applies the
+// identical regex (parachord#911, 2026-06-23 update). Conservative: strips
+// "- [YYYY] Remaster(ed) [YYYY]" / "(Remaster(ed) [YYYY])" forms only; it
+// deliberately does NOT touch Live / Acoustic / Single / Radio / "(feat …)"
+// — those are genuinely different recordings.
+function stripRemasterSuffix(lowerTitle) {
+  return lowerTitle.replace(
+    /\s*[-(]\s*(\d{4}\s+)?remaster(ed)?(\s+\d{4})?\s*\)?\s*$/,
+    ''
+  );
+}
+
+// Derive the `norm` identity tier: `<artist>|<title>`, each lower+trim, with
+// the remaster suffix stripped from the title. Shared by canonicalTrackKey
+// (singleton) and the unify pre-pass's trackTiers (cross-copy matching).
+function deriveNorm(artist, title) {
+  return `${normField(artist)}|${stripRemasterSuffix(normField(title))}`;
+}
+
 /**
  * Canonical track key. Precedence: valid ISRC -> `isrc-<UPPER>`; else
- * recording MBID -> `mbid-<lower>`; else `norm-<artist|title>` (lower+trim).
+ * recording MBID -> `mbid-<lower>`; else `norm-<artist|title>` (lower+trim,
+ * remaster-stripped title).
  * @param {{isrc?:string, recordingMbid?:string, mbid?:string, artist?:string, title?:string}} track
  * @returns {string}
  */
@@ -70,7 +93,7 @@ function canonicalTrackKey(track) {
   if (isrc) return `isrc-${isrc}`;
   const mbid = validMbid(track.recordingMbid) || validMbid(track.mbid);
   if (mbid) return `mbid-${mbid}`;
-  return `norm-${normField(track.artist)}|${normField(track.title)}`;
+  return `norm-${deriveNorm(track.artist, track.title)}`;
 }
 
 function arraysEqual(a, b) {
@@ -181,4 +204,6 @@ module.exports = {
   validIsrc,
   validMbid,
   normField,
+  stripRemasterSuffix,
+  deriveNorm,
 };

--- a/tests/fixtures/nway-merge/README.md
+++ b/tests/fixtures/nway-merge/README.md
@@ -1,5 +1,20 @@
 # N-way merge — shared cross-engine test vectors
 
+Two vendored fixture files, both **verbatim** from parachord-mobile (the
+source of truth). Run against BOTH the desktop JS engine and the mobile Kotlin
+engine; identical fixtures passing on both is the parity contract.
+
+| File | Source (parachord-mobile) | Engine |
+|---|---|---|
+| `canonical-fixtures.json` | `docs/nway-playlist-merge-fixtures.json` (`ff03511`) | the pure 3-way merge (`sync-engine/playlist-merge.js`) |
+| `key-unify-fixtures.json` | `docs/nway-key-unify-fixtures.json` (branch `nway-phase2-migration`) | the cross-copy key-unification pre-pass (`sync-engine/playlist-key-unify.js`) |
+
+Pipeline on both engines: `unifyTrackKeys(baseline + copies)` rewrites each
+copy's tracklist to representative keys, then the unchanged `mergePlaylist`
+runs on the representatives.
+
+---
+
 `canonical-fixtures.json` is **vendored verbatim** from the source-of-truth in
 parachord-mobile: `docs/nway-playlist-merge-fixtures.json` (commit `ff03511`).
 

--- a/tests/fixtures/nway-merge/key-unify-fixtures.json
+++ b/tests/fixtures/nway-merge/key-unify-fixtures.json
@@ -1,0 +1,71 @@
+{
+  "_about": "Canonical cross-engine vectors for N-way cross-copy KEY UNIFICATION (Phase 4 prerequisite). Runs BEFORE the merge: it rewrites each copy's tracklist to canonical representative keys so the same song matches across services, THEN docs/nway-playlist-merge-fixtures.json's merge runs on the representatives. BOTH the Kotlin (mobile, shared/.../sync/NwayKeyUnify.kt) and JS (desktop) implementations MUST produce `expected` for each case. Mobile's NwayKeyUnifyTest is a 1:1 transcription.",
+  "_semantics": {
+    "input": "`lists` = baseline + each copy, in order. Each track is {isrc?, mbid?, norm}: isrc validated+UPPERCASED (^[A-Z]{2}[A-Z0-9]{3}[0-9]{7}$) or null; mbid trim+lowercase or null; norm = '<artist>|<title>' lower+trim, always present.",
+    "match": "Two tracks are the SAME if they share ANY tier value (isrc OR mbid OR norm), transitively (union-find). norm bridges an un-enriched track to its mbid twin AND bridges two different recording-MBIDs of the same song.",
+    "representative": "Per equivalence class, the strongest tier present — 'isrc-<v>' else 'mbid-<v>' else 'norm-<v>' — using the LEXICOGRAPHICALLY-SMALLEST value within that tier. Deterministic regardless of input order. A singleton class yields exactly the single canonical key.",
+    "residual": "Two genuinely different recordings sharing an identical norm unify via norm (accepted, rare). Guarding the norm bridge on disagreeing ISRCs is a tracked refinement.",
+    "output": "Each input list rewritten to its representative keys, order + length preserved (a within-list norm collision collapses to the same repr; the downstream merge dedups)."
+  },
+  "cases": [
+    {
+      "name": "singleton_yields_canonical_key",
+      "lists": [[{ "mbid": "x", "norm": "a|t" }, { "norm": "b|t" }]],
+      "expected": [["mbid-x", "norm-b|t"]]
+    },
+    {
+      "name": "norm_bridges_unenriched_to_mbid_twin",
+      "lists": [
+        [{ "mbid": "x", "norm": "radiohead|creep" }],
+        [{ "norm": "radiohead|creep" }]
+      ],
+      "expected": [["mbid-x"], ["mbid-x"]]
+    },
+    {
+      "name": "norm_bridges_recording_mbid_variance",
+      "lists": [
+        [{ "mbid": "rec-a", "norm": "song|x" }],
+        [{ "mbid": "rec-b", "norm": "song|x" }]
+      ],
+      "expected": [["mbid-rec-a"], ["mbid-rec-a"]]
+    },
+    {
+      "name": "isrc_is_strongest_representative",
+      "lists": [
+        [{ "isrc": "USRC17607839", "mbid": "m1", "norm": "n|n" }],
+        [{ "mbid": "m2", "norm": "n|n" }]
+      ],
+      "expected": [["isrc-USRC17607839"], ["isrc-USRC17607839"]]
+    },
+    {
+      "name": "isrc_match_unifies_even_when_norm_differs",
+      "lists": [
+        [{ "isrc": "GBAYE0601477", "norm": "radiohead|creep" }],
+        [{ "isrc": "GBAYE0601477", "norm": "radiohead|creep - remaster" }]
+      ],
+      "expected": [["isrc-GBAYE0601477"], ["isrc-GBAYE0601477"]]
+    },
+    {
+      "name": "isrc_bridges_when_mbid_and_norm_both_differ",
+      "_note": "Reconciliation-redesign incident case: same recording across services with a DIFFERENT recording-MBID AND a drifted normalized title (remaster suffix). Neither mbid nor norm matches; only the ISRC bridges them. Without the persisted isrc tier these were union-removed → data loss.",
+      "lists": [
+        [{ "isrc": "USABC1234567", "mbid": "rec-a", "norm": "the cranberries|zombie" }],
+        [{ "isrc": "USABC1234567", "mbid": "rec-b", "norm": "the cranberries|zombie - 2025 remastered" }]
+      ],
+      "expected": [["isrc-USABC1234567"], ["isrc-USABC1234567"]]
+    },
+    {
+      "name": "distinct_tracks_stay_distinct",
+      "lists": [
+        [{ "mbid": "x", "norm": "artist|one" }],
+        [{ "mbid": "y", "norm": "artist|two" }]
+      ],
+      "expected": [["mbid-x"], ["mbid-y"]]
+    },
+    {
+      "name": "order_independent_determinism",
+      "lists": [[{ "mbid": "b", "norm": "s|x" }, { "mbid": "a", "norm": "s|x" }]],
+      "expected": [["mbid-a", "mbid-a"]]
+    }
+  ]
+}

--- a/tests/sync/playlist-key-unify.test.js
+++ b/tests/sync/playlist-key-unify.test.js
@@ -1,0 +1,121 @@
+/**
+ * N-way cross-copy key unification — pre-pass tests (Phase 4 prerequisite,
+ * Parachord/parachord#911).
+ *
+ * Layers:
+ *   1. The shared cross-engine fixture suite — key-unify-fixtures.json,
+ *      vendored verbatim from parachord-mobile (the SAME file the Kotlin
+ *      engine runs against). Identical fixtures passing on both engines is
+ *      the parity contract.
+ *   2. The norm remaster-strip identity rule (norm-strip cases, transcribed
+ *      desktop-side per the 2026-06-23 contract update) + the trackTiers
+ *      bridge + the unify→merge pipeline shape.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { unifyTrackKeys, trackTiers } = require('../../sync-engine/playlist-key-unify');
+const {
+  canonicalTrackKey,
+  mergePlaylist,
+  deriveNorm,
+  stripRemasterSuffix,
+} = require('../../sync-engine/playlist-merge');
+
+const UNIFY = JSON.parse(
+  fs.readFileSync(
+    path.join(__dirname, '..', 'fixtures', 'nway-merge', 'key-unify-fixtures.json'),
+    'utf8'
+  )
+);
+
+describe('unifyTrackKeys — canonical cross-engine fixtures', () => {
+  test('fixture file carries the expected case count', () => {
+    expect(Array.isArray(UNIFY.cases)).toBe(true);
+    expect(UNIFY.cases.length).toBe(8);
+  });
+
+  for (const c of UNIFY.cases) {
+    test(`${c.name}`, () => {
+      expect(unifyTrackKeys(c.lists)).toEqual(c.expected);
+    });
+  }
+});
+
+describe('unifyTrackKeys — additional properties', () => {
+  test('transitive: A~B via isrc, B~C via norm -> one class', () => {
+    const [out] = unifyTrackKeys([
+      [
+        { isrc: 'USABC1234567', mbid: 'a', norm: 'x|one' },
+        { isrc: 'USABC1234567', mbid: 'b', norm: 'x|two' }, // shares isrc with #0
+        { mbid: 'c', norm: 'x|two' }, // shares norm with #1
+      ],
+    ]);
+    // All three unify; strongest tier is isrc -> the single isrc value.
+    expect(out).toEqual(['isrc-USABC1234567', 'isrc-USABC1234567', 'isrc-USABC1234567']);
+  });
+
+  test('singleton representative == canonicalTrackKey', () => {
+    const track = { mbid: 'b2181aae-5cba-496c-bb0c-b4cc0109ebf8', artist: 'Radiohead', title: 'Creep' };
+    const tiers = trackTiers(track);
+    const [out] = unifyTrackKeys([[tiers]]);
+    expect(out[0]).toBe(canonicalTrackKey(track));
+  });
+
+  test('empty / missing lists degrade safely', () => {
+    expect(unifyTrackKeys([])).toEqual([]);
+    expect(unifyTrackKeys([[]])).toEqual([[]]);
+    expect(unifyTrackKeys(null)).toEqual([]);
+  });
+});
+
+describe('norm remaster-strip (cross-engine identity rule)', () => {
+  test('strips trailing remaster annotations (various forms)', () => {
+    expect(stripRemasterSuffix('zombie - 2025 remastered')).toBe('zombie');
+    expect(stripRemasterSuffix('creep - 2009 remaster')).toBe('creep');
+    expect(stripRemasterSuffix('bohemian rhapsody (remastered 2011)')).toBe('bohemian rhapsody');
+    expect(stripRemasterSuffix('let it be (2009 remaster)')).toBe('let it be');
+    expect(stripRemasterSuffix('a day in the life - remastered')).toBe('a day in the life');
+  });
+
+  test('does NOT strip live / acoustic / single / radio / feat (genuinely different recordings)', () => {
+    expect(stripRemasterSuffix('creep - live')).toBe('creep - live');
+    expect(stripRemasterSuffix('hurt - acoustic')).toBe('hurt - acoustic');
+    expect(stripRemasterSuffix('roar - single version')).toBe('roar - single version');
+    expect(stripRemasterSuffix('umbrella (feat. jay-z)')).toBe('umbrella (feat. jay-z)');
+  });
+
+  test('deriveNorm applies the strip to the title only, lower+trims both', () => {
+    expect(deriveNorm('The Beatles', 'Let It Be - 2009 Remaster')).toBe('the beatles|let it be');
+    expect(deriveNorm('Radiohead', 'Creep')).toBe('radiohead|creep');
+  });
+
+  test('un-stripped twins unify via norm once derived', () => {
+    // Same recording, drifted title (remaster). No isrc/mbid -> only norm
+    // can bridge; the strip makes the two derived norms equal so they unify.
+    const a = trackTiers({ artist: 'The Beatles', title: 'Let It Be' });
+    const b = trackTiers({ artist: 'The Beatles', title: 'Let It Be - 2009 Remaster' });
+    const out = unifyTrackKeys([[a], [b]]);
+    expect(out[0][0]).toBe(out[1][0]); // same representative
+    expect(out[0][0]).toBe('norm-the beatles|let it be');
+  });
+});
+
+describe('pipeline — unifyTrackKeys feeds merge unchanged', () => {
+  test('representative keys merge correctly (cross-service same-song add)', () => {
+    // baseline + two copies; the "same song" is keyed mbid- on one copy and
+    // norm- on the other. After unify both become the strongest representative,
+    // so the merge sees one track, not an add+remove.
+    const baseline = [trackTiers({ recordingMbid: 'b2181aae-5cba-496c-bb0c-b4cc0109ebf8', artist: 'A', title: 'Song' })];
+    const spotifyTracks = [trackTiers({ recordingMbid: 'b2181aae-5cba-496c-bb0c-b4cc0109ebf8', artist: 'A', title: 'Song' })];
+    const lbTracks = [trackTiers({ artist: 'A', title: 'Song' })]; // un-enriched twin, bridges via norm
+
+    const [uBaseline, uSpotify, uLb] = unifyTrackKeys([baseline, spotifyTracks, lbTracks]);
+    const merged = mergePlaylist(uBaseline, [
+      { id: 'spotify', tracks: uSpotify, editedAt: 1 },
+      { id: 'listenbrainz', tracks: uLb, editedAt: 2 },
+    ]);
+    // One unified track, no false add/remove.
+    expect(merged).toEqual(['mbid-b2181aae-5cba-496c-bb0c-b4cc0109ebf8']);
+  });
+});


### PR DESCRIPTION
Phase-4 prerequisite from the N-way epic ([#911](https://github.com/Parachord/parachord/issues/911)). **Pure + dormant** — no live sync wiring; real writes stay off (matching mobile) until the reconciliation redesign + a no-false-drop harness land.

## Why

Shadow validation on a real 148-playlist library proved the **same track gets different canonical keys across services** — `norm-` vs `mbid-` (un-enriched local vs MBID-native LB), `mbid-` vs `mbid-` recording variance, and the confirmed data-loss vector where a different recording MBID **and** a drifted title (remaster suffix) left only the ISRC to bridge. Exact-equality on a single key produced false `removes`. The fix runs a pure **pre-pass before the unchanged merge**.

## What

- **`sync-engine/playlist-key-unify.js`** (new) — `unifyTrackKeys(lists)`: union-find over shared tier values (isrc/mbid/norm, transitive); per equivalence class the representative is the strongest tier present using the lexicographically-smallest value (deterministic; a singleton yields exactly its canonical key). `trackTiers(rawTrack)` bridges a real track to the `{isrc,mbid,norm}` input. Pipeline: `unifyTrackKeys(baseline+copies)` → representative keys → `mergePlaylist` **unchanged**.
- **`sync-engine/playlist-merge.js`** — the `norm` tier now strips a trailing remaster annotation from the title (the ListenBrainz axis — LB has no per-track ISRC, only `norm` can bridge). Cross-engine-identical regex; deliberately does **not** strip Live/Acoustic/Single/Radio/`(feat …)`. `canonicalTrackKey` uses the shared `deriveNorm`.
- **`tests/fixtures/nway-merge/key-unify-fixtures.json`** — vendored verbatim from parachord-mobile `docs/nway-key-unify-fixtures.json` (branch `nway-phase2-migration`), 8 cases incl. `isrc_bridges_when_mbid_and_norm_both_differ`.
- **`tests/sync/playlist-key-unify.test.js`** — 8 canonical fixtures + transitivity + singleton==canonicalTrackKey + remaster-strip rule + the unify→merge pipeline.

## Test plan

- [x] `npx jest tests/sync/` → 6 suites, 276 tests green.
- [ ] Mobile parity: same `key-unify-fixtures.json` passes on the Kotlin engine (it's the source of the vendored file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)