### PR TITLE
feat(sync): N-way Phase 2 — bootstrap migration seeds sync_playlist_state (#911)

### DIFF
--- a/main.js
+++ b/main.js
@@ -5868,6 +5868,39 @@ function healImportedSyncedFromMismatch() {
 }
 healImportedSyncedFromMismatch();
 
+// Bootstrap the N-way sync state (Phase 2, parachord#911). One-time, idempotent,
+// no network: seed `sync_playlist_state` from existing local_playlists so the
+// N-way engine has a baseline + per-provider record to work from once it's
+// wired (shadow mode first). Skips playlists that already have an entry (so a
+// re-run never clobbers state a future reconcile cycle advanced) and playlists
+// with no sync intent. Behavior-neutral — nothing READS this map for
+// reconciliation yet. The pure per-playlist builder is unit-tested in
+// sync-engine/playlist-sync-state.js; this is the thin iterate-and-persist glue.
+function bootstrapNwayPlaylistState() {
+  try {
+    const { bootstrapPlaylistState } = require('./sync-engine/playlist-sync-state');
+    const playlists = store.get('local_playlists');
+    if (!Array.isArray(playlists) || playlists.length === 0) return;
+    const states = getSyncStates();
+    const now = Date.now();
+    let seeded = 0;
+    for (const pl of playlists) {
+      if (!pl || !pl.id || states[pl.id]) continue; // idempotent: skip existing
+      const entry = bootstrapPlaylistState(pl, now);
+      if (!entry) continue; // no sync intent
+      states[pl.id] = entry;
+      seeded++;
+    }
+    if (seeded > 0) {
+      store.set('sync_playlist_state', states); // single write
+      console.log(`[NwayState] Bootstrap-seeded baseline + provider state for ${seeded} playlist(s)`);
+    }
+  } catch (err) {
+    console.warn('[NwayState] Bootstrap failed (non-fatal):', err && err.message);
+  }
+}
+bootstrapNwayPlaylistState();
+
 // Prune expired track tombstones at app start (parachord#864). One-shot
 // per launch; entries older than TOMBSTONE_TTL_MS (365 days) are
 // dropped. Tombstones get re-armed every time the sync filter sees the

--- a/sync-engine/playlist-sync-state.js
+++ b/sync-engine/playlist-sync-state.js
@@ -144,6 +144,70 @@ function makePlaylistSyncState({ baseline = [], baselineSyncedAt = 0, providers 
   };
 }
 
+// ─────────────────────────────────────────────────────────────────────
+// Bootstrap (Phase 2 — one-time migration)
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Build the initial N-way sync state for ONE local playlist, seeded from its
+ * current (canonical-source-era) shape. Pure + deterministic given `now`.
+ *
+ * The local tracklist is the trustworthy ancestor today (it's the canonical
+ * source), so the baseline = buildBaseline(tracks). One `providers` record is
+ * created per linked mirror — the `syncedFrom` source plus every `syncedTo`
+ * target that has an externalId — carrying that provider's existing change
+ * token (snapshotId) so the first reconcile cycle can detect later edits.
+ *
+ * `editedAt` seeds to 0 (we have no real per-provider edit time at bootstrap;
+ * it only affects merge ORDER and is captured for real on the first push).
+ *
+ * Returns null when the playlist has NO sync intent (no syncedFrom, no
+ * syncedTo) — a local-only playlist is not an N-way participant.
+ *
+ * NOTE (design open question #4, parachord#911): `baseline` stores the
+ * COLLAPSED canonical key per track (string[]), matching the Phase-1 schema.
+ * If cross-copy re-unification later needs the full {isrc,mbid,norm} tiers of
+ * the ancestor, this becomes an additive schema change + re-migration. Safe
+ * to defer: the map is main-write-only, nothing reads it for reconciliation
+ * yet, and the baseline is re-derivable from local_playlists at any time.
+ *
+ * @param {object} playlist - a local_playlists entry
+ * @param {number} now - epoch ms (caller-supplied for determinism)
+ * @returns {object|null} a makePlaylistSyncState shape, or null
+ */
+function bootstrapPlaylistState(playlist, now) {
+  if (!playlist || typeof playlist !== 'object') return null;
+  const syncedTo = playlist.syncedTo && typeof playlist.syncedTo === 'object' ? playlist.syncedTo : {};
+  const hasSyncIntent = !!(playlist.syncedFrom || Object.keys(syncedTo).length);
+  if (!hasSyncIntent) return null;
+
+  const ts = typeof now === 'number' ? now : 0;
+  const baseline = buildBaseline(playlist.tracks || []);
+  const providers = {};
+
+  const sf = playlist.syncedFrom;
+  if (sf && sf.resolver) {
+    providers[sf.resolver] = makeProviderSyncState({
+      changeToken: sf.snapshotId || null,
+      editedAt: 0,
+      lastSyncedAt: ts,
+    });
+  }
+  for (const pid of Object.keys(syncedTo)) {
+    const st = syncedTo[pid];
+    if (!st || !st.externalId) continue;
+    const prev = providers[pid] || {};
+    providers[pid] = makeProviderSyncState({
+      // Preserve the syncedFrom token if this provider is also the source.
+      changeToken: prev.changeToken || st.snapshotId || null,
+      editedAt: 0,
+      lastSyncedAt: st.syncedAt || ts,
+    });
+  }
+
+  return makePlaylistSyncState({ baseline, baselineSyncedAt: ts, providers });
+}
+
 module.exports = {
   buildBaseline,
   toEpochMs,
@@ -151,4 +215,5 @@ module.exports = {
   deriveEditedAt,
   makeProviderSyncState,
   makePlaylistSyncState,
+  bootstrapPlaylistState,
 };

--- a/tests/sync/playlist-sync-state.test.js
+++ b/tests/sync/playlist-sync-state.test.js
@@ -15,6 +15,7 @@ const {
   deriveEditedAt,
   makeProviderSyncState,
   makePlaylistSyncState,
+  bootstrapPlaylistState,
 } = require('../../sync-engine/playlist-sync-state');
 
 describe('buildBaseline', () => {
@@ -124,5 +125,68 @@ describe('record factories', () => {
     expect(s.baseline).not.toBe(base); // copied, not aliased
     expect(s.baselineSyncedAt).toBe(1);
     expect(s.providers).toEqual({ spotify: {} });
+  });
+});
+
+describe('bootstrapPlaylistState — Phase 2 one-time migration (pure)', () => {
+  const NOW = 1_700_000_000_000;
+
+  test('returns null for a local-only playlist (no sync intent)', () => {
+    expect(bootstrapPlaylistState({ id: 'p1', tracks: [{ isrc: 'GBAYE0601498' }] }, NOW)).toBeNull();
+    expect(bootstrapPlaylistState({ id: 'p1', syncedTo: {} }, NOW)).toBeNull();
+    expect(bootstrapPlaylistState(null, NOW)).toBeNull();
+  });
+
+  test('seeds baseline (canonical keys) for a synced playlist', () => {
+    const pl = {
+      id: 'spotify-abc',
+      tracks: [{ isrc: 'GBAYE0601498' }, { artist: 'Radiohead', title: 'Creep' }],
+      syncedFrom: { resolver: 'spotify', externalId: 'abc', snapshotId: 'snap1' },
+    };
+    const s = bootstrapPlaylistState(pl, NOW);
+    expect(s.baseline).toEqual(['isrc-GBAYE0601498', 'norm-radiohead|creep']);
+    expect(s.baselineSyncedAt).toBe(NOW);
+  });
+
+  test('creates a provider record for syncedFrom carrying its snapshot token', () => {
+    const s = bootstrapPlaylistState(
+      { id: 'spotify-abc', tracks: [], syncedFrom: { resolver: 'spotify', externalId: 'abc', snapshotId: 'snap1' } },
+      NOW
+    );
+    expect(s.providers.spotify).toEqual({ changeToken: 'snap1', editedAt: 0, lastSyncedAt: NOW });
+  });
+
+  test('creates a provider record per syncedTo mirror with externalId', () => {
+    const s = bootstrapPlaylistState(
+      {
+        id: 'p1',
+        tracks: [],
+        syncedTo: {
+          applemusic: { externalId: 'am1', snapshotId: 'amSnap', syncedAt: 123 },
+          listenbrainz: { externalId: 'lb1' },
+          spotify: {}, // no externalId -> skipped
+        },
+      },
+      NOW
+    );
+    expect(s.providers.applemusic).toEqual({ changeToken: 'amSnap', editedAt: 0, lastSyncedAt: 123 });
+    expect(s.providers.listenbrainz).toEqual({ changeToken: null, editedAt: 0, lastSyncedAt: NOW });
+    expect(s.providers.spotify).toBeUndefined();
+  });
+
+  test('a round-trip mirror (syncedFrom AND syncedTo same provider) keeps the source token', () => {
+    const s = bootstrapPlaylistState(
+      {
+        id: 'spotify-abc',
+        tracks: [],
+        syncedFrom: { resolver: 'spotify', externalId: 'abc', snapshotId: 'fromSnap' },
+        syncedTo: { spotify: { externalId: 'abc', snapshotId: 'toSnap', syncedAt: 99 }, applemusic: { externalId: 'am1' } },
+      },
+      NOW
+    );
+    // syncedFrom token preserved over the syncedTo token for the source provider.
+    expect(s.providers.spotify.changeToken).toBe('fromSnap');
+    expect(s.providers.spotify.lastSyncedAt).toBe(99); // syncedAt still adopted
+    expect(s.providers.applemusic.changeToken).toBeNull();
   });
 });


### PR DESCRIPTION
Step 0 of the desktop N-way port ([plan doc](https://github.com/Parachord/parachord/blob/main/docs/plans/2026-06-25-nway-desktop-port-plan.md), [#911](https://github.com/Parachord/parachord/issues/911)). Populates the dormant `sync_playlist_state` map from existing `local_playlists` so the N-way engine has a baseline + per-provider record to work from once reconciliation is wired (shadow mode first).

**One-time, idempotent, no network. Behavior-neutral — nothing READS the map for reconciliation yet.** This deliberately decouples storage-population risk from reconcile-logic risk.

## What

- **`sync-engine/playlist-sync-state.js`** — new pure `bootstrapPlaylistState(playlist, now)`. The local tracklist is the trustworthy ancestor today (it's the canonical source), so `baseline = buildBaseline(tracks)`. One `providers` record per linked mirror (the `syncedFrom` source + every `syncedTo` target with an `externalId`), carrying that provider's existing `snapshotId` so the first reconcile cycle can detect later edits. `editedAt` seeds 0 (order-only; captured for real on first push). Returns `null` for a local-only playlist (no sync intent). A round-trip mirror keeps the `syncedFrom` token.
- **`main.js`** — `bootstrapNwayPlaylistState()`, thin iterate-and-persist glue run at startup alongside the existing `migrateSyncLinksFromPlaylists` / `healImportedSyncedFromMismatch`. Skips playlists that already have an entry (idempotent — a re-run never clobbers state a future reconcile advanced) and ones with no sync intent; single `store.set`.
- **tests** — `bootstrapPlaylistState` pure coverage (no-intent null, baseline derivation, syncedFrom/syncedTo provider records, round-trip token preservation).

## Schema note (design open question #4)

`baseline` stores the **collapsed** canonical key per track (`string[]`, the Phase-1 schema). If cross-copy re-unification later needs the ancestor's full `{isrc,mbid,norm}` tiers, that becomes an additive schema change + re-migration — safe to defer (the map is main-write-only, unread by reconciliation, and the baseline is re-derivable from `local_playlists` at any time). Flagged for resolution before the materialize step that consumes it.

## Test plan

- [x] `npx jest tests/sync/` → 6 suites, 281 tests green.
- [ ] Manual: launch on a real library; confirm `sync_playlist_state` populates for synced playlists, log line reports the count, second launch is a no-op (idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)