### PR TITLE
feat(sync): N-way baseline → full tier records, idempotent upgrade (Step 2 / PR-3) (#911)

### DIFF
--- a/main.js
+++ b/main.js
@@ -5868,32 +5868,49 @@ function healImportedSyncedFromMismatch() {
 }
 healImportedSyncedFromMismatch();
 
-// Bootstrap the N-way sync state (Phase 2, parachord#911). One-time, idempotent,
-// no network: seed `sync_playlist_state` from existing local_playlists so the
-// N-way engine has a baseline + per-provider record to work from once it's
-// wired (shadow mode first). Skips playlists that already have an entry (so a
-// re-run never clobbers state a future reconcile cycle advanced) and playlists
-// with no sync intent. Behavior-neutral — nothing READS this map for
-// reconciliation yet. The pure per-playlist builder is unit-tested in
-// sync-engine/playlist-sync-state.js; this is the thin iterate-and-persist glue.
+// Bootstrap + upgrade the N-way sync state (Phase 2, parachord#911). One pass,
+// idempotent, no network. Two jobs, both seeded from existing local_playlists:
+//   1. SEED — a sync-intent playlist with no state entry gets a fresh
+//      baseline (tier records) + per-provider record.
+//   2. UPGRADE — an entry whose `baseline` is the LEGACY collapsed-string
+//      shape (from the first Phase-2 ship) is re-derived to `{isrc,mbid,norm}`
+//      tier records, losslessly, from the live tracklist (NOT by exploding the
+//      collapsed strings — a collapsed key has lost its sibling tiers). This
+//      resolves design #4: the Layer-A reconcile needs the ancestor's full
+//      tiers to re-unify it. Providers/baselineSyncedAt are preserved on
+//      upgrade.
+// Skips no-sync-intent playlists and already-tier-shaped entries, so a re-run
+// is a no-op. Behavior-neutral — nothing READS this map for reconciliation
+// yet. The pure builders are unit-tested in sync-engine/playlist-sync-state.js;
+// this is the thin iterate-and-persist glue.
 function bootstrapNwayPlaylistState() {
   try {
-    const { bootstrapPlaylistState } = require('./sync-engine/playlist-sync-state');
+    const { bootstrapPlaylistState, buildBaselineTiers, isLegacyStringBaseline } =
+      require('./sync-engine/playlist-sync-state');
     const playlists = store.get('local_playlists');
     if (!Array.isArray(playlists) || playlists.length === 0) return;
     const states = getSyncStates();
     const now = Date.now();
     let seeded = 0;
+    let upgraded = 0;
     for (const pl of playlists) {
-      if (!pl || !pl.id || states[pl.id]) continue; // idempotent: skip existing
-      const entry = bootstrapPlaylistState(pl, now);
-      if (!entry) continue; // no sync intent
-      states[pl.id] = entry;
-      seeded++;
+      if (!pl || !pl.id) continue;
+      const existing = states[pl.id];
+      if (!existing) {
+        const entry = bootstrapPlaylistState(pl, now);
+        if (!entry) continue; // no sync intent
+        states[pl.id] = entry;
+        seeded++;
+      } else if (isLegacyStringBaseline(existing.baseline)) {
+        // Re-derive tiers from source tracks; keep providers + baselineSyncedAt.
+        existing.baseline = buildBaselineTiers(pl.tracks || []);
+        upgraded++;
+      }
+      // else: already tier-shaped (or empty) — idempotent skip.
     }
-    if (seeded > 0) {
+    if (seeded > 0 || upgraded > 0) {
       store.set('sync_playlist_state', states); // single write
-      console.log(`[NwayState] Bootstrap-seeded baseline + provider state for ${seeded} playlist(s)`);
+      console.log(`[NwayState] Bootstrap seeded ${seeded}, upgraded ${upgraded} playlist baseline(s) to tier records`);
     }
   } catch (err) {
     console.warn('[NwayState] Bootstrap failed (non-fatal):', err && err.message);

--- a/sync-engine/playlist-sync-state.js
+++ b/sync-engine/playlist-sync-state.js
@@ -16,15 +16,52 @@
 // the merge has a cross-engine parity contract.
 
 const { canonicalTrackKey } = require('./playlist-merge');
+const { trackTiers } = require('./playlist-key-unify');
 
 // ─────────────────────────────────────────────────────────────────────
 // Baseline
 // ─────────────────────────────────────────────────────────────────────
 
 /**
- * Build a baseline (the 3-way merge ancestor) from a tracklist: the ordered
- * list of canonical keys, deduped first-occurrence (so it's directly
- * comparable to a merge result, which is also deduped).
+ * Build the PERSISTED baseline (the 3-way merge ancestor) from a tracklist:
+ * the ordered list of identity tier records `{isrc, mbid, norm}`, 1:1 with the
+ * tracklist (NOT deduped). Design decision #4 (parachord#911): the ancestor
+ * must keep its full tiers so the Layer-A reconcile can re-unify it against
+ * the current copies — a collapsed single key (e.g. `'mbid-x'`) has thrown
+ * away its sibling isrc/norm tiers and can't re-participate in union-find, so a
+ * drifted copy carrying the same song under a different tier would spuriously
+ * read as add+remove. Kept 1:1 (no dedup) to match mobile's
+ * `nwayBaselineTrackKeys` and keep the `trackCount`-based change-detection
+ * compare honest. The desktop tracklist array order IS the position order.
+ *
+ * The COLLAPSED merge-ancestor keys (deduped string[]) are derived on demand
+ * at reconcile time via `unifyTrackKeys`, not stored — see `buildBaseline`,
+ * which remains for that comparison shape.
+ * @param {Array<object>} tracks
+ * @returns {Array<{isrc:string|null, mbid:string|null, norm:string}>}
+ */
+function buildBaselineTiers(tracks) {
+  return (Array.isArray(tracks) ? tracks : []).map(trackTiers);
+}
+
+/**
+ * True when a stored baseline is the LEGACY collapsed-string shape (`string[]`)
+ * rather than the current tier-record shape (`[{isrc,mbid,norm}]`). Used by the
+ * startup migration to upgrade old entries. An empty baseline is treated as
+ * already-current (re-deriving an empty is a no-op, and a tracked playlist
+ * always has a non-empty baseline).
+ * @param {*} baseline
+ * @returns {boolean}
+ */
+function isLegacyStringBaseline(baseline) {
+  return Array.isArray(baseline) && baseline.length > 0 && typeof baseline[0] === 'string';
+}
+
+/**
+ * Build the COLLAPSED merge-ancestor keys (the 3-way merge `baseline` param):
+ * the ordered list of canonical keys, deduped first-occurrence (so it's
+ * directly comparable to a merge result, which is also deduped). No longer the
+ * persisted shape (that's `buildBaselineTiers`); derived on demand.
  * @param {Array<object>} tracks
  * @returns {string[]}
  */
@@ -164,12 +201,12 @@ function makePlaylistSyncState({ baseline = [], baselineSyncedAt = 0, providers 
  * Returns null when the playlist has NO sync intent (no syncedFrom, no
  * syncedTo) — a local-only playlist is not an N-way participant.
  *
- * NOTE (design open question #4, parachord#911): `baseline` stores the
- * COLLAPSED canonical key per track (string[]), matching the Phase-1 schema.
- * If cross-copy re-unification later needs the full {isrc,mbid,norm} tiers of
- * the ancestor, this becomes an additive schema change + re-migration. Safe
- * to defer: the map is main-write-only, nothing reads it for reconciliation
- * yet, and the baseline is re-derivable from local_playlists at any time.
+ * Design decision #4 (parachord#911) is RESOLVED here: `baseline` stores the
+ * full `{isrc,mbid,norm}` tier records (`buildBaselineTiers`), 1:1 with the
+ * tracklist — so the Layer-A reconcile can re-unify the ancestor against the
+ * current copies. (Earlier Phase-1/Phase-2 entries that stored the collapsed
+ * string[] are upgraded by the startup migration in main.js, which re-derives
+ * tiers losslessly from local_playlists.)
  *
  * @param {object} playlist - a local_playlists entry
  * @param {number} now - epoch ms (caller-supplied for determinism)
@@ -182,7 +219,7 @@ function bootstrapPlaylistState(playlist, now) {
   if (!hasSyncIntent) return null;
 
   const ts = typeof now === 'number' ? now : 0;
-  const baseline = buildBaseline(playlist.tracks || []);
+  const baseline = buildBaselineTiers(playlist.tracks || []);
   const providers = {};
 
   const sf = playlist.syncedFrom;
@@ -210,6 +247,8 @@ function bootstrapPlaylistState(playlist, now) {
 
 module.exports = {
   buildBaseline,
+  buildBaselineTiers,
+  isLegacyStringBaseline,
   toEpochMs,
   deriveChangeToken,
   deriveEditedAt,

--- a/tests/sync/playlist-sync-state.test.js
+++ b/tests/sync/playlist-sync-state.test.js
@@ -10,6 +10,8 @@
 
 const {
   buildBaseline,
+  buildBaselineTiers,
+  isLegacyStringBaseline,
   toEpochMs,
   deriveChangeToken,
   deriveEditedAt,
@@ -42,6 +44,45 @@ describe('buildBaseline', () => {
   test('empty / non-array degrades to []', () => {
     expect(buildBaseline([])).toEqual([]);
     expect(buildBaseline(null)).toEqual([]);
+  });
+});
+
+describe('buildBaselineTiers — persisted ancestor (full tiers, 1:1, no dedup)', () => {
+  test('maps each track to its {isrc,mbid,norm} tiers', () => {
+    expect(
+      buildBaselineTiers([
+        { isrc: 'GBAYE0601498', artist: 'A', title: 'T' },
+        { recordingMbid: 'b2181aae-5cba-496c-bb0c-b4cc0109ebf8', artist: 'B', title: 'U' },
+        { artist: 'Radiohead', title: 'Creep' },
+      ])
+    ).toEqual([
+      { isrc: 'GBAYE0601498', mbid: null, norm: 'a|t' },
+      { isrc: null, mbid: 'b2181aae-5cba-496c-bb0c-b4cc0109ebf8', norm: 'b|u' },
+      { isrc: null, mbid: null, norm: 'radiohead|creep' },
+    ]);
+  });
+
+  test('does NOT dedupe — kept 1:1 with the tracklist (length honest)', () => {
+    const tiers = buildBaselineTiers([{ isrc: 'GBAYE0601498' }, { isrc: 'gbaye0601498' }]);
+    expect(tiers.length).toBe(2); // same recording, two entries — NOT collapsed
+    expect(tiers[0]).toEqual(tiers[1]);
+  });
+
+  test('empty / non-array degrades to []', () => {
+    expect(buildBaselineTiers([])).toEqual([]);
+    expect(buildBaselineTiers(null)).toEqual([]);
+  });
+});
+
+describe('isLegacyStringBaseline — migration shape detector', () => {
+  test('true only for a NON-EMPTY string[] (the legacy shape)', () => {
+    expect(isLegacyStringBaseline(['isrc-X', 'norm-a|b'])).toBe(true);
+  });
+  test('false for tier records, empty, and non-arrays', () => {
+    expect(isLegacyStringBaseline([{ isrc: null, mbid: null, norm: 'a|b' }])).toBe(false);
+    expect(isLegacyStringBaseline([])).toBe(false); // empty treated as current
+    expect(isLegacyStringBaseline(undefined)).toBe(false);
+    expect(isLegacyStringBaseline(null)).toBe(false);
   });
 });
 
@@ -137,14 +178,17 @@ describe('bootstrapPlaylistState — Phase 2 one-time migration (pure)', () => {
     expect(bootstrapPlaylistState(null, NOW)).toBeNull();
   });
 
-  test('seeds baseline (canonical keys) for a synced playlist', () => {
+  test('seeds baseline as 1:1 tier records for a synced playlist', () => {
     const pl = {
       id: 'spotify-abc',
       tracks: [{ isrc: 'GBAYE0601498' }, { artist: 'Radiohead', title: 'Creep' }],
       syncedFrom: { resolver: 'spotify', externalId: 'abc', snapshotId: 'snap1' },
     };
     const s = bootstrapPlaylistState(pl, NOW);
-    expect(s.baseline).toEqual(['isrc-GBAYE0601498', 'norm-radiohead|creep']);
+    expect(s.baseline).toEqual([
+      { isrc: 'GBAYE0601498', mbid: null, norm: '|' },
+      { isrc: null, mbid: null, norm: 'radiohead|creep' },
+    ]);
     expect(s.baselineSyncedAt).toBe(NOW);
   });
 


### PR DESCRIPTION
Resolves design open question **#4**. The persisted baseline (the 3-way merge ancestor) now stores full `{isrc,mbid,norm}` tier records instead of collapsed key strings, so the Layer-A reconcile (PR-4) can **re-unify the ancestor** against the current copies.

A collapsed single key (e.g. `'mbid-x'`) has thrown away its sibling isrc/norm tiers and can't re-participate in union-find — a drifted copy carrying the same song under a different tier would spuriously read as add+remove (the exact false-drop the redesign forbids).

**Still additive + behavior-neutral** — nothing reads the map for reconciliation yet; the baseline is main-write-only and re-derivable from `local_playlists`.

## What

- **`sync-engine/playlist-sync-state.js`**
  - `buildBaselineTiers(tracks)` — each track → its tiers via `trackTiers`, **1:1 with the tracklist, no dedup** (matches mobile's `nwayBaselineTrackKeys`, keeps the `trackCount`-based change-detection honest; desktop array order **is** position order).
  - `isLegacyStringBaseline(baseline)` — detects the old non-empty `string[]` shape (empty treated as already-current → idempotent).
  - `bootstrapPlaylistState` now seeds the baseline as tiers.
  - `buildBaseline` (collapsed, deduped) kept + re-documented — it's the on-demand merge-ancestor shape (derived at reconcile via `unifyTrackKeys`), no longer persisted.
- **`main.js`** — the startup bootstrap pass gains an **upgrade arm**: an entry whose baseline is the legacy `string[]` is re-derived to tiers **losslessly from the live tracklist** (never by exploding collapsed strings), preserving providers + `baselineSyncedAt`. Seed + upgrade in one idempotent pass; re-run is a no-op.
- **tests** — `buildBaselineTiers` (tier shape, 1:1 no-dedup, degrade), `isLegacyStringBaseline` (only non-empty `string[]`), bootstrap test updated to assert tier records.

## Note on OQ-1 (dedup)

Per the spec's recommendation, `buildBaselineTiers` does **not** dedupe (1:1 with the tracklist) to match mobile and keep the snapshot-less change-detection compare (`listEntry.trackCount !== baseline.tracks.length`) honest. The collapsed merge-ancestor (`buildBaseline`) still dedupes — they're the two intentional representations.

## Test plan

- [x] `npx jest tests/sync/` → 8 suites, 317 tests green.
- [ ] Manual: launch on a build that ran the old Phase-2 bootstrap (string[] baselines) → confirm the upgrade re-derives tier records, second launch is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)