### PR TITLE
feat(sync): N-way provider write primitives — removals + nativeIdOf + throwing defaults (Step 2 / PR-1) (#911)

### DIFF
--- a/sync-providers/applemusic.js
+++ b/sync-providers/applemusic.js
@@ -399,6 +399,17 @@ const AppleMusicSyncProvider = {
    *     dance for an auth that was never broken. We now go straight to
    *     the `endpoint-unsupported` return on 401/403/405.
    */
+  // ── N-way incremental write primitives (parachord#911) ────────────
+  // Apple Music is `trackRemoveMode: 'Unsupported'` — the public library API
+  // has no track-removal path, so the executor never asks AM to remove. It
+  // still exposes nativeIdOf for parity (used by the source-authority gate +
+  // the ReplaceOnly coverage check on other providers' shapes). The remove
+  // primitives intentionally do NOT exist here; the throwing default applies.
+  nativeIdOf(track) {
+    if (!track) return null;
+    return track.appleMusicId || track.appleMusicCatalogId || null;
+  },
+
   async deletePlaylist(playlistId, token, _refreshTokenCb) {
     const { developerToken, userToken } = JSON.parse(token);
     const resp = await fetch(

--- a/sync-providers/incremental-primitives.js
+++ b/sync-providers/incremental-primitives.js
@@ -1,0 +1,55 @@
+// N-way incremental write-primitive defaults (parachord#911, Step 2 / PR-1).
+//
+// Desktop sync providers are plain objects, not classes with a shared base, so
+// there's no interface to carry "default implementation that throws" the way
+// the Kotlin SyncProvider interface does. This helper supplies that guarantee:
+// wrap a provider and any incremental write primitive it does NOT implement is
+// filled with a stub that THROWS (loudly) rather than silently no-opping.
+//
+// Why throw, not no-op: the materialize executor dispatches removals on
+// `trackRemoveMode`, so in correct operation it only calls the primitives a
+// provider actually supports. A missing primitive being invoked means a
+// dispatch bug — and a silent no-op there could read downstream as "nothing to
+// remove" (a false success), which the no-false-drop invariant forbids. The
+// FakeProvider in the executor tests throws on mis-dispatch for the same
+// reason; this is the production-side equivalent.
+//
+// Pure + dormant: nothing wraps real providers until the reconcile driver
+// (PR-4). `nativeIdOf` is intentionally NOT defaulted — it's a pure accessor
+// every provider defines, and a throwing stub there would mask a real gap.
+
+const INCREMENTAL_PRIMITIVES = [
+  'addPlaylistTracks',
+  'removePlaylistTracksByNativeId',
+  'removePlaylistTracksByPosition',
+  'replacePlaylistTracks',
+  'remotePlaylistExists',
+  'searchForTrackId',
+];
+
+/**
+ * Return a shallow copy of `provider` with every unimplemented incremental
+ * write primitive replaced by an async stub that throws. Methods the provider
+ * already defines are preserved untouched. Non-destructive (does not mutate the
+ * input). Object-method `this` resolves to the returned copy, so a real
+ * provider whose methods call `this.fetchPlaylistTracks` still works.
+ * @param {object} provider - a sync provider object (must have `capabilities`)
+ * @returns {object} the provider augmented with throwing defaults
+ */
+function withIncrementalDefaults(provider) {
+  if (!provider || typeof provider !== 'object') {
+    throw new Error('withIncrementalDefaults: provider must be an object');
+  }
+  const out = { ...provider };
+  const id = out.id || 'provider';
+  for (const method of INCREMENTAL_PRIMITIVES) {
+    if (typeof out[method] !== 'function') {
+      out[method] = async () => {
+        throw new Error(`${method} not implemented by ${id}`);
+      };
+    }
+  }
+  return out;
+}
+
+module.exports = { withIncrementalDefaults, INCREMENTAL_PRIMITIVES };

--- a/sync-providers/listenbrainz.js
+++ b/sync-providers/listenbrainz.js
@@ -479,6 +479,61 @@ async function deletePlaylist(playlistMbid, token) {
   return { success: true };
 }
 
+// ── N-way incremental write primitives (parachord#911) ──────────────
+// ListenBrainz is `trackRemoveMode: 'ByPosition'` — its JSPF playlist API has
+// no delete-by-id; only delete-by-index. Dormant until the N-way reconcile
+// driver calls these (real writes gated OFF).
+
+// The native id LB resolution operates on — the bare recording MBID,
+// trim+lowercased (matches the engine's mbid tier; null when absent).
+function nativeIdOf(track) {
+  const raw = (track && (track.recordingMbid || track.mbid)) || '';
+  const norm = String(raw).trim().toLowerCase();
+  return norm.length > 0 ? norm : null;
+}
+
+/**
+ * Remove specific tracks from a playlist by their 0-based positions.
+ * POST /1/playlist/<mbid>/item/delete { index, count: 1 } per position,
+ * issued DESCENDING so an earlier delete never shifts the index of a position
+ * still to be removed. Returns the refreshed JSPF last_modified anchor.
+ * @param {string} playlistMbid
+ * @param {number[]} positions
+ * @param {string} token
+ * @returns {Promise<{snapshotId:string|null}>}
+ */
+async function removePlaylistTracksByPosition(playlistMbid, positions, token) {
+  const sorted = (Array.isArray(positions) ? positions : [])
+    .filter((p) => Number.isInteger(p) && p >= 0)
+    .sort((a, b) => b - a); // descending — delete from the back forward
+  for (const index of sorted) {
+    const res = await fetch(`${LB_BASE}/1/playlist/${encodeURIComponent(playlistMbid)}/item/delete`, {
+      method: 'POST',
+      headers: authHeaders(token),
+      body: JSON.stringify({ index, count: 1 }),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(`LB delete-by-position returned ${res.status}: ${text.slice(0, 200)}`);
+    }
+  }
+  // Re-fetch the fresh snapshot anchor (same pattern as updatePlaylistTracks).
+  let snapshotId = null;
+  try {
+    const cur = await fetch(`${LB_BASE}/1/playlist/${encodeURIComponent(playlistMbid)}`, {
+      headers: authHeaders(token),
+    });
+    if (cur.ok) {
+      const data = await cur.json();
+      snapshotId =
+        data?.playlist?.extension?.['https://musicbrainz.org/doc/jspf#playlist']?.last_modified_at
+        || data?.playlist?.date
+        || null;
+    }
+  } catch {}
+  return { snapshotId };
+}
+
 // Cheap remote auth check — hits /1/validate-token. Mirrors the
 // `checkAuth(token) -> boolean` contract spotify.js and applemusic.js export
 // so `provider.checkAuth(token)` in main.js's `sync:check-auth` handler
@@ -509,4 +564,6 @@ module.exports = {
   updatePlaylistTracks,
   updatePlaylistDetails,
   deletePlaylist,
+  nativeIdOf,
+  removePlaylistTracksByPosition,
 };

--- a/sync-providers/spotify.js
+++ b/sync-providers/spotify.js
@@ -532,6 +532,40 @@ const SpotifySyncProvider = {
     return { success: true, snapshotId };
   },
 
+  // ── N-way incremental write primitives (parachord#911) ────────────
+  // Spotify is `trackRemoveMode: 'ByNativeId'` — surgical add/remove by URI,
+  // NOT the destructive PUT-replace that updatePlaylistTracks uses. Dormant
+  // until the N-way reconcile driver calls them (real writes gated OFF).
+
+  // The native id Spotify add/remove operate on, off a track object.
+  nativeIdOf(track) {
+    if (!track) return null;
+    if (track.spotifyUri) return track.spotifyUri;
+    if (track.spotifyId) return `spotify:track:${track.spotifyId}`;
+    return null;
+  },
+
+  /**
+   * Remove specific tracks from a playlist by their Spotify URI.
+   * DELETE /v1/playlists/{id}/tracks  body { tracks: [{ uri }] }; batched 100;
+   * returns the new snapshot_id (the echo-suppression anchor).
+   * @returns {Promise<{success:boolean, snapshotId:string|undefined}>}
+   */
+  async removePlaylistTracksByNativeId(playlistId, externalTrackIds, token) {
+    const uris = (externalTrackIds || []).filter(Boolean);
+    let snapshotId;
+    for (let i = 0; i < uris.length; i += 100) {
+      const batch = uris.slice(i, i + 100);
+      if (i > 0) await new Promise((r) => setTimeout(r, 100)); // rate-limit between batches
+      const result = await spotifyRequest(`/playlists/${playlistId}/tracks`, token, {
+        method: 'DELETE',
+        body: { tracks: batch.map((uri) => ({ uri })) },
+      });
+      snapshotId = result.snapshot_id;
+    }
+    return { success: true, snapshotId };
+  },
+
   /**
    * Update playlist metadata (name, description)
    * @param {string} playlistId - Spotify playlist ID

--- a/tests/sync/incremental-primitives.test.js
+++ b/tests/sync/incremental-primitives.test.js
@@ -1,0 +1,177 @@
+/**
+ * N-way incremental write primitives — Layer B provider surface
+ * (Parachord/parachord#911, Step 2 / PR-1).
+ *
+ * Covers the capability-dispatch REMOVAL primitives + nativeIdOf + the
+ * throwing-defaults helper:
+ *   - withIncrementalDefaults: the desktop equivalent of the Kotlin interface
+ *     default — an unimplemented primitive throws (ports IncrementalPrimitive-
+ *     DefaultsTest cases 19-21).
+ *   - nativeIdOf purity per provider.
+ *   - Spotify removePlaylistTracksByNativeId — DELETE-by-URI HTTP shape
+ *     (mirrors SpotifyClientPlaylistRemoveTest).
+ *   - ListenBrainz removePlaylistTracksByPosition — descending positional
+ *     delete HTTP shape.
+ *
+ * The add / remotePlaylistExists / searchForTrackId primitives are tied to the
+ * reconcile driver's hydration + probe flows and land with PR-4's integration
+ * tests. Nothing wires any of this into the live sync path yet.
+ */
+
+const spotify = require('../../sync-providers/spotify.js');
+const applemusic = require('../../sync-providers/applemusic.js');
+const listenbrainz = require('../../sync-providers/listenbrainz.js');
+const { withIncrementalDefaults, INCREMENTAL_PRIMITIVES } = require('../../sync-providers/incremental-primitives.js');
+
+describe('withIncrementalDefaults — throwing defaults (cases 19-21)', () => {
+  test('an unimplemented primitive throws, not silently no-ops', async () => {
+    const stub = withIncrementalDefaults({ id: 'stub', capabilities: { trackRemoveMode: 'ByNativeId' } });
+    await expect(stub.addPlaylistTracks('ext', ['a'])).rejects.toThrow(/addPlaylistTracks not implemented by stub/);
+    await expect(stub.removePlaylistTracksByNativeId('ext', ['a'])).rejects.toThrow(/not implemented/);
+    await expect(stub.removePlaylistTracksByPosition('ext', [0])).rejects.toThrow(/not implemented/);
+    await expect(stub.replacePlaylistTracks('ext', ['a'])).rejects.toThrow(/not implemented/);
+    await expect(stub.remotePlaylistExists('ext')).rejects.toThrow(/not implemented/);
+    await expect(stub.searchForTrackId('t', 'a')).rejects.toThrow(/not implemented/);
+  });
+
+  test('a primitive the provider DOES define is preserved untouched', async () => {
+    const wrapped = withIncrementalDefaults({
+      id: 'p',
+      capabilities: {},
+      addPlaylistTracks: async () => 'kept',
+    });
+    await expect(wrapped.addPlaylistTracks('ext', ['a'])).resolves.toBe('kept');
+    // …while the undefined ones still throw.
+    await expect(wrapped.replacePlaylistTracks('ext', [])).rejects.toThrow(/not implemented/);
+  });
+
+  test('nativeIdOf is NOT defaulted (a throwing stub there would mask a real gap)', () => {
+    const wrapped = withIncrementalDefaults({ id: 'p', capabilities: {} });
+    expect(wrapped.nativeIdOf).toBeUndefined();
+  });
+
+  test('non-destructive — input object is not mutated', () => {
+    const input = { id: 'p', capabilities: {} };
+    withIncrementalDefaults(input);
+    expect(input.addPlaylistTracks).toBeUndefined();
+  });
+
+  test('throws on a non-object provider', () => {
+    expect(() => withIncrementalDefaults(null)).toThrow();
+    expect(() => withIncrementalDefaults('nope')).toThrow();
+  });
+
+  test('exports the canonical primitive list', () => {
+    expect(INCREMENTAL_PRIMITIVES).toContain('removePlaylistTracksByNativeId');
+    expect(INCREMENTAL_PRIMITIVES).not.toContain('nativeIdOf');
+  });
+});
+
+describe('nativeIdOf — pure native-id accessors', () => {
+  test('Spotify: spotifyUri wins, else builds from spotifyId, else null', () => {
+    expect(spotify.nativeIdOf({ spotifyUri: 'spotify:track:abc' })).toBe('spotify:track:abc');
+    expect(spotify.nativeIdOf({ spotifyId: 'xyz' })).toBe('spotify:track:xyz');
+    expect(spotify.nativeIdOf({})).toBeNull();
+    expect(spotify.nativeIdOf(null)).toBeNull();
+  });
+
+  test('ListenBrainz: recordingMbid (trim+lower), else mbid, else null', () => {
+    expect(listenbrainz.nativeIdOf({ recordingMbid: '  ABC-123  ' })).toBe('abc-123');
+    expect(listenbrainz.nativeIdOf({ mbid: 'DEF' })).toBe('def');
+    expect(listenbrainz.nativeIdOf({})).toBeNull();
+  });
+
+  test('Apple Music: appleMusicId, else appleMusicCatalogId, else null', () => {
+    expect(applemusic.nativeIdOf({ appleMusicId: '123' })).toBe('123');
+    expect(applemusic.nativeIdOf({ appleMusicCatalogId: '456' })).toBe('456');
+    expect(applemusic.nativeIdOf({})).toBeNull();
+  });
+});
+
+describe('Spotify removePlaylistTracksByNativeId — DELETE-by-URI HTTP shape', () => {
+  let realFetch;
+  beforeEach(() => {
+    realFetch = global.fetch;
+  });
+  afterEach(() => {
+    global.fetch = realFetch;
+  });
+
+  test('issues DELETE /playlists/{id}/tracks with { tracks: [{ uri }] } and returns snapshotId', async () => {
+    const calls = [];
+    global.fetch = async (url, opts) => {
+      calls.push({ url, opts });
+      return { ok: true, status: 200, text: async () => JSON.stringify({ snapshot_id: 'snap2' }) };
+    };
+    const result = await spotify.removePlaylistTracksByNativeId(
+      'PID',
+      ['spotify:track:1', 'spotify:track:2'],
+      'tok'
+    );
+    expect(calls.length).toBe(1);
+    expect(calls[0].opts.method).toBe('DELETE');
+    expect(calls[0].url).toContain('/playlists/PID/tracks');
+    expect(calls[0].opts.headers.Authorization).toBe('Bearer tok');
+    expect(JSON.parse(calls[0].opts.body)).toEqual({
+      tracks: [{ uri: 'spotify:track:1' }, { uri: 'spotify:track:2' }],
+    });
+    expect(result).toEqual({ success: true, snapshotId: 'snap2' });
+  });
+
+  test('empty id list is a no-op (no DELETE)', async () => {
+    let called = false;
+    global.fetch = async () => {
+      called = true;
+      return { ok: true, status: 200, text: async () => '' };
+    };
+    const result = await spotify.removePlaylistTracksByNativeId('PID', [], 'tok');
+    expect(called).toBe(false);
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('ListenBrainz removePlaylistTracksByPosition — descending positional delete', () => {
+  let realFetch;
+  beforeEach(() => {
+    realFetch = global.fetch;
+  });
+  afterEach(() => {
+    global.fetch = realFetch;
+  });
+
+  test('deletes positions DESCENDING (so earlier deletes do not shift later indices)', async () => {
+    const deleteIndices = [];
+    global.fetch = async (url, opts) => {
+      if (typeof url === 'string' && url.includes('/item/delete')) {
+        deleteIndices.push(JSON.parse(opts.body));
+        return { ok: true, status: 200, text: async () => '' };
+      }
+      // Final snapshot re-fetch (GET the playlist).
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          playlist: { extension: { 'https://musicbrainz.org/doc/jspf#playlist': { last_modified_at: 't2' } } },
+        }),
+      };
+    };
+    const result = await listenbrainz.removePlaylistTracksByPosition('MBID', [0, 2, 1], 'tok');
+    // Issued 2 → 1 → 0, each count 1.
+    expect(deleteIndices).toEqual([
+      { index: 2, count: 1 },
+      { index: 1, count: 1 },
+      { index: 0, count: 1 },
+    ]);
+    expect(result.snapshotId).toBe('t2');
+  });
+
+  test('skips invalid positions and no-ops on an empty list', async () => {
+    let deletes = 0;
+    global.fetch = async (url) => {
+      if (typeof url === 'string' && url.includes('/item/delete')) deletes++;
+      return { ok: true, status: 200, json: async () => ({ playlist: {} }) };
+    };
+    await listenbrainz.removePlaylistTracksByPosition('MBID', [-1, 1.5, null], 'tok');
+    expect(deletes).toBe(0);
+  });
+});


### PR DESCRIPTION
The capability-dispatch **removal primitives** the materialize executor needs, plus the pure `nativeIdOf` accessors and the throwing-defaults guarantee. All **additive + dormant** — nothing wraps or calls a real provider until the reconcile driver (PR-4), and real writes stay gated OFF.

## What

| Provider | mode | new |
|---|---|---|
| **Spotify** | `ByNativeId` | `nativeIdOf` (spotifyUri → `spotify:track:{id}`); `removePlaylistTracksByNativeId` — `DELETE /v1/playlists/{id}/tracks { tracks: [{ uri }] }`, batched 100, returns the new `snapshot_id` (echo-suppression anchor). The surgical counterpart to the destructive PUT-replace `updatePlaylistTracks` uses. |
| **ListenBrainz** | `ByPosition` | `nativeIdOf` (recordingMbid‖mbid, trim+lower); `removePlaylistTracksByPosition` — `POST item/delete { index, count: 1 }` per position issued **descending** (so an earlier delete never shifts a position still to be removed), then re-fetches the JSPF `last_modified` anchor. |
| **Apple Music** | `Unsupported` | `nativeIdOf` (appleMusicId‖catalogId). **No** remove primitive — the throwing default applies (AM's public library API has no track-removal path). |

**`sync-providers/incremental-primitives.js`** (new) — `withIncrementalDefaults`, the desktop equivalent of the Kotlin `SyncProvider` interface default. Wraps a provider; any unimplemented incremental write primitive is filled with a stub that **throws**. A mis-dispatch must be loud, never a silent no-op that reads downstream as a false "nothing to remove" (the no-false-drop invariant). `nativeIdOf` is intentionally **not** defaulted (a throwing stub there would mask a real gap). Non-destructive (shallow copy).

## Tests (`tests/sync/incremental-primitives.test.js`, 13)

- Throwing defaults — ports `IncrementalPrimitiveDefaultsTest` cases 19-21 (+ preserved-method, non-destructive, non-object guard).
- `nativeIdOf` purity per provider.
- Spotify DELETE-by-URI HTTP shape (mocked `fetch`) — mirrors `SpotifyClientPlaylistRemoveTest`: asserts `DELETE`, URL, `Authorization`, `{ tracks: [{ uri }] }` body, returned `snapshotId`; empty-list no-op.
- LB descending positional-delete HTTP shape — asserts `[2,1,0]` order, `count: 1`, snapshot re-fetch; invalid-position skip + empty no-op.

## Scope note

The `addPlaylistTracks` / `remotePlaylistExists` / `searchForTrackId` primitives are tied to the reconcile driver's hydration + probe flows and land with **PR-4's integration tests** — keeping this PR to the genuinely-new, mock-testable removal surface rather than shipping add/search/probe network wrappers with no caller.

## Test plan

- [x] `npx jest tests/sync/` → 9 suites, 330 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)