### PR TITLE
feat(sync): N-way reconcile driver + shadow wiring + two flags (Step 2 / PR-4b) (#911)

### DIFF
--- a/main.js
+++ b/main.js
@@ -5390,6 +5390,154 @@ function removePlaylistSyncState(localPlaylistId, providerId) {
 ipcMain.handle('sync-state:get-all', async () => getSyncStates());
 ipcMain.handle('sync-state:get', async (event, localPlaylistId) => getPlaylistSyncState(localPlaylistId));
 
+// ── N-way reconcile driver wiring (parachord#911, Step 2 / PR-4b) ──────
+// DORMANT by default. The pure reconcile engine (sync-engine/playlist-
+// reconcile.js, unit-tested by the no-false-drop harness) is run here over the
+// real store + providers. Two flags gate it, BOTH default OFF:
+//   nway_shadow_enabled — run the engine at all (compute plan + structured log)
+//   nway_propagate      — perform REAL writes (dryRun = !nway_propagate)
+// So: shadow OFF → nothing runs. shadow ON, propagate OFF → compute + log, ZERO
+// writes (the Step-2 milestone — verified side-effect-free: the core stops
+// before A13/A14/A15, so only fetchPlaylistTracks is called and no effect
+// fires). shadow ON, propagate ON → real N-way materialize (NOT armed until the
+// no-false-drop harness is validated on a real library + the mobile parity
+// (parachord-mobile#277) lands). There is intentionally NO auto-hook into the
+// hot sync path yet — this runs only when explicitly invoked via the
+// `nway:shadow-run` IPC, so it can never perturb a normal sync.
+function isNwayShadowEnabled() { return store.get('nway_shadow_enabled') === true; }
+function isNwayPropagateEnabled() { return store.get('nway_propagate') === true; }
+
+async function getNwayProviderToken(providerId) {
+  if (providerId === 'spotify') return await ensureValidSpotifyToken();
+  if (providerId === 'applemusic') {
+    if (!generatedMusicKitToken) { try { await musicKitTokenReady; } catch {} }
+    const developerToken = generatedMusicKitToken || process.env.MUSICKIT_DEVELOPER_TOKEN || store.get('applemusic_developer_token');
+    const userToken = store.get('applemusic_user_token');
+    return developerToken && userToken ? JSON.stringify({ developerToken, userToken }) : null;
+  }
+  if (providerId === 'listenbrainz') {
+    const cfg = store.get('scrobbler-config-listenbrainz') || {};
+    return cfg.userToken || null;
+  }
+  return null;
+}
+
+// Derive a playlist's remote mirrors { providerId -> externalId } from its
+// syncedFrom (pull source) + syncedTo (push mirrors).
+function nwayMirrorsOf(playlist) {
+  const m = {};
+  if (playlist && playlist.syncedFrom && playlist.syncedFrom.resolver && playlist.syncedFrom.externalId) {
+    m[playlist.syncedFrom.resolver] = playlist.syncedFrom.externalId;
+  }
+  if (playlist && playlist.syncedTo) {
+    for (const [pid, st] of Object.entries(playlist.syncedTo)) {
+      if (st && st.externalId) m[pid] = st.externalId;
+    }
+  }
+  return m;
+}
+
+async function runNwayShadowReconcile() {
+  if (!isNwayShadowEnabled()) return { skipped: 'shadow-disabled' };
+  const { bindProviderToken, makeStoreEffects, runNwayReconcileCycle, createHydrationCache } =
+    require('./sync-engine/nway-reconcile-driver');
+  const dryRun = !isNwayPropagateEnabled();
+  const now = Date.now();
+  const states = getSyncStates();
+  const playlists = store.get('local_playlists') || [];
+  const playlistById = new Map(playlists.map((p) => [p.id, p]));
+  const mirrorsOf = (localId) => nwayMirrorsOf(playlistById.get(localId));
+
+  // Which providers are referenced by any tracked playlist's mirrors?
+  const neededProviders = new Set();
+  for (const localId of Object.keys(states)) {
+    for (const pid of Object.keys(mirrorsOf(localId))) neededProviders.add(pid);
+  }
+
+  // Acquire tokens, bind providers, fetch authoritative remote playlist
+  // metadata (snapshotId + trackCount — the partial-fetch floor's count source).
+  const boundProviders = {};
+  const remoteLists = {};
+  for (const pid of neededProviders) {
+    const provider = SyncEngine.getProvider(pid);
+    if (!provider) continue;
+    let token = null;
+    try { token = await getNwayProviderToken(pid); } catch { token = null; }
+    if (!token) { console.warn(`[nway-shadow] no token for ${pid}; skipping its mirrors`); continue; }
+    boundProviders[pid] = bindProviderToken(provider, token);
+    try {
+      const res = await provider.fetchPlaylists(token);
+      const map = {};
+      for (const rp of (res && res.playlists) || []) {
+        if (rp.externalId) {
+          map[rp.externalId] = {
+            snapshotId: rp.snapshotId != null ? rp.snapshotId : null,
+            trackCount: typeof rp.trackCount === 'number' ? rp.trackCount : null,
+          };
+        }
+      }
+      remoteLists[pid] = map;
+    } catch (e) {
+      console.warn(`[nway-shadow] fetchPlaylists failed for ${pid}: ${e && e.message}`);
+      remoteLists[pid] = {};
+    }
+  }
+
+  // Only run playlists at least one of whose mirrors we could bind (have a token).
+  const runnableStates = {};
+  for (const localId of Object.keys(states)) {
+    if (!playlistById.has(localId)) continue;
+    if (Object.keys(mirrorsOf(localId)).some((pid) => boundProviders[pid])) runnableStates[localId] = states[localId];
+  }
+
+  // Store abstraction for the effects (these fire only when !dryRun).
+  const storeAbstraction = {
+    getPlaylist: (id) => playlistById.get(id) || null,
+    savePlaylist: (p) => {
+      playlistById.set(p.id, p);
+      const arr = store.get('local_playlists') || [];
+      const idx = arr.findIndex((x) => x.id === p.id);
+      if (idx >= 0) { arr[idx] = p; store.set('local_playlists', arr); }
+    },
+    getState: (id) => getSyncStates()[id] || null,
+    saveState: (id, s) => { const all = getSyncStates(); all[id] = s; store.set('sync_playlist_state', all); },
+    removeSyncLink: (id, pid) => { removeSyncLink(id, pid); removePlaylistSyncState(id, pid); },
+  };
+  const cache = createHydrationCache(store.get('nway_hydration_cache') || undefined);
+
+  const out = await runNwayReconcileCycle({
+    states: runnableStates,
+    getPlaylist: storeAbstraction.getPlaylist,
+    getMirrors: mirrorsOf,
+    boundProviders,
+    remoteLists,
+    getPullSource: (localId) => {
+      const pl = playlistById.get(localId);
+      return pl && pl.syncedFrom && pl.syncedFrom.resolver && pl.syncedFrom.externalId
+        ? { providerId: pl.syncedFrom.resolver, externalId: pl.syncedFrom.externalId }
+        : null;
+    },
+    cache,
+    effects: makeStoreEffects(storeAbstraction),
+    now,
+    dryRun,
+    log: console,
+  });
+
+  // Persist the negative cache only after a real (non-dry) cycle — shadow
+  // doesn't mutate it (A5.5 + the coordinator are gated off in dryRun).
+  if (!dryRun) {
+    try { store.set('nway_hydration_cache', Object.fromEntries(cache.entries())); } catch {}
+  }
+  console.log(`[nway-shadow] cycle done (dryRun=${dryRun}): ${out.results.length} planned across ${out.cycles}, ${out.errors.length} error(s)`);
+  return { dryRun, ...out };
+}
+
+ipcMain.handle('nway:shadow-run', async () => {
+  try { return await runNwayShadowReconcile(); }
+  catch (e) { return { error: e && e.message }; }
+});
+
 // ---------------------------------------------------------------------------
 // Achordion playlist-links submission (LB-anchored mirror map)
 // ---------------------------------------------------------------------------

--- a/preload.js
+++ b/preload.js
@@ -38,6 +38,13 @@ contextBridge.exposeInMainWorld('electron', {
     clear: () => ipcRenderer.invoke('store-clear'),
   },
 
+  // N-way reconcile (parachord#911) — dormant; gated by the nway_shadow_enabled
+  // / nway_propagate store flags (both default OFF). shadowRun() manually
+  // triggers one reconcile cycle for validation (shadow = compute + log only).
+  nway: {
+    shadowRun: () => ipcRenderer.invoke('nway:shadow-run'),
+  },
+
   // Spotify operations
   spotify: {
     authenticate: () => ipcRenderer.invoke('spotify-auth'),

--- a/sync-engine/nway-reconcile-driver.js
+++ b/sync-engine/nway-reconcile-driver.js
@@ -1,0 +1,173 @@
+// N-way reconcile DRIVER (parachord#911, Step 2 / PR-4b).
+//
+// The thin, injected orchestration that runs the pure reconcile core
+// (playlist-reconcile.js) over every sync-tracked playlist for one cycle. It
+// owns the three impure concerns the core deliberately doesn't:
+//   1. per-cycle token binding (OQ-2) — real desktop providers take `token` on
+//      every method; the reconcile core + executor call them token-free, so
+//      each provider is wrapped in a per-cycle adapter that closes over its
+//      token (and fills any not-yet-implemented write primitive with a throwing
+//      default, so a mis-call is loud rather than a silent no-op).
+//   2. store-backed effects — the core RETURNS its mutations through injected
+//      effect callbacks; here they read/write electron-store-shaped maps
+//      (local_playlists, sync_playlist_state, sync_playlist_links).
+//   3. per-playlist isolation — one playlist throwing (a throttled mirror's A1
+//      fetch propagates out of the core) must NEVER abort the rest of the
+//      cycle, mirroring sync:start's per-playlist resilience.
+//
+// SHADOW-FIRST: with dryRun=true the core stops before any write, so the only
+// provider call is fetchPlaylistTracks and NONE of the effects fire — the pass
+// is side-effect-free. Real writes are reached only when the caller passes
+// dryRun=false (gated by `nway_propagate`, default OFF). This module is pure +
+// injected (no electron, no fetch); main.js supplies the real store + providers
+// + tokens + remoteLists. Unit-tested in tests/sync/nway-reconcile-driver.test.js.
+
+const { reconcilePlaylist } = require('./playlist-reconcile');
+const { createHydrationCoordinator } = require('./hydration-coordinator');
+const { createHydrationCache } = require('./nway-hydration-cache');
+const { withIncrementalDefaults } = require('../sync-providers/incremental-primitives');
+
+// The provider methods the reconcile core + executor + coordinator call, and
+// whether the token is bound as a trailing arg. nativeIdOf is pure (no token).
+const TOKEN_BOUND_METHODS = [
+  'fetchPlaylistTracks',
+  'addPlaylistTracks',
+  'removePlaylistTracksByNativeId',
+  'removePlaylistTracksByPosition',
+  'replacePlaylistTracks',
+  'getPlaylistSnapshot',
+  'remotePlaylistExists',
+  'searchForTrackId',
+];
+
+/**
+ * Wrap a real provider so the reconcile core can call it token-free. Fills any
+ * unimplemented incremental write primitive with a throwing default first (so a
+ * premature write call is loud), then binds `token` as the trailing arg of each
+ * network method. nativeIdOf passes through unbound (pure).
+ */
+function bindProviderToken(provider, token) {
+  const ready = withIncrementalDefaults(provider);
+  const bound = {
+    id: ready.id,
+    capabilities: ready.capabilities,
+    nativeIdOf: typeof ready.nativeIdOf === 'function' ? (t) => ready.nativeIdOf(t) : () => null,
+  };
+  for (const m of TOKEN_BOUND_METHODS) {
+    bound[m] = (...args) => ready[m](...args, token);
+  }
+  return bound;
+}
+
+/**
+ * Build the effects object the reconcile core writes its mutations through,
+ * backed by an injected `store` abstraction. NONE of these fire in shadow
+ * (dryRun) — the core returns before A13/A14/A15.
+ *
+ * @param {object} store - { getPlaylist(localId), savePlaylist(playlist),
+ *   getState(localId), saveState(localId, state), removeSyncLink(localId, providerId) }
+ */
+function makeStoreEffects(store) {
+  return {
+    replaceAllLocalTracks(localId, tracks) {
+      const pl = store.getPlaylist(localId);
+      if (pl) store.savePlaylist({ ...pl, tracks, lastModified: pl.lastModified });
+    },
+    clearLocallyModified(localId) {
+      const pl = store.getPlaylist(localId);
+      if (pl && pl.locallyModified) store.savePlaylist({ ...pl, locallyModified: false });
+    },
+    setProviderToken(localId, providerId, changeToken, now) {
+      const state = store.getState(localId);
+      if (!state) return;
+      const providers = { ...(state.providers || {}) };
+      providers[providerId] = { ...(providers[providerId] || {}), changeToken, lastSyncedAt: now };
+      store.saveState(localId, { ...state, providers });
+    },
+    removeProviderState(localId, providerId) {
+      const state = store.getState(localId);
+      if (!state || !state.providers || !(providerId in state.providers)) return;
+      const providers = { ...state.providers };
+      delete providers[providerId];
+      store.saveState(localId, { ...state, providers });
+    },
+    setBaseline(localId, tiers, now) {
+      const state = store.getState(localId);
+      if (!state) return;
+      store.saveState(localId, {
+        ...state,
+        baseline: { ...(state.baseline || {}), tracks: tiers, baselineSyncedAt: now },
+      });
+    },
+    removeSyncLink(localId, providerId) {
+      store.removeSyncLink(localId, providerId);
+    },
+  };
+}
+
+/**
+ * Run one reconcile cycle over every tracked playlist. Each playlist is
+ * isolated in its own try/catch so a throttled mirror can't abort the rest.
+ *
+ * @param {object} args
+ * @param {object}   args.states       - sync_playlist_state map { localId -> state }
+ * @param {(localId:string)=>object|null} args.getPlaylist - local playlist lookup
+ * @param {(localId:string)=>Object<string,string>} args.getMirrors - { providerId -> externalId } per playlist
+ * @param {Object<string,object>} args.boundProviders - per-provider token-bound adapter (bindProviderToken output)
+ * @param {object}   args.remoteLists   - { providerId -> { externalId -> { snapshotId?, trackCount? } } }
+ * @param {(localId:string)=>object|null} [args.getPullSource]
+ * @param {object}   args.cache         - hydration cache (createHydrationCache)
+ * @param {object}   args.effects       - makeStoreEffects output
+ * @param {number}   args.now           - epoch ms
+ * @param {boolean}  args.dryRun        - shadow (no writes) when true
+ * @param {object}   [args.log]
+ * @returns {Promise<{cycles:number, results:object[], errors:object[]}>}
+ */
+async function runNwayReconcileCycle(args) {
+  const {
+    states, getPlaylist, getMirrors, boundProviders, remoteLists,
+    getPullSource, cache, effects, now, dryRun, log = console,
+  } = args;
+
+  const providersList = Object.values(boundProviders || {});
+  const coordinator = createHydrationCoordinator({ cache, clock: () => now });
+
+  const results = [];
+  const errors = [];
+  for (const localId of Object.keys(states || {})) {
+    const state = states[localId];
+    const playlist = getPlaylist(localId);
+    if (!playlist) continue;
+    try {
+      const result = await reconcilePlaylist({
+        baseline: state.baseline,
+        playlist,
+        mirrors: getMirrors(localId),
+        providers: providersList,
+        remoteLists,
+        storedTokens: state.providers || {},
+        pullSource: getPullSource ? getPullSource(localId) : null,
+        coordinator,
+        cache,
+        now,
+        dryRun,
+        effects,
+        log,
+      });
+      if (result) results.push(result);
+    } catch (err) {
+      // Per-playlist isolation — one throttled mirror never aborts the cycle.
+      log.warn('[nway-driver] playlist reconcile failed; skipping', { localId, error: err && err.message });
+      errors.push({ localId, error: err && err.message });
+    }
+  }
+  return { cycles: Object.keys(states || {}).length, results, errors };
+}
+
+module.exports = {
+  bindProviderToken,
+  makeStoreEffects,
+  runNwayReconcileCycle,
+  createHydrationCache,
+  TOKEN_BOUND_METHODS,
+};

--- a/tests/sync/nway-reconcile-driver.test.js
+++ b/tests/sync/nway-reconcile-driver.test.js
@@ -1,0 +1,179 @@
+/**
+ * N-way reconcile DRIVER (Parachord/parachord#911, Step 2 / PR-4b). The thin
+ * injected orchestration that runs the pure reconcile core over every tracked
+ * playlist for one cycle: token binding, store-backed effects, per-playlist
+ * isolation, and shadow (dryRun) side-effect-freedom.
+ */
+
+const {
+  bindProviderToken, makeStoreEffects, runNwayReconcileCycle, createHydrationCache,
+} = require('../../sync-engine/nway-reconcile-driver');
+const { buildBaselineTiers } = require('../../sync-engine/playlist-sync-state');
+
+const mk = (mbid) => ({ recordingMbid: mbid, title: `title-${mbid}`, artist: `artist-${mbid}` });
+
+describe('bindProviderToken', () => {
+  test('binds the token as the trailing arg of network methods; nativeIdOf stays pure', async () => {
+    const calls = [];
+    const real = {
+      id: 'spotify',
+      capabilities: { trackRemoveMode: 'ByNativeId' },
+      nativeIdOf: (t) => (t ? `nid:${t.recordingMbid}` : null),
+      async fetchPlaylistTracks(ext, token) { calls.push(['fetch', ext, token]); return []; },
+      async searchForTrackId(title, artist, album, isrc, token) { calls.push(['search', title, artist, album, isrc, token]); return null; },
+    };
+    const bound = bindProviderToken(real, 'TOK');
+    await bound.fetchPlaylistTracks('ext-1');
+    await bound.searchForTrackId('t', 'a', 'al', 'isrc');
+    expect(calls[0]).toEqual(['fetch', 'ext-1', 'TOK']);
+    expect(calls[1]).toEqual(['search', 't', 'a', 'al', 'isrc', 'TOK']);
+    expect(bound.nativeIdOf(mk('x'))).toBe('nid:x'); // unbound, pure
+  });
+
+  test('an unimplemented write primitive throws (the throwing default), bound or not', async () => {
+    const real = { id: 'applemusic', capabilities: { trackRemoveMode: 'Unsupported' }, nativeIdOf: () => null };
+    const bound = bindProviderToken(real, 'TOK');
+    await expect(bound.removePlaylistTracksByNativeId('ext', ['a'])).rejects.toThrow(/not implemented/);
+  });
+});
+
+// A minimal in-memory store matching makeStoreEffects' injected shape.
+function makeMemoryStore(playlists, states) {
+  const pl = new Map(playlists.map((p) => [p.id, p]));
+  const st = new Map(Object.entries(states));
+  const removedLinks = [];
+  return {
+    getPlaylist: (id) => pl.get(id) || null,
+    savePlaylist: (p) => pl.set(p.id, p),
+    getState: (id) => st.get(id) || null,
+    saveState: (id, s) => st.set(id, s),
+    removeSyncLink: (id, provider) => removedLinks.push([id, provider]),
+    _pl: pl,
+    _st: st,
+    _removedLinks: removedLinks,
+  };
+}
+
+// A FakeProvider with a real round-tripping in-memory remote, built as a PLAIN
+// OBJECT (methods as own properties) to mirror the real desktop providers —
+// bindProviderToken's withIncrementalDefaults does {...provider}, which only
+// copies own props, so a class instance would lose its prototype methods.
+// Token-agnostic: the driver binds the real token; the Fake ignores it.
+function makeFakeProvider(id, mode) {
+  const p = {
+    id,
+    capabilities: { trackRemoveMode: mode, canReorder: false, supportsPlaylistDelete: true, supportsPlaylistRename: true },
+    remote: [],
+    snap: 0,
+    fetchCount: 0,
+    addCalls: [],
+    nativeIdOf(t) { return t && t.recordingMbid ? `nid:${t.recordingMbid}` : null; },
+    async fetchPlaylistTracks() { p.fetchCount += 1; return p.remote.map((t) => ({ ...t })); },
+    async addPlaylistTracks(_e, ids) { p.addCalls.push(ids); for (const id of ids) p.remote.push({ recordingMbid: String(id).slice(4) }); p.snap += 1; },
+    async removePlaylistTracksByNativeId(_e, ids) { const d = new Set(ids); p.remote = p.remote.filter((t) => !d.has(p.nativeIdOf(t))); p.snap += 1; },
+    async getPlaylistSnapshot() { return `snap-${id}-${p.snap}`; },
+    async remotePlaylistExists() { return true; },
+    async searchForTrackId() { return null; },
+  };
+  return p;
+}
+
+describe('runNwayReconcileCycle', () => {
+  function setup() {
+    const sp = makeFakeProvider('spotify', 'ByNativeId');
+    sp.remote = [mk('m0'), mk('m1')];
+    const seeded = [mk('m0'), mk('m1')];
+    const states = {
+      'pl-1': {
+        baseline: { localPlaylistId: 'pl-1', tracks: buildBaselineTiers(seeded), baselineSyncedAt: 1000 },
+        providers: { spotify: { changeToken: 'snap-spotify-0', editedAt: 0 } },
+      },
+    };
+    const playlists = [{ id: 'pl-1', tracks: [mk('m0'), mk('m1'), mk('added')], locallyModified: true, lastModified: 2000, writable: true }];
+    const store = makeMemoryStore(playlists, states);
+    const boundProviders = { spotify: bindProviderToken(sp, 'TOK') };
+    const remoteLists = { spotify: { 'ext-sp': { snapshotId: 'snap-spotify-0', trackCount: 2 } } };
+    return { sp, states, store, boundProviders, remoteLists };
+  }
+
+  test('shadow (dryRun) computes the plan with ZERO writes', async () => {
+    const { sp, states, store, boundProviders, remoteLists } = setup();
+    const cache = createHydrationCache();
+    const out = await runNwayReconcileCycle({
+      states,
+      getPlaylist: store.getPlaylist,
+      getMirrors: () => ({ spotify: 'ext-sp' }),
+      boundProviders,
+      remoteLists,
+      cache,
+      effects: makeStoreEffects(store),
+      now: 3000,
+      dryRun: true,
+      log: { info() {}, warn() {} },
+    });
+    expect(out.results[0]).toMatchObject({ status: 'would-push', mergedSize: 3 });
+    expect(sp.remote.length).toBe(2); // remote untouched
+    expect(sp.addCalls).toEqual([]);
+    expect(store.getState('pl-1').baseline.tracks.length).toBe(2); // baseline not advanced
+    expect(store.getPlaylist('pl-1').locallyModified).toBe(true); // flag untouched
+  });
+
+  test('write mode (dryRun=false) materializes + advances baseline via store effects', async () => {
+    const { sp, states, store, boundProviders, remoteLists } = setup();
+    const cache = createHydrationCache();
+    await runNwayReconcileCycle({
+      states,
+      getPlaylist: store.getPlaylist,
+      getMirrors: () => ({ spotify: 'ext-sp' }),
+      boundProviders,
+      remoteLists,
+      cache,
+      effects: makeStoreEffects(store),
+      now: 3000,
+      dryRun: false,
+      log: { info() {}, warn() {} },
+    });
+    expect(new Set(sp.remote.map((t) => t.recordingMbid))).toEqual(new Set(['m0', 'm1', 'added']));
+    expect(store.getState('pl-1').baseline.tracks.length).toBe(3); // advanced
+    expect(store.getState('pl-1').providers.spotify.lastSyncedAt).toBe(3000); // token re-stamped
+    expect(store.getPlaylist('pl-1').locallyModified).toBe(false); // cleared
+  });
+
+  test('per-playlist isolation — one playlist throwing does not abort the others', async () => {
+    // ONE shared provider whose A1 fetch THROWS only for pl-bad's externalId.
+    const sp = makeFakeProvider('spotify', 'ByNativeId');
+    sp.remote = [mk('m0'), mk('m1')];
+    sp.fetchPlaylistTracks = async (ext) => {
+      if (ext === 'ext-bad') throw new Error('429 throttled');
+      sp.fetchCount += 1;
+      return sp.remote.map((t) => ({ ...t }));
+    };
+    const states = {
+      'pl-bad': { baseline: { localPlaylistId: 'pl-bad', tracks: buildBaselineTiers([mk('z0')]), baselineSyncedAt: 1000 }, providers: { spotify: { changeToken: 'snap-spotify-0' } } },
+      'pl-good': { baseline: { localPlaylistId: 'pl-good', tracks: buildBaselineTiers([mk('m0'), mk('m1')]), baselineSyncedAt: 1000 }, providers: { spotify: { changeToken: 'snap-spotify-0' } } },
+    };
+    const playlists = [
+      { id: 'pl-bad', tracks: [mk('z0')], locallyModified: false, lastModified: 1000, writable: true },
+      { id: 'pl-good', tracks: [mk('m0'), mk('m1'), mk('added')], locallyModified: true, lastModified: 2000, writable: true },
+    ];
+    const store = makeMemoryStore(playlists, states);
+    const out = await runNwayReconcileCycle({
+      states,
+      getPlaylist: store.getPlaylist,
+      getMirrors: (id) => ({ spotify: id === 'pl-bad' ? 'ext-bad' : 'ext-good' }),
+      boundProviders: { spotify: bindProviderToken(sp, 'TOK') },
+      // pl-bad's mirror is 'changed' (trackCount 2 vs baseline 1) → it fetches → throws.
+      remoteLists: { spotify: { 'ext-bad': { trackCount: 2 }, 'ext-good': { snapshotId: 'snap-spotify-0', trackCount: 2 } } },
+      cache: createHydrationCache(),
+      effects: makeStoreEffects(store),
+      now: 3000,
+      dryRun: false,
+      log: { info() {}, warn() {} },
+    });
+    expect(out.cycles).toBe(2);
+    expect(out.errors).toEqual([{ localId: 'pl-bad', error: '429 throttled' }]); // isolated
+    // pl-good still converged despite pl-bad throwing.
+    expect(new Set(sp.remote.map((t) => t.recordingMbid))).toEqual(new Set(['m0', 'm1', 'added']));
+    expect(store.getState('pl-good').baseline.tracks.length).toBe(3);
+  });
+});


### PR DESCRIPTION
The final Step-2 slice — wires the pure reconcile core (#922) to the real store + providers, **DORMANT by default** behind two flags (both OFF). This is the shadow-mode milestone: the engine can compute + log its plan over a real library with **zero writes**, and real writes stay gated until validated.

## Flags (both default OFF)

| Flag | Gates |
|---|---|
| `nway_shadow_enabled` | Run the engine at all (compute plan + structured log). |
| `nway_propagate` | Perform REAL writes (`dryRun = !nway_propagate`). |

- shadow OFF → nothing runs.
- shadow ON + propagate OFF → compute + log, **zero writes** (verified side-effect-free: the core returns before A13/A14/A15, so only `fetchPlaylistTracks` is called and no effect/cache mutation fires).
- shadow ON + propagate ON → real N-way materialize — **not armed** until the no-false-drop harness is validated on a real library and mobile parity ([parachord-mobile#277](https://github.com/Parachord/parachord-mobile/issues/277)) lands.

## What

- **`sync-engine/nway-reconcile-driver.js`** (pure / injected):
  - `bindProviderToken` — per-cycle token-binding adapter (resolves OQ-2): fills missing write primitives with throwing defaults, then binds the token as the trailing arg so the core/executor/coordinator call providers token-free.
  - `makeStoreEffects` — the core's mutations backed by an injected store; none fire in `dryRun`.
  - `runNwayReconcileCycle` — iterates tracked playlists, one coordinator per cycle, **per-playlist try/catch** so a throttled mirror never aborts the rest (the review's forward-looking note).
- **`main.js`** — the flag helpers, token acquisition, mirror derivation, `runNwayShadowReconcile` (gathers tokens + `remoteLists` from each provider's `fetchPlaylists` — the **authoritative `trackCount`** the partial-fetch floor needs — and runs one cycle), and the `nway:shadow-run` IPC. **No auto-hook into the hot sync path** (intentionally deferred): it runs only when explicitly invoked, so it can never perturb a normal sync.
- **`preload.js`** — `window.electron.nway.shadowRun()` for manual validation.

## Tests (`tests/sync/nway-reconcile-driver.test.js`, 5)

Token binding (trailing-arg + pure `nativeIdOf` + throwing default); store-effects round-trip — shadow computes the plan with **zero writes**, write-mode materializes + advances the baseline + clears `locallyModified`; per-playlist isolation (one throwing playlist → others still converge).

## How to validate (manual, on a real library)

```js
await window.electron.store.set('nway_shadow_enabled', true)   // arm shadow
await window.electron.nway.shadowRun()                          // → { dryRun:true, results:[…would-push plans…], errors:[] }
```
Inspect the `[nway-shadow]` structured logs / returned plan. `nway_propagate` stays OFF — no remote is touched.

## Step 2 complete after this

PR-1 (primitives) · PR-2 (executor) · PR-3 (baseline tiers) · PR-4a (reconcile core + harness + adversarial fixes + missingStreak gate) · **PR-4b (this)**. Remaining before arming `nway_propagate`: the deferred write primitives (`addPlaylistTracks`/`remotePlaylistExists`/`searchForTrackId` on the real providers), an auto-cadence hook, real-library shadow validation, and the mobile parity item.

## Test plan

- [x] `npx jest tests/sync/` → 11 suites, 353 tests green.
- [x] `node --check main.js && node --check preload.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)