### PR TITLE
feat(sync): N-way provider capability surface — trackRemoveMode dispatch (#911)

### DIFF
--- a/sync-providers/applemusic.js
+++ b/sync-providers/applemusic.js
@@ -200,7 +200,19 @@ const AppleMusicSyncProvider = {
     albums: true,
     artists: false,
     playlists: true,
-    playlistFolders: false
+    playlistFolders: false,
+    // N-way materialize dispatch (parachord#911). The HONEST WORST CASE:
+    // Apple Music's public API rejects PUT/PATCH/DELETE on library playlist
+    // resources (documented policy — Apple Developer Forum 107807), so there
+    // is NO track-removal path: removals are surfaced to the user, never
+    // forced. PUT degrades to POST-append (`amPutUnsupportedRef`), PATCH
+    // (rename) is a silent no-op (`amPatchUnsupportedRef`), playlist DELETE
+    // is unsupported. Declared statically; the runtime kill-switches stay as
+    // defensive downgrade if Apple's behavior shifts mid-session.
+    trackRemoveMode: 'Unsupported',
+    canReorder: false,
+    supportsPlaylistDelete: false,
+    supportsPlaylistRename: false
   },
 
   /**

--- a/sync-providers/listenbrainz.js
+++ b/sync-providers/listenbrainz.js
@@ -18,6 +18,16 @@ const capabilities = {
   tracks: false,
   albums: false,
   artists: false,
+  // Was missing the playlistFolders key the other providers declare; LB has
+  // no folder concept.
+  playlistFolders: false,
+  // N-way materialize dispatch (parachord#911). LB's playlist update is
+  // clear-then-add (no full-replace PUT), which maps to positional removal.
+  // Playlist delete + rename (title/description) are supported.
+  trackRemoveMode: 'ByPosition',
+  canReorder: false,
+  supportsPlaylistDelete: true,
+  supportsPlaylistRename: true,
 };
 
 function authHeaders(token) {

--- a/sync-providers/spotify.js
+++ b/sync-providers/spotify.js
@@ -266,7 +266,14 @@ const SpotifySyncProvider = {
     albums: true,
     artists: true,
     playlists: true,
-    playlistFolders: true
+    playlistFolders: true,
+    // N-way materialize dispatch (parachord#911). Spotify has a full
+    // track-level API: DELETE /playlists/{id}/tracks by URI, PUT for order,
+    // and playlist delete (unfollow) + rename.
+    trackRemoveMode: 'ByNativeId',
+    canReorder: true,
+    supportsPlaylistDelete: true,
+    supportsPlaylistRename: true
   },
 
   /**

--- a/sync-providers/types.js
+++ b/sync-providers/types.js
@@ -1,10 +1,35 @@
 /**
+ * How a provider supports REMOVING a track from a playlist — the dispatch key
+ * for N-way incremental materialization (parachord#911). The engine asks the
+ * provider "can you remove a track, and how" and NEVER branches on provider id,
+ * so a new service (Tidal/Qobuz/…) is a future adapter, not an engine edit.
+ *
+ *   'ByNativeId'   — remove specific tracks by their native id/URI (Spotify
+ *                    DELETE /playlists/{id}/tracks by URI).
+ *   'ByPosition'   — remove by index (ListenBrainz delete-by-position; its
+ *                    clear-then-add update maps to positional removal).
+ *   'Unsupported'  — no track-removal API at all (Apple Music public library
+ *                    playlists). Materialize is add-only; removals are surfaced
+ *                    to the user, never forced, never abort the push.
+ *   'ReplaceOnly'  — only a full wipe + re-add exists; a partial replace is
+ *                    destructive, so replace-all is gated on full add-coverage,
+ *                    else it degrades to add-only. (Reserved; no provider uses
+ *                    it today.)
+ *
+ * @typedef {'ByNativeId'|'ByPosition'|'Unsupported'|'ReplaceOnly'} TrackRemoveMode
+ */
+
+/**
  * @typedef {Object} SyncProviderCapabilities
  * @property {boolean} tracks - Can sync liked/saved songs
  * @property {boolean} albums - Can sync saved albums
  * @property {boolean} artists - Can sync followed artists
  * @property {boolean} playlists - Can sync user playlists
  * @property {boolean} playlistFolders - Supports hierarchical playlist organization
+ * @property {TrackRemoveMode} trackRemoveMode - How playlist track removal works (N-way materialize dispatch)
+ * @property {boolean} canReorder - Whether playlist track order can be set on the remote
+ * @property {boolean} supportsPlaylistDelete - Whether a whole playlist can be deleted via the API
+ * @property {boolean} supportsPlaylistRename - Whether a playlist's name/description can be edited via the API
  */
 
 /**

--- a/tests/sync/provider-capabilities.test.js
+++ b/tests/sync/provider-capabilities.test.js
@@ -1,0 +1,93 @@
+/**
+ * Provider capability surface for N-way materialize dispatch
+ * (Parachord/parachord#911, Step 1).
+ *
+ * The N-way materialize executor dispatches removals purely on
+ * `capabilities.trackRemoveMode` (+ canReorder / supportsPlaylistDelete /
+ * supportsPlaylistRename) and NEVER branches on provider id. These tests pin
+ * each provider's declared HONEST WORST CASE so a drift (e.g. someone marking
+ * Apple Music removable) is caught — that would let the engine attempt a
+ * remove AM can't honor, which the design forbids.
+ *
+ * Pure metadata assertions — the providers require cleanly (no electron /
+ * network at module load).
+ */
+
+const spotify = require('../../sync-providers/spotify.js');
+const applemusic = require('../../sync-providers/applemusic.js');
+const listenbrainz = require('../../sync-providers/listenbrainz.js');
+
+const VALID_REMOVE_MODES = ['ByNativeId', 'ByPosition', 'Unsupported', 'ReplaceOnly'];
+
+describe('provider capabilities — N-way fields present + typed', () => {
+  const providers = [
+    ['spotify', spotify],
+    ['applemusic', applemusic],
+    ['listenbrainz', listenbrainz],
+  ];
+
+  for (const [name, p] of providers) {
+    describe(name, () => {
+      const caps = p.capabilities;
+
+      test('declares the full base capability surface', () => {
+        for (const key of ['tracks', 'albums', 'artists', 'playlists', 'playlistFolders']) {
+          expect(typeof caps[key]).toBe('boolean');
+        }
+      });
+
+      test('trackRemoveMode is one of the valid modes', () => {
+        expect(VALID_REMOVE_MODES).toContain(caps.trackRemoveMode);
+      });
+
+      test('canReorder / supportsPlaylistDelete / supportsPlaylistRename are booleans', () => {
+        expect(typeof caps.canReorder).toBe('boolean');
+        expect(typeof caps.supportsPlaylistDelete).toBe('boolean');
+        expect(typeof caps.supportsPlaylistRename).toBe('boolean');
+      });
+    });
+  }
+});
+
+describe('provider capabilities — the honest worst case per provider', () => {
+  test('Spotify: full track-level control', () => {
+    expect(spotify.capabilities).toMatchObject({
+      trackRemoveMode: 'ByNativeId',
+      canReorder: true,
+      supportsPlaylistDelete: true,
+      supportsPlaylistRename: true,
+    });
+  });
+
+  test('Apple Music: add-only, nothing else (the load-bearing worst case)', () => {
+    expect(applemusic.capabilities).toMatchObject({
+      trackRemoveMode: 'Unsupported',
+      canReorder: false,
+      supportsPlaylistDelete: false,
+      supportsPlaylistRename: false,
+    });
+  });
+
+  test('ListenBrainz: positional removal, no reorder, delete+rename ok', () => {
+    expect(listenbrainz.capabilities).toMatchObject({
+      trackRemoveMode: 'ByPosition',
+      canReorder: false,
+      supportsPlaylistDelete: true,
+      supportsPlaylistRename: true,
+      playlistFolders: false, // was previously missing
+    });
+  });
+});
+
+describe('source-authority gate property (the reason these fields exist)', () => {
+  // An add-only source must never be granted drop-authority — its un-
+  // materialized adds + transient partial fetches would read as deletions.
+  // The gate is `trackRemoveMode !== 'Unsupported'`; assert AM is the one
+  // that declines and the others qualify.
+  const removalCapable = (p) => p.capabilities.trackRemoveMode !== 'Unsupported';
+  test('Apple Music is NOT removal-capable; Spotify + LB are', () => {
+    expect(removalCapable(applemusic)).toBe(false);
+    expect(removalCapable(spotify)).toBe(true);
+    expect(removalCapable(listenbrainz)).toBe(true);
+  });
+});


### PR DESCRIPTION
Step 1 of the desktop N-way port ([plan](https://github.com/Parachord/parachord/blob/main/docs/plans/2026-06-25-nway-desktop-port-plan.md), [#911](https://github.com/Parachord/parachord/issues/911)). Adds the capability fields the N-way materialize executor dispatches on, so it decides **how** to remove a track per provider **without ever branching on provider id** — the rule that makes a future service (Tidal/Qobuz/…) an adapter, not an engine edit.

**Purely additive metadata. Zero behavior change.**

## What

- **`sync-providers/types.js`** — new `TrackRemoveMode` typedef (`ByNativeId | ByPosition | Unsupported | ReplaceOnly`) + four new `SyncProviderCapabilities` fields (`trackRemoveMode`, `canReorder`, `supportsPlaylistDelete`, `supportsPlaylistRename`).
- **Per-provider declared HONEST WORST CASE:**
  | | trackRemoveMode | canReorder | delete | rename |
  |---|---|---|---|---|
  | Spotify | `ByNativeId` | ✅ | ✅ | ✅ |
  | Apple Music | `Unsupported` (add-only) | ❌ | ❌ | ❌ |
  | ListenBrainz | `ByPosition` | ❌ | ✅ | ✅ |

  Apple Music is the load-bearing case — the public API rejects PUT/PATCH/DELETE on library playlists, so there's no removal path; the runtime `amPut`/`amPatch` kill-switches stay as defensive downgrade. LB also gains the previously-missing `playlistFolders: false` key.
- **`tests/sync/provider-capabilities.test.js`** — field presence + per-provider worst-case + the source-authority gate property (AM is **not** removal-capable; Spotify+LB are).

The fields flow to the renderer verbatim (`sync:get-providers` spreads the capabilities object), so no IPC change.

## Scope note

The **incremental write primitives** from the plan's Step 1 (`removePlaylistTracksByNativeId`, `removePlaylistTracksByPosition`, `remotePlaylistExists`, `addPlaylistTracks`, `nativeIdOf`, `searchForTrackId`) are deferred to land **with Step 2** (the materialize executor). They're network-correctness-sensitive and have no caller until the executor exists, so they're co-developed + tested against the executor's `FakeProvider` rather than shipped now as untested dead code. The capability surface here is the true prerequisite the executor dispatches on.

## Test plan

- [x] `npx jest tests/sync/` → 7 suites, 294 tests green.
- [x] Providers require cleanly (no electron/network at module load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)