### PR TITLE
feat(sync): N-way materialize executor + identity-diff (Step 2 / PR-2) (#911)

### DIFF
--- a/sync-engine/playlist-materialize.js
+++ b/sync-engine/playlist-materialize.js
@@ -1,0 +1,202 @@
+// N-way incremental playlist MATERIALIZE — Layer B (the executor).
+//
+// Design: docs/plans/2026-06-23-incremental-materialization-design.md
+// (parachord-mobile) + docs/plans/2026-06-25-nway-desktop-port-plan.md (Step
+// 2). Tracker: Parachord/parachord#911. Kotlin reference:
+// shared/.../sync/PlaylistMaterializeExecutor.kt — port the test vectors 1:1.
+//
+// Reconcile (identity, Layer A) is decoupled from materialize (writing, this
+// module). The executor takes the desired `canonical` tracklist + the live
+// `remote` tracklist for ONE provider mirror and brings the remote to the
+// canonical state with a NON-DESTRUCTIVE incremental identity-diff —
+// capability-dispatched on `provider.capabilities.trackRemoveMode`, NEVER on
+// provider id (so a future service is an adapter, not an engine edit).
+//
+// Pure + injected-provider: tests pass a FakeProvider, prod passes a real
+// provider (token-bound by a per-cycle adapter). It NEVER calls a destructive
+// replace-all for the add/remove providers — every removal is a targeted
+// delete-by-native-id or delete-by-position. The Layer-A reconcile driver,
+// the hydration coordinator, the shadow flags, and the real-provider write
+// primitives land in later PRs (#911 Steps 2.3/2.4).
+
+const { trackTiers, unifyTrackKeys } = require('./playlist-key-unify');
+
+function arraysEqual(a, b) {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+function distinct(arr) {
+  const seen = new Set();
+  const out = [];
+  for (const x of arr) {
+    if (!seen.has(x)) {
+      seen.add(x);
+      out.push(x);
+    }
+  }
+  return out;
+}
+
+/**
+ * Identity-diff the desired `canonical` tracklist against the live `remote`
+ * one. Both lists are unified TOGETHER (so the same song across the two gets
+ * the same representative key — the remaster-drift / cross-service guard), then
+ * compared by representative key. NOT a native-id diff.
+ *
+ * @param {object[]} canonical - desired tracks (Layer-A merge output)
+ * @param {object[]} remote    - the provider's current tracks
+ * @returns {{addKeys:string[], removeKeys:string[], reorderNeeded:boolean, canonicalKeys:string[], remoteKeys:string[]}}
+ *   `canonicalKeys`/`remoteKeys` are 1:1 (order + length) with their inputs,
+ *   NOT deduped, so the caller can map a key back to its track/position.
+ */
+function computeMaterializeDiff(canonical, remote) {
+  const can = Array.isArray(canonical) ? canonical : [];
+  const rem = Array.isArray(remote) ? remote : [];
+  const keysOf = (ts) => ts.map((t) => trackTiers(t));
+  const [canonicalKeys, remoteKeys] = unifyTrackKeys([keysOf(can), keysOf(rem)]);
+  const canSet = new Set(canonicalKeys);
+  const remSet = new Set(remoteKeys);
+  const addKeys = distinct(canonicalKeys.filter((k) => !remSet.has(k)));
+  const removeKeys = distinct(remoteKeys.filter((k) => !canSet.has(k)));
+  const reorderNeeded =
+    addKeys.length === 0 && removeKeys.length === 0 && !arraysEqual(canonicalKeys, remoteKeys);
+  return { addKeys, removeKeys, reorderNeeded, canonicalKeys, remoteKeys };
+}
+
+// ── add/remove helpers ──────────────────────────────────────────────
+
+// Hydrate add keys to native ids via the injected resolver (search/cache).
+// An unresolvable add this cycle is PENDING (a fill target), never a drop.
+async function resolveAdds(addKeys, keyToCanonical, resolveNativeId) {
+  const ids = [];
+  let pending = 0;
+  for (const key of addKeys) {
+    const track = keyToCanonical[key];
+    if (!track) continue;
+    const nid = await resolveNativeId(track);
+    if (!nid) pending++;
+    else ids.push(nid);
+  }
+  return { ids, pending };
+}
+
+// Empty-add guard: never call addPlaylistTracks([]).
+async function appendAdds(provider, externalId, ids) {
+  if (!ids.length) return 0;
+  await provider.addPlaylistTracks(externalId, ids);
+  return ids.length;
+}
+
+async function removeByNativeId(provider, externalId, removeKeys, keyToRemote) {
+  const ids = removeKeys
+    .map((k) => keyToRemote[k])
+    .filter(Boolean)
+    .map((t) => provider.nativeIdOf(t))
+    .filter(Boolean);
+  if (!ids.length) return 0;
+  await provider.removePlaylistTracksByNativeId(externalId, ids);
+  return ids.length;
+}
+
+/**
+ * Bring ONE provider mirror to the canonical tracklist via a non-destructive
+ * incremental diff, dispatched on `provider.capabilities.trackRemoveMode`.
+ *
+ * @param {object}   args
+ * @param {object}   args.provider        - SyncProvider (real adapter or Fake): `capabilities`, `nativeIdOf`, `addPlaylistTracks`, `removePlaylistTracksByNativeId`, `removePlaylistTracksByPosition`, `replacePlaylistTracks`
+ * @param {string}   args.externalId      - remote playlist id
+ * @param {object[]} args.canonical       - desired tracklist
+ * @param {object[]} args.remote          - the provider's current tracklist
+ * @param {(track:object)=>Promise<string|null>} args.resolveNativeId - hydration closure for ADDS
+ * @returns {Promise<{added:number, removed:number, pendingAdds:number, unsupportedRemoves:number}>}
+ *   counts what the executor ACTUALLY DID (not what the diff wanted).
+ */
+async function materializeToProvider({ provider, externalId, canonical, remote, resolveNativeId }) {
+  const diff = computeMaterializeDiff(canonical, remote);
+
+  // Key -> track maps over the diff's OWN keyspace (never re-unify). First
+  // occurrence wins (matches the dedupe the diff already applied to add/remove).
+  const keyToCanonical = {};
+  diff.canonicalKeys.forEach((k, i) => {
+    if (!(k in keyToCanonical)) keyToCanonical[k] = canonical[i];
+  });
+  const keyToRemote = {};
+  const remKeyToPosition = {};
+  diff.remoteKeys.forEach((k, i) => {
+    if (!(k in keyToRemote)) keyToRemote[k] = remote[i];
+    if (!(k in remKeyToPosition)) remKeyToPosition[k] = i;
+  });
+
+  let added = 0;
+  let removed = 0;
+  let pendingAdds = 0;
+  let unsupportedRemoves = 0;
+
+  const mode = provider.capabilities && provider.capabilities.trackRemoveMode;
+
+  if (mode === 'ByNativeId') {
+    removed = await removeByNativeId(provider, externalId, diff.removeKeys, keyToRemote);
+    const resolved = await resolveAdds(diff.addKeys, keyToCanonical, resolveNativeId);
+    pendingAdds = resolved.pending;
+    added = await appendAdds(provider, externalId, resolved.ids);
+  } else if (mode === 'ByPosition') {
+    const positions = distinct(
+      diff.removeKeys.map((k) => remKeyToPosition[k]).filter((p) => p != null)
+    );
+    if (positions.length) {
+      await provider.removePlaylistTracksByPosition(externalId, positions);
+      removed = positions.length;
+    }
+    const resolved = await resolveAdds(diff.addKeys, keyToCanonical, resolveNativeId);
+    pendingAdds = resolved.pending;
+    added = await appendAdds(provider, externalId, resolved.ids);
+  } else if (mode === 'Unsupported') {
+    unsupportedRemoves = diff.removeKeys.length; // surfaced, never forced
+    const resolved = await resolveAdds(diff.addKeys, keyToCanonical, resolveNativeId);
+    pendingAdds = resolved.pending;
+    added = await appendAdds(provider, externalId, resolved.ids);
+  } else if (mode === 'ReplaceOnly') {
+    // Full wipe + re-add ONLY when every canonical track contributes a native
+    // id; otherwise a partial replace would SHRINK the list (destructive), so
+    // degrade to add-only and leave removals unapplied.
+    const addKeySet = new Set(diff.addKeys);
+    const resolvedAdds = {};
+    let addCoverageGap = 0;
+    for (const key of diff.addKeys) {
+      const track = keyToCanonical[key];
+      if (!track) continue;
+      const nid = await resolveNativeId(track);
+      if (!nid) addCoverageGap++;
+      else resolvedAdds[key] = nid;
+    }
+    const allNativeIds = [];
+    diff.canonicalKeys.forEach((key, i) => {
+      const nid = addKeySet.has(key) ? resolvedAdds[key] : provider.nativeIdOf(canonical[i]);
+      if (nid) allNativeIds.push(nid); // a blank SHRINKS the list -> blocks replace
+    });
+    const fullCoverage = allNativeIds.length === canonical.length;
+    if (fullCoverage && diff.removeKeys.length) {
+      await provider.replacePlaylistTracks(externalId, allNativeIds);
+      removed = diff.removeKeys.length;
+      added = diff.addKeys.length;
+    } else {
+      if (diff.removeKeys.length) unsupportedRemoves = diff.removeKeys.length;
+      pendingAdds = addCoverageGap;
+      const orderedAddIds = diff.addKeys.map((k) => resolvedAdds[k]).filter(Boolean);
+      added = await appendAdds(provider, externalId, orderedAddIds);
+    }
+  }
+  // Unknown / undeclared mode: no-op (no writes) — defensive.
+
+  // Reorder is v1-deferred: log only, no API call (matches mobile YAGNI).
+  if (diff.reorderNeeded && provider.capabilities && provider.capabilities.canReorder) {
+    // eslint-disable-next-line no-console
+    console.log('[nway-materialize] reorder needed but deferred (v1):', externalId);
+  }
+
+  return { added, removed, pendingAdds, unsupportedRemoves };
+}
+
+module.exports = { materializeToProvider, computeMaterializeDiff };

--- a/sync-engine/playlist-merge.js
+++ b/sync-engine/playlist-merge.js
@@ -38,7 +38,6 @@
 //            tracks == baseline contributes no delta and is ignored.
 
 const ISRC_RE = /^[A-Z]{2}[A-Z0-9]{3}[0-9]{7}$/;
-const MBID_RE = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
 
 function validIsrc(value) {
   if (typeof value !== 'string') return null;
@@ -46,10 +45,18 @@ function validIsrc(value) {
   return ISRC_RE.test(norm) ? norm : null;
 }
 
+// Normalize a recording MBID to its tier value. Per the cross-engine
+// key-derivation contract (the merge/key-unify fixtures' `_semantics`), the
+// MBID tier is `trim + lowercase`, NON-EMPTY — and is NOT regex-validated
+// (only ISRC is). A 36-char UUID regex here was over-strict and DIVERGED from
+// the Kotlin engine (which accepts any non-blank recordingMbid), so a track
+// whose mbid field carried a non-UUID id keyed differently across the two
+// engines. Real recording MBIDs are UUIDs, so this only changes behavior for
+// non-standard ids — but matching the contract byte-for-byte is the point.
 function validMbid(value) {
   if (typeof value !== 'string') return null;
   const norm = value.trim().toLowerCase();
-  return MBID_RE.test(norm) ? norm : null;
+  return norm.length > 0 ? norm : null;
 }
 
 // Fallback-key normalization: lower + trim ONLY (NOT the strip-non-

--- a/tests/sync/playlist-materialize.test.js
+++ b/tests/sync/playlist-materialize.test.js
@@ -1,0 +1,215 @@
+/**
+ * N-way incremental materialize executor — Layer B (Parachord/parachord#911,
+ * Step 2). Ports the Kotlin PlaylistMaterializeExecutorTest +
+ * PlaylistMaterializeDiffTest vectors 1:1 against a desktop FakeProvider.
+ *
+ * The pure executor + diff are testable in complete isolation — no real
+ * provider, no baseline, no driver. The full Layer-A reconcile harness
+ * (NwayMaterializeTest) lands with the driver PR.
+ */
+
+const { materializeToProvider, computeMaterializeDiff } = require('../../sync-engine/playlist-materialize');
+
+// Track factory: distinct title+artist so `norm` never unions; mbid strongest
+// so the representative is `mbid-<id>`. Matches the Kotlin Fake's `t(id)`.
+const t = (id) => ({ playlistId: 'p', position: 0, title: `title-${id}`, artist: `artist-${id}`, recordingMbid: id });
+
+function features(mode, canReorder = false) {
+  return { trackRemoveMode: mode, canReorder, supportsPlaylistDelete: true, supportsPlaylistRename: true };
+}
+
+// FakeProvider records every write call; the two remove variants THROW when
+// invoked outside their declared mode so a mis-dispatch is loud.
+class FakeProvider {
+  constructor(capabilities, nullNativeIdFor = new Set()) {
+    this.capabilities = capabilities;
+    this.nullNativeIdFor = nullNativeIdFor;
+    this.addCalls = [];
+    this.removeByNativeIdCalls = [];
+    this.removeByPositionCalls = [];
+    this.replaceCalls = [];
+  }
+  nativeIdOf(track) {
+    return this.nullNativeIdFor.has(track.recordingMbid) ? null : track.recordingMbid;
+  }
+  async addPlaylistTracks(_externalId, ids) {
+    this.addCalls.push(ids);
+  }
+  async removePlaylistTracksByNativeId(_externalId, ids) {
+    if (this.capabilities.trackRemoveMode !== 'ByNativeId') throw new Error('wrong removeMode: ByNativeId');
+    this.removeByNativeIdCalls.push(ids);
+  }
+  async removePlaylistTracksByPosition(_externalId, positions) {
+    if (this.capabilities.trackRemoveMode !== 'ByPosition') throw new Error('wrong removeMode: ByPosition');
+    this.removeByPositionCalls.push(positions);
+  }
+  async replacePlaylistTracks(_externalId, ids) {
+    this.replaceCalls.push(ids);
+  }
+}
+
+// Hydration resolver closures (for ADDS).
+const resolverFor = (idSet) => async (track) => (idSet.has(track.recordingMbid) ? track.recordingMbid : null);
+const resolveAll = async (track) => track.recordingMbid;
+
+const run = (provider, canonical, remote, resolveNativeId) =>
+  materializeToProvider({ provider, externalId: 'ext', canonical, remote, resolveNativeId });
+
+describe('materializeToProvider — capability-dispatched executor (Group 1)', () => {
+  test('1. ByNativeId — adds appended, removes target remote native ids', async () => {
+    const p = new FakeProvider(features('ByNativeId'));
+    const r = await run(p, [t('a'), t('b'), t('c')], [t('a'), t('x')], resolveAll);
+    expect(p.addCalls.length).toBe(1);
+    expect(new Set(p.addCalls[0])).toEqual(new Set(['b', 'c']));
+    expect(p.removeByNativeIdCalls).toEqual([['x']]);
+    expect(r).toEqual({ added: 2, removed: 1, pendingAdds: 0, unsupportedRemoves: 0 });
+  });
+
+  test('2. ByPosition — removes dispatch as DISTINCT positions', async () => {
+    const p = new FakeProvider(features('ByPosition'));
+    const r = await run(p, [t('a'), t('c')], [t('a'), t('b'), t('c'), t('d')], resolveAll);
+    expect(p.removeByPositionCalls.length).toBe(1);
+    const positions = p.removeByPositionCalls[0];
+    expect(new Set(positions)).toEqual(new Set([1, 3]));
+    expect(positions.length).toBe(new Set(positions).size); // distinct
+    expect(p.addCalls).toEqual([]);
+    expect(p.removeByNativeIdCalls).toEqual([]);
+    expect(r).toMatchObject({ removed: 2, added: 0 });
+  });
+
+  test('3. Unsupported — removes skipped+counted, adds still applied', async () => {
+    const p = new FakeProvider(features('Unsupported'));
+    const r = await run(p, [t('a'), t('b')], [t('a'), t('x')], resolveAll);
+    expect(r.unsupportedRemoves).toBe(1);
+    expect(p.removeByNativeIdCalls).toEqual([]);
+    expect(p.removeByPositionCalls).toEqual([]);
+    expect(p.addCalls).toEqual([['b']]);
+    expect(r).toMatchObject({ added: 1, removed: 0 });
+  });
+
+  test('4. ReplaceOnly — full coverage replaces (SUB1); partial degrades additive (SUB2)', async () => {
+    // SUB1: full coverage -> replace in canonical order.
+    const p1 = new FakeProvider(features('ReplaceOnly'));
+    const r1 = await run(p1, [t('a'), t('b')], [t('a'), t('x')], resolverFor(new Set(['a', 'b'])));
+    expect(p1.replaceCalls).toEqual([['a', 'b']]);
+    expect(p1.addCalls).toEqual([]);
+    expect(r1).toEqual({ removed: 1, added: 1, pendingAdds: 0, unsupportedRemoves: 0 });
+
+    // SUB2: c unresolvable -> no replace, degrade to add-only.
+    const p2 = new FakeProvider(features('ReplaceOnly'));
+    const r2 = await run(p2, [t('a'), t('b'), t('c')], [t('a'), t('x')], resolverFor(new Set(['a', 'b'])));
+    expect(p2.replaceCalls).toEqual([]);
+    expect(p2.addCalls).toEqual([['b']]);
+    expect(r2).toEqual({ added: 1, pendingAdds: 1, unsupportedRemoves: 1, removed: 0 });
+  });
+
+  test('5. ReplaceOnly — existing canonical track w/ null native id degrades additive (I1 regression)', async () => {
+    const p = new FakeProvider(features('ReplaceOnly'), new Set(['a']));
+    const r = await run(p, [t('a'), t('b')], [t('a'), t('x')], resolverFor(new Set(['a', 'b'])));
+    expect(p.replaceCalls).toEqual([]); // no shrinking replace
+    expect(p.addCalls).toEqual([['b']]);
+    expect(r).toEqual({ added: 1, removed: 0, unsupportedRemoves: 1, pendingAdds: 0 });
+  });
+
+  test('6. Unresolvable add left pending, never drops existing remote', async () => {
+    const p = new FakeProvider(features('ByNativeId'));
+    const r = await run(p, [t('a'), t('b')], [t('a')], resolverFor(new Set()));
+    expect(r).toMatchObject({ pendingAdds: 1, added: 0, removed: 0 });
+    expect(p.addCalls).toEqual([]);
+    expect(p.removeByNativeIdCalls).toEqual([]);
+  });
+
+  test('7. No resolved adds — addPlaylistTracks NOT called', async () => {
+    const p = new FakeProvider(features('ByNativeId'));
+    await run(p, [t('a'), t('b')], [t('a')], resolverFor(new Set()));
+    expect(p.addCalls).toEqual([]);
+  });
+
+  test('8. Idempotent — canonical equals remote -> zero ops', async () => {
+    const p = new FakeProvider(features('ByNativeId', true));
+    const same = [t('a'), t('b'), t('c')];
+    const r = await run(p, same, [t('a'), t('b'), t('c')], resolveAll);
+    expect(p.addCalls).toEqual([]);
+    expect(p.removeByNativeIdCalls).toEqual([]);
+    expect(p.removeByPositionCalls).toEqual([]);
+    expect(p.replaceCalls).toEqual([]);
+    expect(r).toEqual({ added: 0, removed: 0, pendingAdds: 0, unsupportedRemoves: 0 });
+  });
+});
+
+describe('computeMaterializeDiff — identity diff (Group 2)', () => {
+  test('9. add-only', () => {
+    const d = computeMaterializeDiff([t('a'), t('b')], [t('a')]);
+    expect(d.addKeys).toEqual(['mbid-b']);
+    expect(d.removeKeys).toEqual([]);
+    expect(d.canonicalKeys.length).toBe(2); // 1:1 length contract
+    expect(d.remoteKeys.length).toBe(1);
+  });
+
+  test('10. remove', () => {
+    const d = computeMaterializeDiff([t('a')], [t('a'), t('b')]);
+    expect(d.removeKeys.length).toBe(1);
+    expect(d.addKeys).toEqual([]);
+  });
+
+  test('11. norm-bridged remaster — neither add nor remove', () => {
+    const canonical = [{ title: 'Zombie', artist: 'X', recordingMbid: 'm1' }];
+    const remote = [{ title: 'Zombie - 2025 Remaster', artist: 'X', recordingMbid: 'm2' }];
+    const d = computeMaterializeDiff(canonical, remote);
+    expect(d.addKeys).toEqual([]);
+    expect(d.removeKeys).toEqual([]);
+  });
+
+  test('12. isrc-bridged (different mbid AND norm) + negative control', () => {
+    const canonical = [{ title: 'Zombie', artist: 'The Cranberries', recordingMbid: 'm1', isrc: 'USABC1234567' }];
+    const remote = [{ title: 'Zombie', artist: 'Cranberries', recordingMbid: 'm2', isrc: 'USABC1234567' }];
+    const d = computeMaterializeDiff(canonical, remote);
+    expect(d.addKeys).toEqual([]);
+    expect(d.removeKeys).toEqual([]);
+
+    // NEGATIVE CONTROL: different ISRCs (and different mbid + norm) -> no bridge.
+    const canonicalN = [{ title: 'Zombie', artist: 'The Cranberries', recordingMbid: 'm1', isrc: 'USXYZ9999999' }];
+    const remoteN = [{ title: 'Zombie', artist: 'Cranberries', recordingMbid: 'm2', isrc: 'GBABC0000001' }];
+    const dn = computeMaterializeDiff(canonicalN, remoteN);
+    expect(dn.addKeys.length).toBe(1);
+    expect(dn.removeKeys.length).toBe(1);
+  });
+
+  test('13. idempotent equal sets', () => {
+    const d = computeMaterializeDiff([t('a'), t('b')], [t('a'), t('b')]);
+    expect(d.addKeys).toEqual([]);
+    expect(d.removeKeys).toEqual([]);
+    expect(d.reorderNeeded).toBe(false);
+  });
+
+  test('14. reorder flagged', () => {
+    const d = computeMaterializeDiff([t('a'), t('b')], [t('b'), t('a')]);
+    expect(d.addKeys).toEqual([]);
+    expect(d.removeKeys).toEqual([]);
+    expect(d.reorderNeeded).toBe(true);
+  });
+
+  test('15. duplicate identity in canonical -> single add', () => {
+    const d = computeMaterializeDiff([t('a'), t('a')], []);
+    expect(d.addKeys).toEqual(['mbid-a']);
+  });
+
+  test('16. duplicate identity in remote -> single remove', () => {
+    const d = computeMaterializeDiff([], [t('a'), t('a')]);
+    expect(d.removeKeys).toEqual(['mbid-a']);
+    expect(d.addKeys).toEqual([]);
+  });
+
+  test('17. empty + empty', () => {
+    const d = computeMaterializeDiff([], []);
+    expect(d.addKeys).toEqual([]);
+    expect(d.removeKeys).toEqual([]);
+    expect(d.reorderNeeded).toBe(false);
+  });
+
+  test('18. empty remote — every canonical is an add', () => {
+    const d = computeMaterializeDiff([t('a'), t('b')], []);
+    expect(d.addKeys.length).toBe(2);
+    expect(d.removeKeys).toEqual([]);
+  });
+});


### PR DESCRIPTION
Step 2 of the desktop N-way port — the **pure Layer-B materialize executor**. Brings ONE provider mirror to the desired canonical tracklist via a **non-destructive incremental identity-diff**, capability-dispatched on `trackRemoveMode` and **never** on provider id.

**Fully isolated + unit-tested against a FakeProvider** — no real provider, no baseline change, no driver, no live writes. Ports the Kotlin `PlaylistMaterializeExecutorTest` + `PlaylistMaterializeDiffTest` vectors 1:1. This is the byte-parity heart of Step 2, landed as the smallest reviewable slice (per the [port spec](https://github.com/Parachord/parachord/blob/main/docs/plans/2026-06-25-nway-desktop-port-plan.md)'s PR-2).

## What

`sync-engine/playlist-materialize.js`:
- **`computeMaterializeDiff(canonical, remote)`** — unifies **both** lists together, then diffs by representative key (identity, **not** native-id — the remaster-drift / cross-service guard). Returns add/remove keys + `reorderNeeded` + the 1:1 canonical/remote key lists.
- **`materializeToProvider({provider, externalId, canonical, remote, resolveNativeId})`** dispatch:
  | mode | behavior |
  |---|---|
  | `ByNativeId` | remove-by-URI + hydrate-and-append adds |
  | `ByPosition` | remove-by-distinct-position + append |
  | `Unsupported` | add-only; removals surfaced (`unsupportedRemoves`), never forced |
  | `ReplaceOnly` | full replace **only** at full native-id coverage; else degrade to add-only (a blank id would shrink the list → blocks replace — the I1 regression) |

  Never calls replace for the add/remove providers. Empty-add guard. An unresolvable add is **pending** (a fill target), never a drop. Reorder is v1 log-only.

`tests/sync/playlist-materialize.test.js`: 8 executor cases + 10 diff cases incl. the isrc-bridge negative control proving ISRC is load-bearing.

## Also: `validMbid` contract fix

Relaxed `validMbid` in `playlist-merge.js` to the contract shape. The cross-engine key-derivation `_semantics` says the MBID tier is **`trim + lowercase, non-empty`** and is **not** regex-validated (only ISRC is). The prior 36-char-UUID regex was over-strict and **diverged from the Kotlin engine** (which accepts any non-blank `recordingMbid`) — a non-UUID mbid keyed differently across engines. The fixtures never caught it (they feed pre-normalized tiers); the materialize vectors (`recordingMbid` `'a'`/`'b'`/`'c'`) do. **Real MBIDs are UUIDs, so production behavior is unchanged.**

## Test plan

- [x] `npx jest tests/sync/` → 8 suites, 312 tests green (18 new materialize vectors; nothing regressed from the validMbid relax).

## What's next (this PR is one of four for Step 2)

- PR-3 — baseline schema migration to full `{isrc,mbid,norm}` tier records (resolves design Q4).
- PR-1 — real-provider write primitives (DELETE-by-URI, positional delete, `remotePlaylistExists`, `searchForTrackId`).
- PR-4 — Layer-A reconcile + shadow driver + the two flags (`nway_shadow_enabled` / `nway_propagate`, real writes OFF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)