### PR TITLE
feat(sync): N-way mobile parity — Sync-channels menu (mirror-only + LB re-export) (#911)

### DIFF
--- a/app.js
+++ b/app.js
@@ -6636,7 +6636,7 @@ const Parachord = () => {
                 // Per-playlist LB re-export opt-in map { localId: ['spotify','applemusic'] }.
                 // A `listenbrainz-*` playlist re-exports to streaming ONLY when the
                 // user opted it into that provider — see the gate in the create branch.
-                const reexportOptIn = await window.electron.store.get('sync_playlist_reexport') || {};
+                const channelOverrides = await window.electron.store.get('sync_playlist_channels') || {};
                 let playlistsChanged = false;
                 // Track which specific playlists mutated so we save only those
                 // at the end. Saving all 142 sequentially used to pinwheel the
@@ -6723,24 +6723,26 @@ const Parachord = () => {
                   const syncInfo = playlist.syncedTo?.[providerId];
 
                   if (!syncInfo) {
-                    // LB RE-EXPORT opt-in (parachord#911, parity with mobile
-                    // ec526bb). SYNC: sync-engine/playlist-push-candidate.js
-                    // isReexportOptInRequired. A `listenbrainz-*` playlist
-                    // (created/edited on ListenBrainz via Achordion) is ELIGIBLE
-                    // to re-export to Spotify / Apple Music, but NEVER auto-mirrors
-                    // — without this gate, enabling Spotify/AM sync would push the
-                    // user's ENTIRE pulled LB library at once (the duplicate-flood
-                    // class). It mirrors only when the user explicitly opted this
-                    // playlist into this provider (the sync_playlist_reexport map,
-                    // set from the playlist's Sync context menu). Already-linked
-                    // playlists (syncedTo[provider]) are NOT gated — they push
-                    // updates via the `else if (locallyModified)` branch.
-                    if (
-                      playlist.id?.startsWith('listenbrainz-')
-                      && (providerId === 'spotify' || providerId === 'applemusic')
-                      && !(reexportOptIn[playlist.id] || []).includes(providerId)
-                    ) {
-                      continue;
+                    // CHANNEL gate (parachord#911). SYNC:
+                    // sync-engine/playlist-push-candidate.js channelGateBlocksCreate.
+                    // A per-playlist channel override is AUTHORITATIVE — sync only
+                    // to the providers the user chose in the Sync menu. With NO
+                    // override, only a `listenbrainz-*` playlist is gated from
+                    // auto-mirroring to streaming (the no-flood opt-in: enabling
+                    // Spotify/AM sync must not push the user's entire pulled LB
+                    // library). Already-linked playlists (syncedTo[provider]) are
+                    // NOT gated here — they push updates via the `else if
+                    // (locallyModified)` branch.
+                    {
+                      const chOverride = channelOverrides[playlist.id];
+                      if (Array.isArray(chOverride)) {
+                        if (!chOverride.includes(providerId)) continue;
+                      } else if (
+                        playlist.id?.startsWith('listenbrainz-')
+                        && (providerId === 'spotify' || providerId === 'applemusic')
+                      ) {
+                        continue;
+                      }
                     }
                     // LB-specific opt-in. Without this gate, enabling LB sync
                     // would auto-create one LB playlist per non-localOnly local
@@ -6786,6 +6788,17 @@ const Parachord = () => {
                     }
                     await breathe();
                   } else if (playlist.locallyModified) {
+                    // CHANNEL gate for the EDIT branch (parachord#911). SYNC:
+                    // sync-engine/playlist-push-candidate.js channelOverrideExcludes.
+                    // An already-linked mirror must STOP receiving edits the moment
+                    // the user excludes its provider from the override — even if a
+                    // detach hasn't landed yet (this cycle snapshotted allPlaylists
+                    // before the user disabled the channel). The override is the
+                    // source of truth; without it, existing mirrors keep syncing.
+                    {
+                      const chOverride = channelOverrides[playlist.id];
+                      if (Array.isArray(chOverride) && !chOverride.includes(providerId)) continue;
+                    }
                     // Playlist exists remotely and has local changes — push updates
                     console.log(`[Sync] Pushing updates for "${playlist.title}" to ${providerId}`);
                     try {
@@ -8078,6 +8091,9 @@ const Parachord = () => {
 
   // Synced playlist delete dialog state
   const [syncDeleteDialog, setSyncDeleteDialog] = useState({ show: false, playlist: null });
+  // "Stop syncing to <service>?" prompt when a user disables a live Sync channel
+  // (parachord#911). { show, playlistId, playlistName, providerId, providerLabel }
+  const [syncChannelDisableDialog, setSyncChannelDisableDialog] = useState({ show: false });
 
   const handleDeleteSyncedPlaylist = async (action) => {
     const playlist = syncDeleteDialog.playlist;
@@ -11163,7 +11179,7 @@ const Parachord = () => {
             const allPlaylists = await window.electron.playlists.load();
             // LB re-export opt-in map — see the gate in the create branch below
             // (in lockstep with the background-sync push loop).
-            const reexportOptIn = await window.electron.store.get('sync_playlist_reexport') || {};
+            const channelOverrides = await window.electron.store.get('sync_playlist_channels') || {};
             let playlistsChanged = false;
             // Track which playlists actually mutated so the save loop only
             // writes those — saving all 142 unconditionally caused the app
@@ -11213,18 +11229,26 @@ const Parachord = () => {
               const syncInfo = playlist.syncedTo?.[providerId];
 
               if (!syncInfo) {
-                // LB RE-EXPORT opt-in (parachord#911) — in lockstep with the
+                // CHANNEL gate (parachord#911) — in lockstep with the
                 // background-sync push loop's identical gate. SYNC:
-                // sync-engine/playlist-push-candidate.js isReexportOptInRequired.
-                // A `listenbrainz-*` playlist re-exports to Spotify/AM ONLY when
-                // the user opted it into that provider; never auto-mirror (would
-                // flood the pulled LB library). Already-linked playlists push
-                // updates via the `else if (locallyModified)` branch.
-                if (
-                  playlist.id?.startsWith('listenbrainz-')
-                  && (providerId === 'spotify' || providerId === 'applemusic')
-                  && !(reexportOptIn[playlist.id] || []).includes(providerId)
-                ) {
+                // sync-engine/playlist-push-candidate.js channelGateBlocksCreate.
+                // A per-playlist channel override is authoritative; with none, a
+                // `listenbrainz-*` playlist is gated from auto-mirroring to
+                // streaming. Already-linked playlists push updates via the
+                // `else if (locallyModified)` branch.
+                let channelBlocked = false;
+                {
+                  const chOverride = channelOverrides[playlist.id];
+                  if (Array.isArray(chOverride)) {
+                    channelBlocked = !chOverride.includes(providerId);
+                  } else if (
+                    playlist.id?.startsWith('listenbrainz-')
+                    && (providerId === 'spotify' || providerId === 'applemusic')
+                  ) {
+                    channelBlocked = true;
+                  }
+                }
+                if (channelBlocked) {
                   continue;
                 }
                 // LB-specific opt-in. Mirrors the background-sync push loop's
@@ -11266,6 +11290,13 @@ const Parachord = () => {
                 }
                 await breathe();
               } else if (playlist.locallyModified) {
+                // CHANNEL gate for the EDIT branch (parachord#911) — lockstep with
+                // the background-sync loop. An already-linked mirror stops getting
+                // edits the moment the user's override excludes its provider.
+                {
+                  const chOverride = channelOverrides[playlist.id];
+                  if (Array.isArray(chOverride) && !chOverride.includes(providerId)) continue;
+                }
                 // Playlist exists remotely and has local changes — push updates
                 console.log(`[Sync] Pushing updates for "${playlist.title}" to ${providerId}`);
                 try {
@@ -15751,14 +15782,35 @@ ${trackListXml}
           // The native playlist context menu toggled the mirror-only (one-way)
           // sync setting (persisted main-side in sync_playlist_mirror_only).
           showToast(data.mirrorOnly ? 'Playlist set to mirror only (one-way)' : 'Playlist mirror-only disabled');
-        } else if (data.action === 'reexport-changed' && data.playlistId) {
-          // The native playlist context menu toggled a ListenBrainz re-export
-          // opt-in (persisted main-side in sync_playlist_reexport). The next
-          // background sync creates/removes the mirror accordingly.
+        } else if (data.action === 'sync-channel-toggle' && data.playlistId) {
+          // The "Sync ▸" submenu toggled where this playlist syncs (parachord#911).
           const label = data.providerLabel || data.providerId;
-          showToast(data.enabled
-            ? `Will mirror this playlist to ${label} on next sync`
-            : `Stopped mirroring this playlist to ${label}`);
+          if (data.enabling) {
+            // Enable: write the channel override; the next sync creates the
+            // mirror. Nothing on the playlist object changes yet, so no reload.
+            await window.electron.sync.setChannel(data.playlistId, data.providerId, true);
+            showToast(`Will sync this playlist to ${label} on next sync`);
+          } else if (data.currentlyMirrored) {
+            // Disabling a LIVE mirror → ask whether to also delete the remote.
+            setSyncChannelDisableDialog({
+              show: true,
+              playlistId: data.playlistId,
+              playlistName: data.name,
+              providerId: data.providerId,
+              providerLabel: label,
+            });
+          } else {
+            // Disabling a channel with no remote yet → just drop it. Reload in
+            // case a mirror landed since the menu opened (detach mutates the row
+            // main-side; reloading prevents a stale renderer save resurrecting it).
+            await window.electron.sync.setChannel(data.playlistId, data.providerId, false);
+            try {
+              const fresh = await window.electron.playlists.load();
+              setPlaylists(fresh);
+              if (selectedPlaylist?.id === data.playlistId) { const u = fresh.find(p => p.id === data.playlistId); if (u) setSelectedPlaylist(u); }
+            } catch {}
+            showToast(`Stopped syncing this playlist to ${label}`);
+          }
         } else if (data.action === 'remove-from-playlist' && data.playlistId !== undefined) {
           // Remove track from playlist
           const trackIndex = data.trackIndex;
@@ -62808,6 +62860,72 @@ useEffect(() => {
               cursor: 'pointer'
             }
           }, 'Cancel')
+        )
+      )
+    ),
+
+    // Sync Channel Disable Dialog — "stop syncing to <service>?" with the
+    // optional "delete from that service too" choice (parachord#911).
+    syncChannelDisableDialog.show && React.createElement('div', {
+      className: 'fixed inset-0 flex items-center justify-center z-[60]',
+      style: { backgroundColor: 'rgba(0, 0, 0, 0.4)', backdropFilter: 'blur(4px)' },
+      onClick: () => setSyncChannelDisableDialog({ show: false })
+    },
+      React.createElement('div', {
+        style: {
+          backgroundColor: 'var(--card-bg)', borderRadius: '16px',
+          boxShadow: '0 4px 24px rgba(0,0,0,0.15), 0 12px 48px rgba(0,0,0,0.1)',
+          maxWidth: '400px', width: '100%', margin: '0 16px', overflow: 'hidden'
+        },
+        onClick: (e) => e.stopPropagation()
+      },
+        React.createElement('div', { className: 'flex flex-col items-center text-center', style: { padding: '32px 24px 20px' } },
+          React.createElement('h3', {
+            style: { fontSize: '16px', fontWeight: '600', color: 'var(--text-primary)', marginBottom: '8px' }
+          }, `Stop syncing to ${syncChannelDisableDialog.providerLabel}?`),
+          React.createElement('p', {
+            style: { fontSize: '13px', color: 'var(--text-secondary)', lineHeight: '1.5' }
+          }, `Keep "${syncChannelDisableDialog.playlistName}" on ${syncChannelDisableDialog.providerLabel} and just stop syncing it, or delete it from ${syncChannelDisableDialog.providerLabel} too?`)
+        ),
+        React.createElement('div', { style: { padding: '4px 24px 24px', display: 'flex', flexDirection: 'column', gap: '8px' } },
+          (() => {
+            const applyDisable = async (deleteRemote) => {
+              const d = syncChannelDisableDialog;
+              setSyncChannelDisableDialog({ show: false });
+              let res = null;
+              try { res = await window.electron.sync.setChannel(d.playlistId, d.providerId, false, { deleteRemote }); } catch {}
+              try {
+                const fresh = await window.electron.playlists.load();
+                setPlaylists(fresh);
+                if (selectedPlaylist?.id === d.playlistId) { const u = fresh.find(p => p.id === d.playlistId); if (u) setSelectedPlaylist(u); }
+              } catch {}
+              const rd = res && res.remoteDelete;
+              if (deleteRemote && rd && rd.deleted === false && rd.reason === 'unsupported') {
+                showToast(`Stopped syncing — remove it from ${d.providerLabel} manually (the app can't delete library playlists there).`, 'info');
+              } else if (deleteRemote && rd && rd.deleted) {
+                showToast(`Stopped syncing and deleted from ${d.providerLabel}`);
+              } else {
+                showToast(`Stopped syncing this playlist to ${d.providerLabel}`);
+              }
+            };
+            return React.createElement(React.Fragment, null,
+              React.createElement('button', {
+                onClick: () => applyDisable(false),
+                className: 'w-full transition-colors',
+                style: { padding: '12px 16px', fontSize: '13px', fontWeight: '500', color: '#ffffff', backgroundColor: '#7c3aed', border: 'none', borderRadius: '10px', cursor: 'pointer' }
+              }, 'Stop Syncing'),
+              React.createElement('button', {
+                onClick: () => applyDisable(true),
+                className: 'w-full transition-colors',
+                style: { padding: '12px 16px', fontSize: '13px', fontWeight: '500', color: '#ffffff', backgroundColor: '#dc2626', border: 'none', borderRadius: '10px', cursor: 'pointer' }
+              }, `Delete from ${syncChannelDisableDialog.providerLabel} too`),
+              React.createElement('button', {
+                onClick: () => setSyncChannelDisableDialog({ show: false }),
+                className: 'w-full transition-colors',
+                style: { padding: '12px 16px', fontSize: '13px', fontWeight: '500', color: 'var(--text-secondary)', backgroundColor: 'transparent', border: '1px solid #e5e7eb', borderRadius: '10px', cursor: 'pointer' }
+              }, 'Cancel')
+            );
+          })()
         )
       )
     ),

--- a/app.js
+++ b/app.js
@@ -15891,7 +15891,12 @@ ${trackListXml}
           // If the playlist mirrors to/from any remote (a synced playlist OR a
           // hosted XSPF mirrored to Spotify/AM), ask whether to delete from those
           // services too. Otherwise just confirm + delete locally.
-          const playlistToDelete = playlists.find(p => p.id === data.playlistId);
+          // NOTE: read the playlist via playlistsRef (NOT the `playlists` closure
+          // var) — this listener's useEffect deps don't include `playlists`, so
+          // the closure is STALE: a stale-undefined lookup is exactly why the
+          // mirror prompt never showed and the hosted-store cleanup was skipped
+          // (deletePlaylistLocally with no sourceUrl → hosted XSPF re-imported).
+          const playlistToDelete = (playlistsRef.current || []).find(p => p.id === data.playlistId);
           const hasMirrors = getPlaylistMirrorTargets(playlistToDelete).length > 0;
           if (hasMirrors) {
             setSyncDeleteDialog({ show: true, playlist: playlistToDelete });
@@ -20332,23 +20337,16 @@ ${trackListXml}
         }
       },
       deletePlaylist: async (playlistId) => {
-        const result = await window.electron.playlists.delete(playlistId);
-        if (result.success) {
-          setPlaylists(prev => prev.filter(p => p.id !== playlistId));
-          delete playlistCoverCache.current[playlistId];
-          setAllPlaylistCovers(prev => {
-            const updated = { ...prev };
-            delete updated[playlistId];
-            return updated;
-          });
-          // Navigate away if viewing this playlist
-          if (selectedPlaylistRef.current?.id === playlistId) {
-            setSelectedPlaylist(null);
-            setPlaylistTracks([]);
-            navigateTo('playlists');
-          }
+        // Use the shared helper so a hosted XSPF is removed from BOTH stores
+        // (else the load+merge re-imports it).
+        const target = (playlistsRef.current || []).find(p => p.id === playlistId) || { id: playlistId };
+        await deletePlaylistLocally(target);
+        if (selectedPlaylistRef.current?.id === playlistId) {
+          setSelectedPlaylist(null);
+          setPlaylistTracks([]);
+          navigateTo('playlists');
         }
-        return result;
+        return { success: true };
       }
     };
 
@@ -43536,9 +43534,9 @@ useEffect(() => {
                   React.createElement('button', {
                     className: 'text-xs px-3 py-1.5 rounded-md bg-red-100 text-red-700 hover:bg-red-200 transition-colors',
                     onClick: async () => {
-                      // Delete locally too
-                      await window.electron.playlists.delete(playlist.id);
-                      setPlaylists(prev => prev.filter(p => p.id !== playlist.id));
+                      // Delete locally too (remote already gone) — via the helper
+                      // so a hosted XSPF is cleared from BOTH stores.
+                      await deletePlaylistLocally(playlist);
                       setSelectedPlaylist(null);
                     }
                   }, 'Delete locally too'),
@@ -44140,21 +44138,17 @@ useEffect(() => {
                 }, `Modified: ${new Date(selectedPlaylist.lastModified).toLocaleDateString()}`),
                 // Delete Playlist button (only in edit mode)
                 playlistEditMode && React.createElement('button', {
-                  onClick: () => {
-                    if (selectedPlaylist.syncedFrom) {
-                      // Synced playlist: show options dialog
+                  onClick: async () => {
+                    // Ask about mirrors when the playlist syncs to/from ANY remote
+                    // (source OR push targets, incl. a hosted XSPF mirrored to
+                    // Spotify/AM) — not just syncedFrom. Otherwise confirm + delete
+                    // locally via the helper that clears BOTH hosted_playlists AND
+                    // local_playlists so it can't be re-imported.
+                    if (getPlaylistMirrorTargets(selectedPlaylist).length > 0) {
                       setSyncDeleteDialog({ show: true, playlist: selectedPlaylist });
                     } else {
-                      // Local playlist: simple confirm
                       if (window.confirm(`Are you sure you want to delete "${selectedPlaylist.title}"? This cannot be undone.`)) {
-                        window.electron.playlists.delete(selectedPlaylist.id);
-                        setPlaylists(prev => prev.filter(p => p.id !== selectedPlaylist.id));
-                        delete playlistCoverCache.current[selectedPlaylist.id];
-                        setAllPlaylistCovers(prev => {
-                          const newCovers = { ...prev };
-                          delete newCovers[selectedPlaylist.id];
-                          return newCovers;
-                        });
+                        await deletePlaylistLocally(selectedPlaylist);
                         setPlaylistEditMode(false);
                         setEditedPlaylistData(null);
                         setSelectedPlaylist(null);

--- a/app.js
+++ b/app.js
@@ -8095,50 +8095,84 @@ const Parachord = () => {
   // (parachord#911). { show, playlistId, playlistName, providerId, providerLabel }
   const [syncChannelDisableDialog, setSyncChannelDisableDialog] = useState({ show: false });
 
+  // The remote services a playlist mirrors to/from (source + push mirrors) that
+  // could be cleaned up on delete. Returns [{ providerId, externalId, role }].
+  const getPlaylistMirrorTargets = (playlist) => {
+    if (!playlist) return [];
+    const out = [];
+    if (playlist.syncedFrom?.resolver && playlist.syncedFrom?.externalId) {
+      out.push({ providerId: playlist.syncedFrom.resolver, externalId: playlist.syncedFrom.externalId, role: 'source' });
+    }
+    for (const [pid, info] of Object.entries(playlist.syncedTo || {})) {
+      if (info?.externalId) out.push({ providerId: pid, externalId: info.externalId, role: 'mirror' });
+    }
+    return out;
+  };
+
+  const PROVIDER_LABEL = { spotify: 'Spotify', applemusic: 'Apple Music', listenbrainz: 'ListenBrainz' };
+
+  // Remove a playlist from ALL local persistence. A hosted XSPF lives in BOTH
+  // the hosted_playlists URL list AND local_playlists (handleImportPlaylistFromUrl
+  // persists it there so sync can pick it up) — removing only one lets the
+  // load+merge re-import it (the "instant recreation" bug). Also drops the
+  // per-playlist sync prefs + state.
+  const deletePlaylistLocally = async (playlist) => {
+    if (!playlist?.id) return;
+    if (playlist.sourceUrl) {
+      try {
+        const hosted = await window.electron?.store?.get('hosted_playlists') || [];
+        const filtered = hosted.filter(hp => hp.id !== playlist.id && hp.url !== playlist.sourceUrl);
+        await window.electron?.store?.set('hosted_playlists', filtered);
+      } catch (e) { console.warn('hosted_playlists cleanup failed:', e); }
+    }
+    try { await window.electron.playlists.delete(playlist.id); } catch (e) { console.warn('local_playlists delete failed:', e); }
+    setPlaylists(prev => prev.filter(p => p.id !== playlist.id));
+    delete playlistCoverCache.current[playlist.id];
+    setAllPlaylistCovers(prev => { const u = { ...prev }; delete u[playlist.id]; return u; });
+  };
+
   const handleDeleteSyncedPlaylist = async (action) => {
     const playlist = syncDeleteDialog.playlist;
     if (!playlist) return;
     setSyncDeleteDialog({ show: false, playlist: null });
 
-    const providerId = playlist.syncedFrom?.resolver;
-    const externalId = playlist.syncedFrom?.externalId;
+    if (action !== 'stop-syncing' && action !== 'delete-from-source') return;
 
-    if (action === 'stop-syncing' || action === 'delete-from-source') {
-      // Suppress future syncs
-      if (providerId && externalId) {
-        await window.electron.playlists.suppressSync(providerId, externalId);
-      }
+    const targets = getPlaylistMirrorTargets(playlist);
 
-      // Delete from source service if requested
-      if (action === 'delete-from-source' && providerId && externalId) {
-        const result = await window.electron.playlists.deleteFromSource(providerId, externalId);
-        if (!result.success) {
-          showConfirmDialog({
-            type: 'error',
-            title: 'Could not delete from source',
-            message: result.error
-          });
+    // Suppress future re-sync of the source so it doesn't reimport.
+    if (playlist.syncedFrom?.resolver && playlist.syncedFrom?.externalId) {
+      await window.electron.playlists.suppressSync(playlist.syncedFrom.resolver, playlist.syncedFrom.externalId);
+    }
+
+    // Delete from every mirror/source if requested (best-effort; surface the
+    // Apple-Music-can't-delete case so the user removes it manually).
+    if (action === 'delete-from-source') {
+      const manual = [];
+      for (const t of targets) {
+        try {
+          const result = await window.electron.playlists.deleteFromSource(t.providerId, t.externalId);
+          if (result && result.success === false) {
+            manual.push(PROVIDER_LABEL[t.providerId] || t.providerId);
+          }
+        } catch (e) {
+          manual.push(PROVIDER_LABEL[t.providerId] || t.providerId);
         }
       }
-
-      // Delete locally
-      await window.electron.playlists.delete(playlist.id);
-      setPlaylists(prev => prev.filter(p => p.id !== playlist.id));
-      delete playlistCoverCache.current[playlist.id];
-      setAllPlaylistCovers(prev => {
-        const newCovers = { ...prev };
-        delete newCovers[playlist.id];
-        return newCovers;
-      });
-
-      // Exit edit mode and navigate back
-      setPlaylistEditMode(false);
-      setEditedPlaylistData(null);
-      setSelectedPlaylist(null);
-      setPlaylistTracks([]);
-      setPlaylistCoverArt([]);
-      navigateTo('playlists');
+      if (manual.length) {
+        showToast(`Deleted locally — remove it manually from ${[...new Set(manual)].join(', ')} (the app can't delete library playlists there).`, 'info');
+      }
     }
+
+    await deletePlaylistLocally(playlist);
+
+    // Exit edit mode and navigate back
+    setPlaylistEditMode(false);
+    setEditedPlaylistData(null);
+    setSelectedPlaylist(null);
+    setPlaylistTracks([]);
+    setPlaylistCoverArt([]);
+    navigateTo('playlists');
   };
 
   const [refreshingPlaylist, setRefreshingPlaylist] = useState(null); // Track which playlist is refreshing
@@ -15854,46 +15888,20 @@ ${trackListXml}
             }));
           }
         } else if (data.action === 'delete-playlist' && data.playlistId) {
-          // Check if this is a synced playlist
+          // If the playlist mirrors to/from any remote (a synced playlist OR a
+          // hosted XSPF mirrored to Spotify/AM), ask whether to delete from those
+          // services too. Otherwise just confirm + delete locally.
           const playlistToDelete = playlists.find(p => p.id === data.playlistId);
-          if (playlistToDelete?.syncedFrom) {
+          const hasMirrors = getPlaylistMirrorTargets(playlistToDelete).length > 0;
+          if (hasMirrors) {
             setSyncDeleteDialog({ show: true, playlist: playlistToDelete });
           } else {
             const confirmed = window.confirm(`Are you sure you want to delete "${data.name}"?`);
             if (confirmed) {
-              const isHosted = data.playlistId.startsWith('hosted-');
-              let deleteSuccess = false;
-
-              if (isHosted) {
-                // Hosted playlists are stored in hosted_playlists URL list, not local_playlists
-                try {
-                  const hostedPlaylists = await window.electron?.store?.get('hosted_playlists') || [];
-                  const filtered = hostedPlaylists.filter(hp => hp.id !== data.playlistId);
-                  await window.electron?.store?.set('hosted_playlists', filtered);
-                  // Also clean up any metadata overrides
-                  console.log(`🗑️ Deleted hosted playlist: ${data.name}`);
-                  deleteSuccess = true;
-                } catch (error) {
-                  console.error('Failed to delete hosted playlist:', error);
-                  alert(`Failed to delete playlist: ${error.message}`);
-                }
-              } else {
-                const result = await window.electron.playlists.delete(data.playlistId);
-                deleteSuccess = result.success;
-                if (!result.success) {
-                  alert(`Failed to delete playlist: ${result.error}`);
-                }
-              }
-
-              if (deleteSuccess) {
-                setPlaylists(prev => prev.filter(p => p.id !== data.playlistId));
-                delete playlistCoverCache.current[data.playlistId];
-                setAllPlaylistCovers(prev => {
-                  const updated = { ...prev };
-                  delete updated[data.playlistId];
-                  return updated;
-                });
-              }
+              // deletePlaylistLocally removes from BOTH hosted_playlists AND
+              // local_playlists, so a hosted XSPF can't be re-imported by the
+              // load+merge (the recreation bug).
+              await deletePlaylistLocally(playlistToDelete || { id: data.playlistId });
             }
           }
         } else if (data.action === 'edit-id3-tags' && data.track) {
@@ -62811,7 +62819,11 @@ useEffect(() => {
           }, `Delete "${syncDeleteDialog.playlist?.title}"?`),
           React.createElement('p', {
             style: { fontSize: '13px', color: 'var(--text-secondary)', lineHeight: '1.5' }
-          }, `This playlist is synced from ${syncDeleteDialog.playlist?.syncedFrom?.resolver === 'spotify' ? 'Spotify' : 'Apple Music'}. What would you like to do?`)
+          }, (() => {
+            const svcs = [...new Set(getPlaylistMirrorTargets(syncDeleteDialog.playlist).map(t => PROVIDER_LABEL[t.providerId] || t.providerId))];
+            const list = svcs.length ? svcs.join(', ') : 'a sync service';
+            return `This playlist is synced with ${list}. What would you like to do?`;
+          })())
         ),
         // Actions
         React.createElement('div', { style: { padding: '4px 24px 24px', display: 'flex', flexDirection: 'column', gap: '8px' } },
@@ -62844,7 +62856,10 @@ useEffect(() => {
               borderRadius: '10px',
               cursor: 'pointer'
             }
-          }, `Delete from ${syncDeleteDialog.playlist?.syncedFrom?.resolver === 'spotify' ? 'Spotify' : 'Apple Music'} too`),
+          }, (() => {
+            const svcs = [...new Set(getPlaylistMirrorTargets(syncDeleteDialog.playlist).map(t => PROVIDER_LABEL[t.providerId] || t.providerId))];
+            return `Delete from ${svcs.length ? svcs.join(', ') : 'the service'} too`;
+          })()),
           // Cancel
           React.createElement('button', {
             onClick: () => setSyncDeleteDialog({ show: false, playlist: null }),

--- a/app.js
+++ b/app.js
@@ -6107,6 +6107,20 @@ const Parachord = () => {
   const [playlistDropTarget, setPlaylistDropTarget] = useState(null); // Index where track will be dropped
   const [playlistEditMode, setPlaylistEditMode] = useState(false); // Edit mode for playlist detail view
   const [editedPlaylistData, setEditedPlaylistData] = useState(null); // Buffered changes: { title, creator, tracks }
+  // Per-playlist "mirror only (one-way)" user flag (parachord#911). Persisted in
+  // electron-store (sync_playlist_mirror_only_<id>), NOT on the playlist row, so
+  // a pull can't clobber it. Loaded for the open playlist; forced ON+locked for
+  // followed/hosted playlists (inherently one-way). See window.electron.nway.
+  const [playlistMirrorOnly, setPlaylistMirrorOnly] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    const id = selectedPlaylist?.id;
+    if (!id || !window.electron?.nway?.getMirrorOnly) { setPlaylistMirrorOnly(false); return; }
+    window.electron.nway.getMirrorOnly(id)
+      .then(v => { if (!cancelled) setPlaylistMirrorOnly(v === true); })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [selectedPlaylist?.id]);
   const [shareDropdownOpen, setShareDropdownOpen] = useState(false); // Share dropdown on album/playlist detail pages
   const [parachordLinkMenu, setParachordLinkMenu] = useState(null); // { x, y, link } — right-click "Copy link" menu
   useEffect(() => {
@@ -44003,7 +44017,33 @@ useEffect(() => {
                       await window.electron.playlists.save(updatedPlaylist);
                       showToast(updatedPlaylist.localOnly ? 'Playlist set to local only' : 'Playlist will sync to services');
                     }
-                  }, selectedPlaylist.localOnly ? 'Local only' : 'Syncing')
+                  }, selectedPlaylist.localOnly ? 'Local only' : 'Syncing'),
+                  // Mirror-only (one-way) toggle (parachord#911). A followed
+                  // (source ends '-import') or hosted-XSPF playlist is INHERENTLY
+                  // one-way → forced ON + locked. An owned playlist is
+                  // user-settable (covers owned-but-dynamic Daily Brews a 3rd-party
+                  // app writes through the user's OAuth).
+                  !selectedPlaylist.localOnly && (() => {
+                    const isHostedXspf = !!selectedPlaylist.sourceUrl;
+                    const isFollowed = typeof selectedPlaylist.source === 'string' && selectedPlaylist.source.endsWith('-import');
+                    const forced = isFollowed || isHostedXspf;
+                    const effective = forced || playlistMirrorOnly;
+                    return React.createElement('button', {
+                      className: `text-xs px-2 py-0.5 rounded-full transition-colors ${
+                        effective ? 'bg-gray-200 text-gray-600' : 'bg-gray-100 text-gray-400 hover:bg-gray-200'
+                      } ${forced ? 'opacity-60 cursor-default' : ''}`,
+                      disabled: forced,
+                      title: forced
+                        ? 'Followed and hosted playlists are inherently one-way — their source is the single authority.'
+                        : 'Mirror only: reconcile as a one-way mirror from the source (rotate-outs drop immediately). Use for owned-but-dynamic playlists (e.g. a SmarterPlaylists Daily Brew).',
+                      onClick: forced ? undefined : async () => {
+                        const next = !playlistMirrorOnly;
+                        setPlaylistMirrorOnly(next);
+                        try { await window.electron.nway.setMirrorOnly(selectedPlaylist.id, next); } catch {}
+                        showToast(next ? 'Playlist set to mirror only (one-way)' : 'Playlist mirror-only disabled');
+                      }
+                    }, effective ? 'Mirror only' : 'Two-way');
+                  })()
                 ),
                 // Edit mode: Title input
                 playlistEditMode && editedPlaylistData && React.createElement('input', {

--- a/app.js
+++ b/app.js
@@ -11122,14 +11122,27 @@ const Parachord = () => {
 
   // Start sync from modal
   const startSync = async () => {
-    const { providerId, settings, selectedPlaylists } = syncSetupModal;
+    const { providerId, settings, selectedPlaylists, playlists } = syncSetupModal;
 
-    // Save settings first
+    // Save settings first. setProvider also UN-suppresses every re-selected
+    // playlist (so re-ticking undoes a prior exclusion).
     await window.electron.syncSettings.setProvider(providerId, {
       enabled: true,
       ...settings,
       selectedPlaylistIds: selectedPlaylists
     });
+
+    // ListenBrainz imports ALL by default (#911), so the wizard's selection is an
+    // EXCLUDE list: any fetched LB playlist the user UN-ticked is suppressed (the
+    // import filter skips suppressed). Ticked ones were un-suppressed above.
+    if (providerId === 'listenbrainz' && settings.syncPlaylists && Array.isArray(playlists)) {
+      const checked = new Set(selectedPlaylists || []);
+      for (const p of playlists) {
+        if (p && p.externalId && !checked.has(p.externalId)) {
+          try { await window.electron.playlists.suppressSync('listenbrainz', p.externalId); } catch {}
+        }
+      }
+    }
 
     // Also update the React-state mirror of these settings. Without this, the
     // background-sync push loop (which reads from `resolverSyncSettingsRef.current`)
@@ -63428,10 +63441,24 @@ useEffect(() => {
                   setSyncSetupModal(prev => ({ ...prev, step: 'playlists', error: null }));
                   const result = await window.electron.sync.fetchPlaylists(syncSetupModal.providerId);
                   if (result.success) {
+                    // ListenBrainz imports ALL playlists by default (#911), so
+                    // pre-check every fetched playlist EXCEPT already-suppressed
+                    // ones — unticking is what EXCLUDES (suppresses) a playlist,
+                    // ticking re-includes it. Spotify/AM keep their seeded
+                    // (relationship-based) selection.
+                    let lbPreselect = null;
+                    if (syncSetupModal.providerId === 'listenbrainz') {
+                      const suppMap = await window.electron.store.get('suppressed_sync_playlists').catch(() => null);
+                      const supp = (suppMap && suppMap.listenbrainz) || [];
+                      lbPreselect = (result.playlists || [])
+                        .map(p => p.externalId)
+                        .filter(id => !supp.includes(id));
+                    }
                     setSyncSetupModal(prev => ({
                       ...prev,
                       playlists: result.playlists,
-                      folders: result.folders
+                      folders: result.folders,
+                      ...(lbPreselect ? { selectedPlaylists: lbPreselect } : {})
                     }));
                   } else {
                     // Handle failed playlist fetch - show error and go back to options

--- a/app.js
+++ b/app.js
@@ -6633,6 +6633,10 @@ const Parachord = () => {
               playlistSyncInProgressRef.current.add(providerId);
               try {
                 const allPlaylists = await window.electron.playlists.load();
+                // Per-playlist LB re-export opt-in map { localId: ['spotify','applemusic'] }.
+                // A `listenbrainz-*` playlist re-exports to streaming ONLY when the
+                // user opted it into that provider — see the gate in the create branch.
+                const reexportOptIn = await window.electron.store.get('sync_playlist_reexport') || {};
                 let playlistsChanged = false;
                 // Track which specific playlists mutated so we save only those
                 // at the end. Saving all 142 sequentially used to pinwheel the
@@ -6719,6 +6723,25 @@ const Parachord = () => {
                   const syncInfo = playlist.syncedTo?.[providerId];
 
                   if (!syncInfo) {
+                    // LB RE-EXPORT opt-in (parachord#911, parity with mobile
+                    // ec526bb). SYNC: sync-engine/playlist-push-candidate.js
+                    // isReexportOptInRequired. A `listenbrainz-*` playlist
+                    // (created/edited on ListenBrainz via Achordion) is ELIGIBLE
+                    // to re-export to Spotify / Apple Music, but NEVER auto-mirrors
+                    // — without this gate, enabling Spotify/AM sync would push the
+                    // user's ENTIRE pulled LB library at once (the duplicate-flood
+                    // class). It mirrors only when the user explicitly opted this
+                    // playlist into this provider (the sync_playlist_reexport map,
+                    // set from the playlist's Sync context menu). Already-linked
+                    // playlists (syncedTo[provider]) are NOT gated — they push
+                    // updates via the `else if (locallyModified)` branch.
+                    if (
+                      playlist.id?.startsWith('listenbrainz-')
+                      && (providerId === 'spotify' || providerId === 'applemusic')
+                      && !(reexportOptIn[playlist.id] || []).includes(providerId)
+                    ) {
+                      continue;
+                    }
                     // LB-specific opt-in. Without this gate, enabling LB sync
                     // would auto-create one LB playlist per non-localOnly local
                     // playlist on first run — potentially 100+ private LB
@@ -11138,6 +11161,9 @@ const Parachord = () => {
           playlistSyncInProgressRef.current.add(providerId);
           try {
             const allPlaylists = await window.electron.playlists.load();
+            // LB re-export opt-in map — see the gate in the create branch below
+            // (in lockstep with the background-sync push loop).
+            const reexportOptIn = await window.electron.store.get('sync_playlist_reexport') || {};
             let playlistsChanged = false;
             // Track which playlists actually mutated so the save loop only
             // writes those — saving all 142 unconditionally caused the app
@@ -11187,6 +11213,20 @@ const Parachord = () => {
               const syncInfo = playlist.syncedTo?.[providerId];
 
               if (!syncInfo) {
+                // LB RE-EXPORT opt-in (parachord#911) — in lockstep with the
+                // background-sync push loop's identical gate. SYNC:
+                // sync-engine/playlist-push-candidate.js isReexportOptInRequired.
+                // A `listenbrainz-*` playlist re-exports to Spotify/AM ONLY when
+                // the user opted it into that provider; never auto-mirror (would
+                // flood the pulled LB library). Already-linked playlists push
+                // updates via the `else if (locallyModified)` branch.
+                if (
+                  playlist.id?.startsWith('listenbrainz-')
+                  && (providerId === 'spotify' || providerId === 'applemusic')
+                  && !(reexportOptIn[playlist.id] || []).includes(providerId)
+                ) {
+                  continue;
+                }
                 // LB-specific opt-in. Mirrors the background-sync push loop's
                 // gate (see comment at L~6357) — must stay in lockstep with it
                 // per CLAUDE.md ("Push-loop syncedFrom guard must be
@@ -15711,6 +15751,14 @@ ${trackListXml}
           // The native playlist context menu toggled the mirror-only (one-way)
           // sync setting (persisted main-side in sync_playlist_mirror_only).
           showToast(data.mirrorOnly ? 'Playlist set to mirror only (one-way)' : 'Playlist mirror-only disabled');
+        } else if (data.action === 'reexport-changed' && data.playlistId) {
+          // The native playlist context menu toggled a ListenBrainz re-export
+          // opt-in (persisted main-side in sync_playlist_reexport). The next
+          // background sync creates/removes the mirror accordingly.
+          const label = data.providerLabel || data.providerId;
+          showToast(data.enabled
+            ? `Will mirror this playlist to ${label} on next sync`
+            : `Stopped mirroring this playlist to ${label}`);
         } else if (data.action === 'remove-from-playlist' && data.playlistId !== undefined) {
           // Remove track from playlist
           const trackIndex = data.trackIndex;

--- a/app.js
+++ b/app.js
@@ -44017,18 +44017,25 @@ useEffect(() => {
                       await window.electron.playlists.save(updatedPlaylist);
                       showToast(updatedPlaylist.localOnly ? 'Playlist set to local only' : 'Playlist will sync to services');
                     }
-                  }, selectedPlaylist.localOnly ? 'Local only' : 'Syncing'),
-                  // Mirror-only (one-way) toggle (parachord#911). A followed
-                  // (source ends '-import') or hosted-XSPF playlist is INHERENTLY
-                  // one-way → forced ON + locked. An owned playlist is
-                  // user-settable (covers owned-but-dynamic Daily Brews a 3rd-party
-                  // app writes through the user's OAuth).
-                  !selectedPlaylist.localOnly && (() => {
-                    const isHostedXspf = !!selectedPlaylist.sourceUrl;
-                    const isFollowed = typeof selectedPlaylist.source === 'string' && selectedPlaylist.source.endsWith('-import');
-                    const forced = isFollowed || isHostedXspf;
-                    const effective = forced || playlistMirrorOnly;
-                    return React.createElement('button', {
+                  }, selectedPlaylist.localOnly ? 'Local only' : 'Syncing')
+                ),
+                // Mirror-only (one-way) chip (parachord#911). Rendered for ANY
+                // sync-participating playlist — followed (its `source` ends
+                // '-import'), owned-pushed (syncedTo), or hosted-XSPF (sourceUrl).
+                // A followed or hosted playlist is INHERENTLY one-way (its source
+                // is the single authority) → shown ON + LOCKED. An owned playlist
+                // is user-settable (covers owned-but-dynamic Daily Brews a 3rd-
+                // party app writes through the user's OAuth, which the provider
+                // reports as user-owned). Mirrors main.js's writability signal.
+                (() => {
+                  const hasSyncRel = !!(selectedPlaylist.syncedFrom || selectedPlaylist.syncedTo || selectedPlaylist.sourceUrl);
+                  if (!hasSyncRel || selectedPlaylist.localOnly) return null;
+                  const isHostedXspf = !!selectedPlaylist.sourceUrl;
+                  const isFollowed = typeof selectedPlaylist.source === 'string' && selectedPlaylist.source.endsWith('-import');
+                  const forced = isFollowed || isHostedXspf;
+                  const effective = forced || playlistMirrorOnly;
+                  return React.createElement('div', { className: 'flex items-center gap-2 mt-1' },
+                    React.createElement('button', {
                       className: `text-xs px-2 py-0.5 rounded-full transition-colors ${
                         effective ? 'bg-gray-200 text-gray-600' : 'bg-gray-100 text-gray-400 hover:bg-gray-200'
                       } ${forced ? 'opacity-60 cursor-default' : ''}`,
@@ -44042,9 +44049,12 @@ useEffect(() => {
                         try { await window.electron.nway.setMirrorOnly(selectedPlaylist.id, next); } catch {}
                         showToast(next ? 'Playlist set to mirror only (one-way)' : 'Playlist mirror-only disabled');
                       }
-                    }, effective ? 'Mirror only' : 'Two-way');
-                  })()
-                ),
+                    }, effective ? 'Mirror only' : 'Two-way'),
+                    forced && React.createElement('span', {
+                      className: 'text-xs', style: { color: 'var(--text-tertiary)' }
+                    }, isHostedXspf ? 'Hosted — one-way' : 'Followed — one-way')
+                  );
+                })(),
                 // Edit mode: Title input
                 playlistEditMode && editedPlaylistData && React.createElement('input', {
                   type: 'text',

--- a/app.js
+++ b/app.js
@@ -6107,20 +6107,6 @@ const Parachord = () => {
   const [playlistDropTarget, setPlaylistDropTarget] = useState(null); // Index where track will be dropped
   const [playlistEditMode, setPlaylistEditMode] = useState(false); // Edit mode for playlist detail view
   const [editedPlaylistData, setEditedPlaylistData] = useState(null); // Buffered changes: { title, creator, tracks }
-  // Per-playlist "mirror only (one-way)" user flag (parachord#911). Persisted in
-  // electron-store (sync_playlist_mirror_only_<id>), NOT on the playlist row, so
-  // a pull can't clobber it. Loaded for the open playlist; forced ON+locked for
-  // followed/hosted playlists (inherently one-way). See window.electron.nway.
-  const [playlistMirrorOnly, setPlaylistMirrorOnly] = useState(false);
-  useEffect(() => {
-    let cancelled = false;
-    const id = selectedPlaylist?.id;
-    if (!id || !window.electron?.nway?.getMirrorOnly) { setPlaylistMirrorOnly(false); return; }
-    window.electron.nway.getMirrorOnly(id)
-      .then(v => { if (!cancelled) setPlaylistMirrorOnly(v === true); })
-      .catch(() => {});
-    return () => { cancelled = true; };
-  }, [selectedPlaylist?.id]);
   const [shareDropdownOpen, setShareDropdownOpen] = useState(false); // Share dropdown on album/playlist detail pages
   const [parachordLinkMenu, setParachordLinkMenu] = useState(null); // { x, y, link } — right-click "Copy link" menu
   useEffect(() => {
@@ -15721,6 +15707,10 @@ ${trackListXml}
             sourceType: data.sourceType || 'track'
           });
           setSelectedPlaylistsForAdd([]); // Reset selection
+        } else if (data.action === 'mirror-only-changed' && data.playlistId) {
+          // The native playlist context menu toggled the mirror-only (one-way)
+          // sync setting (persisted main-side in sync_playlist_mirror_only).
+          showToast(data.mirrorOnly ? 'Playlist set to mirror only (one-way)' : 'Playlist mirror-only disabled');
         } else if (data.action === 'remove-from-playlist' && data.playlistId !== undefined) {
           // Remove track from playlist
           const trackIndex = data.trackIndex;
@@ -44019,42 +44009,6 @@ useEffect(() => {
                     }
                   }, selectedPlaylist.localOnly ? 'Local only' : 'Syncing')
                 ),
-                // Mirror-only (one-way) chip (parachord#911). Rendered for ANY
-                // sync-participating playlist — followed (its `source` ends
-                // '-import'), owned-pushed (syncedTo), or hosted-XSPF (sourceUrl).
-                // A followed or hosted playlist is INHERENTLY one-way (its source
-                // is the single authority) → shown ON + LOCKED. An owned playlist
-                // is user-settable (covers owned-but-dynamic Daily Brews a 3rd-
-                // party app writes through the user's OAuth, which the provider
-                // reports as user-owned). Mirrors main.js's writability signal.
-                (() => {
-                  const hasSyncRel = !!(selectedPlaylist.syncedFrom || selectedPlaylist.syncedTo || selectedPlaylist.sourceUrl);
-                  if (!hasSyncRel || selectedPlaylist.localOnly) return null;
-                  const isHostedXspf = !!selectedPlaylist.sourceUrl;
-                  const isFollowed = typeof selectedPlaylist.source === 'string' && selectedPlaylist.source.endsWith('-import');
-                  const forced = isFollowed || isHostedXspf;
-                  const effective = forced || playlistMirrorOnly;
-                  return React.createElement('div', { className: 'flex items-center gap-2 mt-1' },
-                    React.createElement('button', {
-                      className: `text-xs px-2 py-0.5 rounded-full transition-colors ${
-                        effective ? 'bg-gray-200 text-gray-600' : 'bg-gray-100 text-gray-400 hover:bg-gray-200'
-                      } ${forced ? 'opacity-60 cursor-default' : ''}`,
-                      disabled: forced,
-                      title: forced
-                        ? 'Followed and hosted playlists are inherently one-way — their source is the single authority.'
-                        : 'Mirror only: reconcile as a one-way mirror from the source (rotate-outs drop immediately). Use for owned-but-dynamic playlists (e.g. a SmarterPlaylists Daily Brew).',
-                      onClick: forced ? undefined : async () => {
-                        const next = !playlistMirrorOnly;
-                        setPlaylistMirrorOnly(next);
-                        try { await window.electron.nway.setMirrorOnly(selectedPlaylist.id, next); } catch {}
-                        showToast(next ? 'Playlist set to mirror only (one-way)' : 'Playlist mirror-only disabled');
-                      }
-                    }, effective ? 'Mirror only' : 'Two-way'),
-                    forced && React.createElement('span', {
-                      className: 'text-xs', style: { color: 'var(--text-tertiary)' }
-                    }, isHostedXspf ? 'Hosted — one-way' : 'Followed — one-way')
-                  );
-                })(),
                 // Edit mode: Title input
                 playlistEditMode && editedPlaylistData && React.createElement('input', {
                   type: 'text',

--- a/main.js
+++ b/main.js
@@ -4626,8 +4626,42 @@ ipcMain.handle('show-track-context-menu', async (event, data) => {
     });
   }
 
-  // Add delete option for playlists
+  // Add sync + delete options for playlists
   if (data.type === 'playlist' && data.playlistId) {
+    // Mirror-only (one-way) sync setting (parachord#911 / parachord-mobile#277).
+    // Only for sync-participating playlists. A FOLLOWED ('-import' source) or
+    // hosted-XSPF playlist is INHERENTLY one-way (its source is the single
+    // authority) → shown checked + DISABLED (locked). An OWNED playlist is
+    // user-settable — covers owned-but-dynamic playlists a 3rd-party app
+    // (e.g. SmarterPlaylists) rebuilds through the user's OAuth, which the
+    // provider reports as user-owned.
+    const pl = (store.get('local_playlists') || []).find(p => p.id === data.playlistId);
+    if (pl && (pl.syncedFrom || pl.syncedTo || pl.sourceUrl) && !pl.localOnly) {
+      const isHostedXspf = !!pl.sourceUrl;
+      const isFollowed = typeof pl.source === 'string' && pl.source.endsWith('-import');
+      const forced = isFollowed || isHostedXspf;
+      const effective = forced || getPlaylistMirrorOnly(data.playlistId);
+      menuItems.push({ type: 'separator' });
+      menuItems.push({
+        label: forced
+          ? (isHostedXspf ? 'Mirror only (one-way · hosted)' : 'Mirror only (one-way · followed)')
+          : 'Mirror only (one-way)',
+        type: 'checkbox',
+        checked: effective,
+        enabled: !forced, // locked on for followed/hosted — inherently one-way
+        click: () => {
+          const next = !getPlaylistMirrorOnly(data.playlistId);
+          setPlaylistMirrorOnly(data.playlistId, next);
+          safeSendToRenderer('track-context-menu-action', {
+            action: 'mirror-only-changed',
+            playlistId: data.playlistId,
+            name: data.name,
+            mirrorOnly: next
+          });
+        }
+      });
+    }
+
     menuItems.push({ type: 'separator' });
     menuItems.push({
       label: 'Delete Playlist',
@@ -5427,11 +5461,6 @@ function setPlaylistMirrorOnly(localPlaylistId, value) {
   else delete map[localPlaylistId];
   store.set('sync_playlist_mirror_only', map);
 }
-ipcMain.handle('nway:get-mirror-only', async (event, localPlaylistId) => getPlaylistMirrorOnly(localPlaylistId));
-ipcMain.handle('nway:set-mirror-only', async (event, localPlaylistId, value) => {
-  setPlaylistMirrorOnly(localPlaylistId, value === true);
-  return { success: true, mirrorOnly: getPlaylistMirrorOnly(localPlaylistId) };
-});
 
 // Desktop's owned-vs-followed (writable) signal for a playlist's pull source —
 // the equivalent of mobile's `playlist.writable` (#269). Followed/read-only

--- a/main.js
+++ b/main.js
@@ -6826,6 +6826,27 @@ ipcMain.handle('sync-settings:set-provider', async (event, providerId, providerS
     const settings = store.get('resolver_sync_settings') || {};
     settings[providerId] = providerSettings;
     store.set('resolver_sync_settings', settings);
+
+    // Re-SELECTING a playlist in the sync wizard is an unambiguous "sync this
+    // again" — so clear it from the suppression list (which the import filter
+    // also checks). Without this there is NO UI path to undo a suppression: a
+    // playlist deleted with "Stop syncing" stays hidden forever even after the
+    // user re-ticks it. (parachord#911 — surfaced by "deleted LB playlist won't
+    // come back".)
+    const selectedIds = Array.isArray(providerSettings && providerSettings.selectedPlaylistIds)
+      ? providerSettings.selectedPlaylistIds
+      : null;
+    if (selectedIds && selectedIds.length) {
+      const suppressed = store.get('suppressed_sync_playlists') || {};
+      const list = Array.isArray(suppressed[providerId]) ? suppressed[providerId] : [];
+      const selectedSet = new Set(selectedIds);
+      const pruned = list.filter(id => !selectedSet.has(id));
+      if (pruned.length !== list.length) {
+        suppressed[providerId] = pruned;
+        store.set('suppressed_sync_playlists', suppressed);
+        console.log(`[Sync] Un-suppressed ${list.length - pruned.length} re-selected ${providerId} playlist(s)`);
+      }
+    }
     return { success: true };
   } catch (error) {
     console.error('  ❌ Set provider sync settings failed:', error.message);

--- a/main.js
+++ b/main.js
@@ -4628,6 +4628,8 @@ ipcMain.handle('show-track-context-menu', async (event, data) => {
 
   // Add sync + delete options for playlists
   if (data.type === 'playlist' && data.playlistId) {
+    const pl = (store.get('local_playlists') || []).find(p => p.id === data.playlistId);
+
     // Mirror-only (one-way) sync setting (parachord#911 / parachord-mobile#277).
     // Only for sync-participating playlists. A FOLLOWED ('-import' source) or
     // hosted-XSPF playlist is INHERENTLY one-way (its source is the single
@@ -4635,7 +4637,6 @@ ipcMain.handle('show-track-context-menu', async (event, data) => {
     // user-settable — covers owned-but-dynamic playlists a 3rd-party app
     // (e.g. SmarterPlaylists) rebuilds through the user's OAuth, which the
     // provider reports as user-owned.
-    const pl = (store.get('local_playlists') || []).find(p => p.id === data.playlistId);
     if (pl && (pl.syncedFrom || pl.syncedTo || pl.sourceUrl) && !pl.localOnly) {
       const isHostedXspf = !!pl.sourceUrl;
       const isFollowed = typeof pl.source === 'string' && pl.source.endsWith('-import');
@@ -4660,6 +4661,35 @@ ipcMain.handle('show-track-context-menu', async (event, data) => {
           });
         }
       });
+    }
+
+    // LB RE-EXPORT opt-in (parachord#911 / parachord-mobile ec526bb). A
+    // `listenbrainz-*` playlist (created/edited on ListenBrainz via Achordion)
+    // can be mirrored to Spotify / Apple Music — but ONLY by explicit opt-in
+    // here; it never auto-mirrors, so a pulled LB library can't flood streaming.
+    // Each toggle writes the sync_playlist_reexport map the push loops read.
+    if (pl && !pl.localOnly && data.playlistId.startsWith('listenbrainz-')) {
+      const optedIn = getPlaylistReexport(data.playlistId);
+      menuItems.push({ type: 'separator' });
+      for (const [pid, label] of [['spotify', 'Spotify'], ['applemusic', 'Apple Music']]) {
+        menuItems.push({
+          label: `Mirror to ${label}`,
+          type: 'checkbox',
+          checked: optedIn.includes(pid),
+          click: () => {
+            const next = !getPlaylistReexport(data.playlistId).includes(pid);
+            setPlaylistReexport(data.playlistId, pid, next);
+            safeSendToRenderer('track-context-menu-action', {
+              action: 'reexport-changed',
+              playlistId: data.playlistId,
+              name: data.name,
+              providerId: pid,
+              providerLabel: label,
+              enabled: next
+            });
+          }
+        });
+      }
     }
 
     menuItems.push({ type: 'separator' });
@@ -5424,6 +5454,36 @@ function removePlaylistSyncState(localPlaylistId, providerId) {
 ipcMain.handle('sync-state:get-all', async () => getSyncStates());
 ipcMain.handle('sync-state:get', async (event, localPlaylistId) => getPlaylistSyncState(localPlaylistId));
 
+// Per-playlist LB RE-EXPORT opt-in (parachord#911, parity with mobile ec526bb).
+// `sync_playlist_reexport = { [localPlaylistId]: ['spotify','applemusic'] }` —
+// the streaming providers a `listenbrainz-*` playlist has been EXPLICITLY opted
+// into for re-export. Its own electron-store map (pull-safe; not a playlist row
+// field). Read by the renderer push loops' opt-in gate; written from the
+// playlist's Sync context menu. Absent/empty → never auto-mirrors (the flood
+// guard); only the providers in the list are pushed.
+// The pure opt-in predicate (parity anchor) — shared by the renderer push-loop
+// gates (inlined there) and the main-process side-doors (relinkOrphansFor + the
+// create gateway) so the flood guard is byte-consistent everywhere.
+const { isReexportOptInRequired } = require('./sync-engine/playlist-push-candidate');
+
+function getReexportMap() {
+  const m = store.get('sync_playlist_reexport');
+  return m && typeof m === 'object' ? m : {};
+}
+function getPlaylistReexport(localPlaylistId) {
+  const v = getReexportMap()[localPlaylistId];
+  return Array.isArray(v) ? v : [];
+}
+function setPlaylistReexport(localPlaylistId, providerId, enabled) {
+  if (!localPlaylistId || !providerId) return;
+  const map = getReexportMap();
+  const set = new Set(Array.isArray(map[localPlaylistId]) ? map[localPlaylistId] : []);
+  if (enabled) set.add(providerId); else set.delete(providerId);
+  if (set.size) map[localPlaylistId] = [...set];
+  else delete map[localPlaylistId];
+  store.set('sync_playlist_reexport', map);
+}
+
 // ── N-way reconcile driver wiring (parachord#911, Step 2 / PR-4b) ──────
 // DORMANT by default. The pure reconcile engine (sync-engine/playlist-
 // reconcile.js, unit-tested by the no-false-drop harness) is run here over the
@@ -5875,7 +5935,16 @@ function relinkOrphansFor(providerId, ownedRemote) {
   const orphans = localPlaylists.filter(p =>
     !p.localOnly &&
     !isLinked(p) &&
-    (p.tracks?.length || 0) > 0
+    (p.tracks?.length || 0) > 0 &&
+    // LB RE-EXPORT flood guard (parachord#911) — a side-door twin of the push
+    // loops' create-branch gate. relinkOrphansFor name-matches an orphan to an
+    // owned remote and writes syncedTo + locallyModified, which then re-exports
+    // via the (un-gated) `locallyModified` push branch. So a `listenbrainz-*`
+    // playlist the user has NOT opted into this streaming provider must NOT be a
+    // relink candidate — otherwise a same-named owned Spotify/AM playlist would
+    // auto-link + flood the user's pulled LB library. Uses the SAME predicate +
+    // map as the push-loop gate, so opted-in LB playlists still relink.
+    !(isReexportOptInRequired(p, providerId) && !getPlaylistReexport(p.id).includes(providerId))
   );
 
   const orphansByName = new Map();
@@ -7657,6 +7726,22 @@ ipcMain.handle('sync:push-playlist', async (event, providerId, playlistExternalI
 
     if (!provider.createPlaylist) {
       return { success: false, error: 'Provider does not support creating playlists' };
+    }
+
+    // LB RE-EXPORT flood guard (defense-in-depth, parachord#911). This gateway
+    // is the single create/link chokepoint; the renderer push loops already gate
+    // before calling it, but enforcing the opt-in HERE too means no future
+    // caller (or side-door) can re-export a `listenbrainz-*` playlist to a
+    // streaming service without the user explicitly opting it in
+    // (sync_playlist_reexport). Safe: the loops only reach this for opted-in LB
+    // or non-LB playlists, so it never false-blocks a legitimate create.
+    if (
+      localPlaylistId
+      && isReexportOptInRequired({ id: localPlaylistId }, providerId)
+      && !getPlaylistReexport(localPlaylistId).includes(providerId)
+    ) {
+      console.warn(`[Sync] Blocked un-opted ListenBrainz re-export of "${name}" to ${providerId}`);
+      return { success: false, error: 'reexport-not-opted-in' };
     }
 
     let token;

--- a/main.js
+++ b/main.js
@@ -5407,6 +5407,43 @@ ipcMain.handle('sync-state:get', async (event, localPlaylistId) => getPlaylistSy
 function isNwayShadowEnabled() { return store.get('nway_shadow_enabled') === true; }
 function isNwayPropagateEnabled() { return store.get('nway_propagate') === true; }
 
+// Per-playlist MIRROR-ONLY flag (parachord#911 / parachord-mobile#277). When
+// set, the playlist is reconciled as a ONE-WAY mirror FROM its source: the
+// source is single-authority and its rotate-out drops IMMEDIATELY (no
+// missingStreak gate), exactly like a followed playlist — for OWNED-but-dynamic
+// playlists the source-writability split alone can't catch (e.g. a
+// SmarterPlaylists-managed Daily Brew the provider reports as user-owned).
+// Stored in its OWN electron-store map (parallel to sync_playlist_links /
+// sync_playlist_state), NOT on the playlist row — a pull refreshes the playlist
+// (and its owned/followed signal) and must NEVER clobber the user's intent.
+function getMirrorOnlyMap() { return store.get('sync_playlist_mirror_only') || {}; }
+function getPlaylistMirrorOnly(localPlaylistId) {
+  return getMirrorOnlyMap()[localPlaylistId] === true;
+}
+function setPlaylistMirrorOnly(localPlaylistId, value) {
+  if (!localPlaylistId) return;
+  const map = getMirrorOnlyMap();
+  if (value) map[localPlaylistId] = true;
+  else delete map[localPlaylistId];
+  store.set('sync_playlist_mirror_only', map);
+}
+ipcMain.handle('nway:get-mirror-only', async (event, localPlaylistId) => getPlaylistMirrorOnly(localPlaylistId));
+ipcMain.handle('nway:set-mirror-only', async (event, localPlaylistId, value) => {
+  setPlaylistMirrorOnly(localPlaylistId, value === true);
+  return { success: true, mirrorOnly: getPlaylistMirrorOnly(localPlaylistId) };
+});
+
+// Desktop's owned-vs-followed (writable) signal for a playlist's pull source —
+// the equivalent of mobile's `playlist.writable` (#269). Followed/read-only
+// imports stamp `source: <provider>-import`; owned imports + user-created
+// playlists are writable. (The import path at sync:start sets this from
+// remotePlaylist.isOwnedByUser.)
+function isPlaylistWritable(playlist) {
+  const src = playlist && playlist.source;
+  if (typeof src === 'string' && src.endsWith('-import')) return false;
+  return true;
+}
+
 async function getNwayProviderToken(providerId) {
   if (providerId === 'spotify') return await ensureValidSpotifyToken();
   if (providerId === 'applemusic') {
@@ -5445,8 +5482,16 @@ async function runNwayShadowReconcile() {
   const now = Date.now();
   const states = getSyncStates();
   const playlists = store.get('local_playlists') || [];
+  // CLEAN store of rows — the effects read+persist these, so they must NOT carry
+  // the derived `writable` (it's a per-cycle computed signal, never a row field).
   const playlistById = new Map(playlists.map((p) => [p.id, p]));
   const mirrorsOf = (localId) => nwayMirrorsOf(playlistById.get(localId));
+  // The reconcile reads `playlist.writable` (owned vs followed → immediate
+  // authority); attach it ONLY to the per-cycle copy handed to the engine.
+  const reconcileGetPlaylist = (localId) => {
+    const p = playlistById.get(localId);
+    return p ? { ...p, writable: isPlaylistWritable(p) } : null;
+  };
 
   // Which providers are referenced by any tracked playlist's mirrors?
   const neededProviders = new Set();
@@ -5507,7 +5552,7 @@ async function runNwayShadowReconcile() {
 
   const out = await runNwayReconcileCycle({
     states: runnableStates,
-    getPlaylist: storeAbstraction.getPlaylist,
+    getPlaylist: reconcileGetPlaylist, // carries the derived `writable`
     getMirrors: mirrorsOf,
     boundProviders,
     remoteLists,
@@ -5517,6 +5562,7 @@ async function runNwayShadowReconcile() {
         ? { providerId: pl.syncedFrom.resolver, externalId: pl.syncedFrom.externalId }
         : null;
     },
+    getMirrorOnly: (localId) => getPlaylistMirrorOnly(localId),
     cache,
     effects: makeStoreEffects(storeAbstraction),
     now,

--- a/main.js
+++ b/main.js
@@ -4630,26 +4630,53 @@ ipcMain.handle('show-track-context-menu', async (event, data) => {
   if (data.type === 'playlist' && data.playlistId) {
     const pl = (store.get('local_playlists') || []).find(p => p.id === data.playlistId);
 
-    // Mirror-only (one-way) sync setting (parachord#911 / parachord-mobile#277).
-    // Only for sync-participating playlists. A FOLLOWED ('-import' source) or
-    // hosted-XSPF playlist is INHERENTLY one-way (its source is the single
-    // authority) → shown checked + DISABLED (locked). An OWNED playlist is
-    // user-settable — covers owned-but-dynamic playlists a 3rd-party app
-    // (e.g. SmarterPlaylists) rebuilds through the user's OAuth, which the
-    // provider reports as user-owned.
-    if (pl && (pl.syncedFrom || pl.syncedTo || pl.sourceUrl) && !pl.localOnly) {
+    // "Sync ▸" submenu (parachord#911, parity with mobile's PlaylistSyncChannels
+    // sheet) — manually choose WHERE this playlist syncs, plus the one-way
+    // "Mirror only" toggle. One channel toggle per available provider; toggling
+    // writes the per-playlist channel override (authoritative). "Mirror only"
+    // sits at the bottom, locked-on for followed/hosted (inherently one-way).
+    if (pl && !pl.localOnly) {
+      const channels = getPlaylistSyncChannelsForMenu(pl).filter(c => c.available);
       const isHostedXspf = !!pl.sourceUrl;
       const isFollowed = typeof pl.source === 'string' && pl.source.endsWith('-import');
-      const forced = isFollowed || isHostedXspf;
-      const effective = forced || getPlaylistMirrorOnly(data.playlistId);
-      menuItems.push({ type: 'separator' });
-      menuItems.push({
-        label: forced
+      const mirrorForced = isFollowed || isHostedXspf;
+      const mirrorEffective = mirrorForced || getPlaylistMirrorOnly(data.playlistId);
+
+      const submenu = channels.map(ch => {
+        // Source-only channels (the playlist's pull source) are shown checked
+        // but LOCKED — detaching a pull source is a "Delete playlist" concern,
+        // not a channel toggle. Push targets are togglable when connected.
+        const togglable = ch.connected && ch.pushTarget;
+        const label = ch.isSource && !ch.pushTarget
+          ? `${ch.displayName} (source)`
+          : (ch.connected ? ch.displayName : `${ch.displayName} (connect in Settings)`);
+        return {
+          label,
+          type: 'checkbox',
+          checked: ch.enabled,
+          enabled: togglable,
+          click: togglable ? () => {
+            safeSendToRenderer('track-context-menu-action', {
+              action: 'sync-channel-toggle',
+              playlistId: data.playlistId,
+              name: data.name,
+              providerId: ch.providerId,
+              providerLabel: ch.displayName,
+              enabling: !ch.enabled,
+              currentlyMirrored: !!(pl.syncedTo && pl.syncedTo[ch.providerId] && pl.syncedTo[ch.providerId].externalId)
+            });
+          } : undefined
+        };
+      });
+
+      submenu.push({ type: 'separator' });
+      submenu.push({
+        label: mirrorForced
           ? (isHostedXspf ? 'Mirror only (one-way · hosted)' : 'Mirror only (one-way · followed)')
           : 'Mirror only (one-way)',
         type: 'checkbox',
-        checked: effective,
-        enabled: !forced, // locked on for followed/hosted — inherently one-way
+        checked: mirrorEffective,
+        enabled: !mirrorForced, // locked on for followed/hosted — inherently one-way
         click: () => {
           const next = !getPlaylistMirrorOnly(data.playlistId);
           setPlaylistMirrorOnly(data.playlistId, next);
@@ -4661,34 +4688,10 @@ ipcMain.handle('show-track-context-menu', async (event, data) => {
           });
         }
       });
-    }
 
-    // LB RE-EXPORT opt-in (parachord#911 / parachord-mobile ec526bb). A
-    // `listenbrainz-*` playlist (created/edited on ListenBrainz via Achordion)
-    // can be mirrored to Spotify / Apple Music — but ONLY by explicit opt-in
-    // here; it never auto-mirrors, so a pulled LB library can't flood streaming.
-    // Each toggle writes the sync_playlist_reexport map the push loops read.
-    if (pl && !pl.localOnly && data.playlistId.startsWith('listenbrainz-')) {
-      const optedIn = getPlaylistReexport(data.playlistId);
-      menuItems.push({ type: 'separator' });
-      for (const [pid, label] of [['spotify', 'Spotify'], ['applemusic', 'Apple Music']]) {
-        menuItems.push({
-          label: `Mirror to ${label}`,
-          type: 'checkbox',
-          checked: optedIn.includes(pid),
-          click: () => {
-            const next = !getPlaylistReexport(data.playlistId).includes(pid);
-            setPlaylistReexport(data.playlistId, pid, next);
-            safeSendToRenderer('track-context-menu-action', {
-              action: 'reexport-changed',
-              playlistId: data.playlistId,
-              name: data.name,
-              providerId: pid,
-              providerLabel: label,
-              enabled: next
-            });
-          }
-        });
+      if (submenu.length > 1) { // at least one channel + the mirror-only row
+        menuItems.push({ type: 'separator' });
+        menuItems.push({ label: 'Sync', submenu });
       }
     }
 
@@ -5302,6 +5305,16 @@ ipcMain.handle('playlists-delete', async (event, playlistId) => {
     }
 
     store.set('local_playlists', filteredPlaylists);
+
+    // Drop the playlist's per-playlist sync prefs so they don't leak (parachord#911).
+    for (const key of ['sync_playlist_channels', 'sync_playlist_mirror_only']) {
+      const map = store.get(key);
+      if (map && typeof map === 'object' && playlistId in map) {
+        delete map[playlistId];
+        store.set(key, map);
+      }
+    }
+
     console.log('  ✅ Deleted playlist');
     return { success: true };
   } catch (error) {
@@ -5454,35 +5467,129 @@ function removePlaylistSyncState(localPlaylistId, providerId) {
 ipcMain.handle('sync-state:get-all', async () => getSyncStates());
 ipcMain.handle('sync-state:get', async (event, localPlaylistId) => getPlaylistSyncState(localPlaylistId));
 
-// Per-playlist LB RE-EXPORT opt-in (parachord#911, parity with mobile ec526bb).
-// `sync_playlist_reexport = { [localPlaylistId]: ['spotify','applemusic'] }` —
-// the streaming providers a `listenbrainz-*` playlist has been EXPLICITLY opted
-// into for re-export. Its own electron-store map (pull-safe; not a playlist row
-// field). Read by the renderer push loops' opt-in gate; written from the
-// playlist's Sync context menu. Absent/empty → never auto-mirrors (the flood
-// guard); only the providers in the list are pushed.
-// The pure opt-in predicate (parity anchor) — shared by the renderer push-loop
-// gates (inlined there) and the main-process side-doors (relinkOrphansFor + the
-// create gateway) so the flood guard is byte-consistent everywhere.
-const { isReexportOptInRequired } = require('./sync-engine/playlist-push-candidate');
+// Per-playlist Sync CHANNEL override (parachord#911, parity with mobile
+// PlaylistSyncChannelManager). `sync_playlist_channels = { [localId]:
+// ['spotify','applemusic','listenbrainz'] }` — when present it is AUTHORITATIVE:
+// the playlist syncs ONLY to the listed providers (the user picked them in the
+// Sync menu). Absent → no override → default auto-sync (with the listenbrainz-*
+// re-export opt-in still gating streaming). Its own pull-safe electron-store map
+// (not a playlist row field). The pure gate + channel-state predicates live in
+// sync-engine/playlist-push-candidate.js so the renderer push loops (inlined)
+// and the main-process side-doors (relinkOrphansFor + the create gateway) stay
+// byte-consistent.
+const {
+  channelGateBlocksCreate,
+  channelOverrideExcludes,
+  computeSyncChannels,
+} = require('./sync-engine/playlist-push-candidate');
 
-function getReexportMap() {
-  const m = store.get('sync_playlist_reexport');
+const SYNC_PROVIDER_DISPLAY = { spotify: 'Spotify', applemusic: 'Apple Music', listenbrainz: 'ListenBrainz' };
+
+function getChannelMap() {
+  const m = store.get('sync_playlist_channels');
   return m && typeof m === 'object' ? m : {};
 }
-function getPlaylistReexport(localPlaylistId) {
-  const v = getReexportMap()[localPlaylistId];
-  return Array.isArray(v) ? v : [];
+function getChannelOverride(localPlaylistId) {
+  const v = getChannelMap()[localPlaylistId];
+  return Array.isArray(v) ? v : null; // null = no override (default behavior)
 }
-function setPlaylistReexport(localPlaylistId, providerId, enabled) {
-  if (!localPlaylistId || !providerId) return;
-  const map = getReexportMap();
-  const set = new Set(Array.isArray(map[localPlaylistId]) ? map[localPlaylistId] : []);
+function setChannelOverride(localPlaylistId, providers) {
+  if (!localPlaylistId) return;
+  const map = getChannelMap();
+  map[localPlaylistId] = Array.isArray(providers) ? [...new Set(providers)] : [];
+  store.set('sync_playlist_channels', map);
+}
+
+// Providers the user has configured for sync (for the Sync menu connected/dim).
+function getEnabledSyncProviders() {
+  const s = store.get('resolver_sync_settings') || {};
+  return Object.keys(s).filter(pid => s[pid] && s[pid].enabled !== false);
+}
+
+// The providers a playlist currently syncs with (its source + its push mirrors).
+function getCurrentMirrorProviders(playlist) {
+  if (!playlist) return [];
+  const out = new Set();
+  if (playlist.syncedFrom && playlist.syncedFrom.resolver) out.add(playlist.syncedFrom.resolver);
+  if (playlist.syncedTo) {
+    for (const pid of Object.keys(playlist.syncedTo)) {
+      if (playlist.syncedTo[pid] && playlist.syncedTo[pid].externalId) out.add(pid);
+    }
+  }
+  return [...out];
+}
+
+// Channel states (+ display names) for a playlist's Sync submenu.
+function getPlaylistSyncChannelsForMenu(playlist) {
+  return computeSyncChannels(playlist, {
+    enabledProviders: getEnabledSyncProviders(),
+    override: getChannelOverride(playlist.id),
+    currentMirrors: getCurrentMirrorProviders(playlist),
+  }).map(c => ({ ...c, displayName: SYNC_PROVIDER_DISPLAY[c.providerId] || c.providerId }));
+}
+
+// Detach a playlist from one provider's mirror: drop the durable link, the
+// per-provider sync state, and the playlist's `syncedTo[provider]` so the
+// edit-push branch stops pushing to it. Keeps the remote (caller deletes it
+// separately if the user chose to).
+function detachPlaylistMirror(localPlaylistId, providerId) {
+  removeSyncLink(localPlaylistId, providerId);
+  removePlaylistSyncState(localPlaylistId, providerId);
+  const playlists = store.get('local_playlists') || [];
+  const idx = playlists.findIndex(p => p.id === localPlaylistId);
+  if (idx >= 0 && playlists[idx].syncedTo && playlists[idx].syncedTo[providerId]) {
+    const syncedTo = { ...playlists[idx].syncedTo };
+    delete syncedTo[providerId];
+    playlists[idx] = { ...playlists[idx], syncedTo };
+    store.set('local_playlists', playlists);
+  }
+}
+
+// Best-effort remote delete for the "delete from this service too" choice.
+// Returns { deleted } or { deleted:false, reason } where reason 'unsupported'
+// means the user must remove it manually (Apple Music library playlists).
+async function deleteRemotePlaylistBestEffort(providerId, externalId) {
+  try {
+    const provider = SyncEngine.getProvider(providerId);
+    if (!provider || !provider.deletePlaylist) return { deleted: false, reason: 'unsupported' };
+    const token = await getNwayProviderToken(providerId);
+    if (!token) return { deleted: false, reason: 'no-token' };
+    const refreshCb = providerId === 'spotify'
+      ? (async () => { try { return await ensureValidSpotifyToken(true); } catch { return null; } })
+      : null;
+    const result = await provider.deletePlaylist(externalId, token, refreshCb);
+    if (result && result.success === false) {
+      return { deleted: false, reason: result.reason === 'endpoint-unsupported' ? 'unsupported' : (result.reason || 'failed') };
+    }
+    return { deleted: true };
+  } catch (e) {
+    return { deleted: false, reason: (e && e.message) || 'failed' };
+  }
+}
+
+// Toggle one Sync channel for a playlist (parity with mobile setChannel /
+// disableChannel). Enabling materializes the override from the current mirrors +
+// adds the provider (the next sync creates/links the mirror). Disabling removes
+// it from the override, optionally deletes the remote, and detaches locally.
+ipcMain.handle('sync:set-channel', async (event, localPlaylistId, providerId, enabled, opts = {}) => {
+  const playlists = store.get('local_playlists') || [];
+  const playlist = playlists.find(p => p.id === localPlaylistId);
+  if (!playlist) return { success: false, error: 'Playlist not found' };
+  const base = getChannelOverride(localPlaylistId) || getCurrentMirrorProviders(playlist);
+  const set = new Set(base);
   if (enabled) set.add(providerId); else set.delete(providerId);
-  if (set.size) map[localPlaylistId] = [...set];
-  else delete map[localPlaylistId];
-  store.set('sync_playlist_reexport', map);
-}
+  setChannelOverride(localPlaylistId, [...set]);
+
+  let remoteDelete = null;
+  if (!enabled) {
+    const externalId = playlist.syncedTo && playlist.syncedTo[providerId] && playlist.syncedTo[providerId].externalId;
+    if (opts.deleteRemote && externalId) {
+      remoteDelete = await deleteRemotePlaylistBestEffort(providerId, externalId);
+    }
+    detachPlaylistMirror(localPlaylistId, providerId);
+  }
+  return { success: true, override: getChannelOverride(localPlaylistId), remoteDelete };
+});
 
 // ── N-way reconcile driver wiring (parachord#911, Step 2 / PR-4b) ──────
 // DORMANT by default. The pure reconcile engine (sync-engine/playlist-
@@ -5936,15 +6043,14 @@ function relinkOrphansFor(providerId, ownedRemote) {
     !p.localOnly &&
     !isLinked(p) &&
     (p.tracks?.length || 0) > 0 &&
-    // LB RE-EXPORT flood guard (parachord#911) — a side-door twin of the push
-    // loops' create-branch gate. relinkOrphansFor name-matches an orphan to an
-    // owned remote and writes syncedTo + locallyModified, which then re-exports
-    // via the (un-gated) `locallyModified` push branch. So a `listenbrainz-*`
-    // playlist the user has NOT opted into this streaming provider must NOT be a
-    // relink candidate — otherwise a same-named owned Spotify/AM playlist would
-    // auto-link + flood the user's pulled LB library. Uses the SAME predicate +
-    // map as the push-loop gate, so opted-in LB playlists still relink.
-    !(isReexportOptInRequired(p, providerId) && !getPlaylistReexport(p.id).includes(providerId))
+    // CHANNEL gate (parachord#911) — a side-door twin of the push loops'
+    // create-branch gate. relinkOrphansFor name-matches an orphan to an owned
+    // remote and writes syncedTo + locallyModified, which then syncs via the
+    // (un-gated) `locallyModified` push branch. So a playlist whose channel
+    // override excludes this provider — or an un-opted-in `listenbrainz-*`
+    // playlist — must NOT be a relink candidate, else a same-named owned remote
+    // would auto-link against the user's intent (and flood a pulled LB library).
+    !channelGateBlocksCreate(p, providerId, getChannelOverride(p.id))
   );
 
   const orphansByName = new Map();
@@ -7605,6 +7711,23 @@ ipcMain.handle('sync:push-playlist', async (event, providerId, playlistExternalI
     return { success: false, error: 'Provider does not support playlists' };
   }
 
+  // CHANNEL gate (defense-in-depth, parachord#911). The renderer EDIT push branch
+  // already gates, but this is the actual write path — reverse-look-up the local
+  // playlist via the durable link map and refuse to push to a provider the user
+  // EXCLUDED from this playlist's channel override. So no caller (or a stale push
+  // cycle racing a just-landed disable) can write to an excluded mirror.
+  try {
+    const links = getSyncLinks();
+    const lpId = Object.keys(links).find(id => links[id] && links[id][providerId] && links[id][providerId].externalId === playlistExternalId);
+    if (lpId && channelOverrideExcludes(getChannelOverride(lpId), providerId)) {
+      console.warn(`[Sync] Blocked push to ${providerId} for "${(metadata && metadata.name) || lpId}" — provider excluded from the playlist's sync channels`);
+      return { success: false, error: 'channel-excluded' };
+    }
+  } catch (e) {
+    // Never let the guard's own failure block a legitimate push.
+    console.warn('[Sync] channel-gate lookup failed (non-fatal):', e && e.message);
+  }
+
   if (!provider.updatePlaylistTracks) {
     return { success: false, error: 'Provider does not support pushing playlist changes' };
   }
@@ -7728,20 +7851,15 @@ ipcMain.handle('sync:push-playlist', async (event, providerId, playlistExternalI
       return { success: false, error: 'Provider does not support creating playlists' };
     }
 
-    // LB RE-EXPORT flood guard (defense-in-depth, parachord#911). This gateway
-    // is the single create/link chokepoint; the renderer push loops already gate
-    // before calling it, but enforcing the opt-in HERE too means no future
-    // caller (or side-door) can re-export a `listenbrainz-*` playlist to a
-    // streaming service without the user explicitly opting it in
-    // (sync_playlist_reexport). Safe: the loops only reach this for opted-in LB
-    // or non-LB playlists, so it never false-blocks a legitimate create.
-    if (
-      localPlaylistId
-      && isReexportOptInRequired({ id: localPlaylistId }, providerId)
-      && !getPlaylistReexport(localPlaylistId).includes(providerId)
-    ) {
-      console.warn(`[Sync] Blocked un-opted ListenBrainz re-export of "${name}" to ${providerId}`);
-      return { success: false, error: 'reexport-not-opted-in' };
+    // CHANNEL gate (defense-in-depth, parachord#911). This gateway is the single
+    // create/link chokepoint; the renderer push loops already gate before calling
+    // it, but enforcing the channel override / LB opt-in HERE too means no future
+    // caller (or side-door) can create a mirror the user didn't choose. Safe: the
+    // loops only reach this for channel-allowed playlists, so it never
+    // false-blocks a legitimate create.
+    if (localPlaylistId && channelGateBlocksCreate({ id: localPlaylistId }, providerId, getChannelOverride(localPlaylistId))) {
+      console.warn(`[Sync] Blocked create of "${name}" on ${providerId} — not in the playlist's sync channels`);
+      return { success: false, error: 'channel-not-selected' };
     }
 
     let token;

--- a/main.js
+++ b/main.js
@@ -7149,19 +7149,31 @@ ipcMain.handle('sync:start', async (event, providerId, options = {}) => {
     if (isCancelled()) return await finalizeCancelled(collection, results);
 
     // Sync playlists
-    if (settings.syncPlaylists && settings.selectedPlaylistIds?.length > 0 && provider.capabilities.playlists) {
+    // ListenBrainz imports ALL of the user's remote playlists by default (mobile
+    // parity — an empty pull-allowlist means "import all"; see
+    // SyncEngine.kt getPullPlaylists). So a playlist created on another device
+    // (e.g. Android) auto-appears here. Spotify/Apple Music keep the opt-IN model
+    // (only playlists in selectedPlaylistIds). Suppression + an explicit channel
+    // override still exclude individual playlists on every provider.
+    const importAll = providerId === 'listenbrainz';
+    if (settings.syncPlaylists && (importAll || settings.selectedPlaylistIds?.length > 0) && provider.capabilities.playlists) {
       // Load current playlists
       const currentPlaylists = store.get('local_playlists') || [];
 
       // Fetch playlist metadata to check for updates
-      sendProgress({ phase: 'playlists', current: 0, total: settings.selectedPlaylistIds.length, providerId });
+      sendProgress({ phase: 'playlists', current: 0, total: settings.selectedPlaylistIds?.length || 0, providerId });
       const { playlists: remotePlaylists } = await provider.fetchPlaylists(token, null, refreshToken);
       const suppressedPlaylists = store.get('suppressed_sync_playlists') || {};
       const suppressedForProvider = suppressedPlaylists[providerId] || [];
-      const allSelectedRemote = remotePlaylists.filter(p =>
-        settings.selectedPlaylistIds.includes(p.externalId) &&
-        !suppressedForProvider.includes(p.externalId)
-      );
+      const allSelectedRemote = remotePlaylists.filter(p => {
+        if (suppressedForProvider.includes(p.externalId)) return false; // user removed it
+        if (importAll) {
+          // Import-all (LB): include unless an explicit channel override drops it.
+          const override = getChannelOverride(`${providerId}-${p.externalId}`);
+          return !(Array.isArray(override) && !override.includes(providerId));
+        }
+        return (settings.selectedPlaylistIds || []).includes(p.externalId);
+      });
 
       // Stagger across cycles (parachord#800). Background sync processes
       // the top N oldest-stale-first per cycle; over 4-5 cycles the whole

--- a/main.js
+++ b/main.js
@@ -5306,8 +5306,10 @@ ipcMain.handle('playlists-delete', async (event, playlistId) => {
 
     store.set('local_playlists', filteredPlaylists);
 
-    // Drop the playlist's per-playlist sync prefs so they don't leak (parachord#911).
-    for (const key of ['sync_playlist_channels', 'sync_playlist_mirror_only']) {
+    // Drop the playlist's per-playlist sync prefs + durable links/state so they
+    // don't leak — and so re-adding a hosted XSPF (id = hosted-<hash(url)>, which
+    // is re-derivable) doesn't reuse a stale link (parachord#911).
+    for (const key of ['sync_playlist_channels', 'sync_playlist_mirror_only', 'sync_playlist_links', 'sync_playlist_state']) {
       const map = store.get(key);
       if (map && typeof map === 'object' && playlistId in map) {
         delete map[playlistId];

--- a/preload.js
+++ b/preload.js
@@ -43,6 +43,8 @@ contextBridge.exposeInMainWorld('electron', {
   // triggers one reconcile cycle for validation (shadow = compute + log only).
   nway: {
     shadowRun: () => ipcRenderer.invoke('nway:shadow-run'),
+    getMirrorOnly: (localPlaylistId) => ipcRenderer.invoke('nway:get-mirror-only', localPlaylistId),
+    setMirrorOnly: (localPlaylistId, value) => ipcRenderer.invoke('nway:set-mirror-only', localPlaylistId, value),
   },
 
   // Spotify operations

--- a/preload.js
+++ b/preload.js
@@ -43,8 +43,6 @@ contextBridge.exposeInMainWorld('electron', {
   // triggers one reconcile cycle for validation (shadow = compute + log only).
   nway: {
     shadowRun: () => ipcRenderer.invoke('nway:shadow-run'),
-    getMirrorOnly: (localPlaylistId) => ipcRenderer.invoke('nway:get-mirror-only', localPlaylistId),
-    setMirrorOnly: (localPlaylistId, value) => ipcRenderer.invoke('nway:set-mirror-only', localPlaylistId, value),
   },
 
   // Spotify operations

--- a/preload.js
+++ b/preload.js
@@ -407,6 +407,9 @@ contextBridge.exposeInMainWorld('electron', {
     fetchPlaylistTracks: (providerId, playlistExternalId) => ipcRenderer.invoke('sync:fetch-playlist-tracks', providerId, playlistExternalId),
     pushPlaylist: (providerId, playlistExternalId, tracks, metadata) => ipcRenderer.invoke('sync:push-playlist', providerId, playlistExternalId, tracks, metadata),
     createPlaylist: (providerId, name, description, tracks, localPlaylistId = null) => ipcRenderer.invoke('sync:create-playlist', providerId, name, description, tracks, localPlaylistId),
+    // Per-playlist Sync channel toggle (parachord#911). enabled=false + { deleteRemote }
+    // optionally deletes the remote, then detaches the local mirror.
+    setChannel: (localPlaylistId, providerId, enabled, opts = {}) => ipcRenderer.invoke('sync:set-channel', localPlaylistId, providerId, enabled, opts),
     resolveTracks: (providerId, tracks) => ipcRenderer.invoke('sync:resolve-tracks', providerId, tracks),
     cleanupDuplicatePlaylists: (providerId) => ipcRenderer.invoke('sync:cleanup-duplicate-playlists', providerId),
     relinkOrphanedPlaylists: (providerId) => ipcRenderer.invoke('sync:relink-orphaned-playlists', providerId),

--- a/sync-engine/nway-reconcile-driver.js
+++ b/sync-engine/nway-reconcile-driver.js
@@ -116,6 +116,7 @@ function makeStoreEffects(store) {
  * @param {Object<string,object>} args.boundProviders - per-provider token-bound adapter (bindProviderToken output)
  * @param {object}   args.remoteLists   - { providerId -> { externalId -> { snapshotId?, trackCount? } } }
  * @param {(localId:string)=>object|null} [args.getPullSource]
+ * @param {(localId:string)=>boolean} [args.getMirrorOnly] - user mirror-only flag per playlist
  * @param {object}   args.cache         - hydration cache (createHydrationCache)
  * @param {object}   args.effects       - makeStoreEffects output
  * @param {number}   args.now           - epoch ms
@@ -126,7 +127,7 @@ function makeStoreEffects(store) {
 async function runNwayReconcileCycle(args) {
   const {
     states, getPlaylist, getMirrors, boundProviders, remoteLists,
-    getPullSource, cache, effects, now, dryRun, log = console,
+    getPullSource, getMirrorOnly, cache, effects, now, dryRun, log = console,
   } = args;
 
   const providersList = Object.values(boundProviders || {});
@@ -147,6 +148,7 @@ async function runNwayReconcileCycle(args) {
         remoteLists,
         storedTokens: state.providers || {},
         pullSource: getPullSource ? getPullSource(localId) : null,
+        mirrorOnly: getMirrorOnly ? getMirrorOnly(localId) : false,
         coordinator,
         cache,
         now,

--- a/sync-engine/playlist-push-candidate.js
+++ b/sync-engine/playlist-push-candidate.js
@@ -15,6 +15,9 @@
 // Streaming providers a ListenBrainz playlist can RE-EXPORT to — opt-in only.
 const REEXPORT_PROVIDERS = ['spotify', 'applemusic'];
 
+// The providers offered as Sync CHANNELS in the per-playlist Sync menu.
+const SYNC_CHANNEL_PROVIDERS = ['spotify', 'applemusic', 'listenbrainz'];
+
 function playlistId(playlist) {
   return playlist && typeof playlist.id === 'string' ? playlist.id : '';
 }
@@ -80,9 +83,79 @@ function isReexportOptInRequired(playlist, providerId) {
   return !autoMirrorsByDefault(playlist) && REEXPORT_PROVIDERS.includes(providerId);
 }
 
+/**
+ * The per-playlist Sync menu's "where does this sync" decision (parity with
+ * mobile's PlaylistSyncChannelManager.getChannels). For each sync-channel
+ * provider, report whether the service is `connected` (set up in Settings),
+ * whether this playlist is currently `enabled` (syncing) to it, and whether it's
+ * an `available` target at all. `effective` = the channel override when the user
+ * has set one (authoritative), else the playlist's current mirrors.
+ * @param {{id?:string, sourceUrl?:string, spotifyId?:string, sources?:object}} playlist
+ * @param {{enabledProviders?:string[], override?:string[]|null, currentMirrors?:string[]}} ctx
+ * @returns {Array<{providerId:string, connected:boolean, enabled:boolean, available:boolean}>}
+ */
+function computeSyncChannels(playlist, { enabledProviders = [], override = null, currentMirrors = [] } = {}) {
+  const effective = Array.isArray(override) ? override : (Array.isArray(currentMirrors) ? currentMirrors : []);
+  const id = playlistId(playlist);
+  return SYNC_CHANNEL_PROVIDERS.map((pid) => {
+    const pushTarget = isPlaylistPushCandidate(playlist, pid);
+    const isSource = id.startsWith(`${pid}-`); // imported FROM this provider
+    return {
+      providerId: pid,
+      connected: enabledProviders.includes(pid),
+      enabled: effective.includes(pid),
+      // `available` = show the row at all. `pushTarget` = a togglable PUSH
+      // destination; a source-only channel is shown (checked) but locked, since
+      // detaching a pull source fights the imported-playlist `syncedFrom` heal.
+      available: pushTarget || isSource,
+      pushTarget,
+      isSource,
+    };
+  });
+}
+
+/**
+ * Whether the auto-push loops must NOT create a mirror of `playlist` on
+ * `providerId` this cycle — the unified channel gate (parity with mobile's
+ * `if (override != null) providerId in override else autoMirrorsByDefault && …`):
+ *   - a per-playlist channel OVERRIDE is AUTHORITATIVE: block any provider not
+ *     in it (the user manually chose where this playlist syncs);
+ *   - with NO override, fall to the default — only a listenbrainz-* playlist
+ *     targeting a streaming provider is blocked (the no-auto-flood opt-in).
+ * Already-linked mirrors are gated by the caller (this is the CREATE gate only).
+ * @param {{id?:string}} playlist
+ * @param {string} providerId
+ * @param {string[]|null|undefined} channelOverride - the playlist's override, or null/undefined for none
+ * @returns {boolean}
+ */
+function channelGateBlocksCreate(playlist, providerId, channelOverride) {
+  if (Array.isArray(channelOverride)) return !channelOverride.includes(providerId);
+  return isReexportOptInRequired(playlist, providerId);
+}
+
+/**
+ * Whether a channel OVERRIDE, if present, EXCLUDES a provider — the gate for the
+ * EDIT/update push branch (and sync:push-playlist). Distinct from the CREATE
+ * gate: an ALREADY-LINKED mirror keeps receiving edits unless the user has set
+ * an override that explicitly drops its provider (so a previously-opted-in
+ * listenbrainz-* → Spotify mirror with NO override keeps syncing). This closes
+ * the cross-snapshot race where a push cycle's stale snapshot still holds
+ * syncedTo[X] after the user just disabled X (detach hadn't landed yet).
+ * @param {string[]|null|undefined} channelOverride
+ * @param {string} providerId
+ * @returns {boolean}
+ */
+function channelOverrideExcludes(channelOverride, providerId) {
+  return Array.isArray(channelOverride) && !channelOverride.includes(providerId);
+}
+
 module.exports = {
   REEXPORT_PROVIDERS,
+  SYNC_CHANNEL_PROVIDERS,
   isPlaylistPushCandidate,
   autoMirrorsByDefault,
   isReexportOptInRequired,
+  computeSyncChannels,
+  channelGateBlocksCreate,
+  channelOverrideExcludes,
 };

--- a/sync-engine/playlist-push-candidate.js
+++ b/sync-engine/playlist-push-candidate.js
@@ -1,0 +1,88 @@
+// Playlist push-candidate eligibility + the opt-in gate for re-exporting a
+// ListenBrainz-originated playlist to streaming services (parachord#911,
+// parity with mobile ec526bb). PURE — no electron, no fetch.
+//
+// Desktop's background + post-wizard push loops decide per-(playlist, provider)
+// eligibility with INLINE skip-guards rather than calling an accept-list, so
+// these functions are the SOURCE-OF-TRUTH parity anchor + test target; the
+// renderer applies the same rules inline (a SYNC marker sits at the call sites
+// in app.js). The opt-in gate (autoMirrorsByDefault / isReexportOptInRequired)
+// is the LOAD-BEARING flood guard and MUST be applied at every renderer site
+// that can auto-create a remote mirror — otherwise enabling Spotify/AM sync
+// would push a user's entire pulled ListenBrainz library at once (the
+// duplicate-flood class).
+
+// Streaming providers a ListenBrainz playlist can RE-EXPORT to — opt-in only.
+const REEXPORT_PROVIDERS = ['spotify', 'applemusic'];
+
+function playlistId(playlist) {
+  return playlist && typeof playlist.id === 'string' ? playlist.id : '';
+}
+
+function hasSpotifyId(playlist) {
+  if (!playlist) return false;
+  return !!(playlist.spotifyId || (playlist.sources && playlist.sources.spotify && playlist.sources.spotify.spotifyId));
+}
+
+/**
+ * Mobile-parity push-candidate accept-list — whether `playlist` is ELIGIBLE to
+ * push to `providerId` at all (independent of opt-in + already-linked state):
+ *   local-* / hosted (sourceUrl)  -> any provider
+ *   spotify-*                     -> applemusic, listenbrainz
+ *   applemusic-*                  -> listenbrainz
+ *   listenbrainz-*                -> spotify (unless it already has a Spotify id),
+ *                                    applemusic                  ← NEW (ec526bb)
+ * Spotify keeps the don't-write-back guard: a playlist that already carries a
+ * Spotify id is not re-pushed to Spotify.
+ * @param {{id?:string, sourceUrl?:string, spotifyId?:string, sources?:object}} playlist
+ * @param {string} providerId
+ * @returns {boolean}
+ */
+function isPlaylistPushCandidate(playlist, providerId) {
+  const id = playlistId(playlist);
+  const base = id.startsWith('local-') || !!(playlist && playlist.sourceUrl);
+  switch (providerId) {
+    case 'spotify':
+      return !hasSpotifyId(playlist) && (base || id.startsWith('listenbrainz-'));
+    case 'applemusic':
+      return base || id.startsWith('spotify-') || id.startsWith('listenbrainz-');
+    case 'listenbrainz':
+      return base || id.startsWith('spotify-') || id.startsWith('applemusic-');
+    default:
+      return base;
+  }
+}
+
+/**
+ * Whether `playlist` AUTO-mirrors via a provider's DEFAULT push selection
+ * (desktop: the background/post-wizard loop reaching the create branch), vs.
+ * only when the user explicitly opts in. A ListenBrainz-imported playlist
+ * (`listenbrainz-*`) is OPT-IN ONLY — eligible to re-export but never
+ * auto-mirrored, so a pulled LB library can't flood Spotify / Apple Music.
+ * @param {{id?:string}} playlist
+ * @returns {boolean}
+ */
+function autoMirrorsByDefault(playlist) {
+  return !playlistId(playlist).startsWith('listenbrainz-');
+}
+
+/**
+ * Whether re-exporting `playlist` to `providerId` requires EXPLICIT opt-in —
+ * i.e. the auto-push loops must NOT create the remote unless the user opted
+ * this playlist into this provider. True only for a `listenbrainz-*` playlist
+ * targeting a streaming provider; false for everything else (including a
+ * listenbrainz-* pushing back to listenbrainz, which the id-prefix guard owns).
+ * @param {{id?:string}} playlist
+ * @param {string} providerId
+ * @returns {boolean}
+ */
+function isReexportOptInRequired(playlist, providerId) {
+  return !autoMirrorsByDefault(playlist) && REEXPORT_PROVIDERS.includes(providerId);
+}
+
+module.exports = {
+  REEXPORT_PROVIDERS,
+  isPlaylistPushCandidate,
+  autoMirrorsByDefault,
+  isReexportOptInRequired,
+};

--- a/sync-engine/playlist-reconcile.js
+++ b/sync-engine/playlist-reconcile.js
@@ -141,7 +141,7 @@ function computeNwayPropagationPlan(baselineRepr, augmentedCopies) {
 async function reconcilePlaylist(ctx) {
   const {
     baseline, playlist, mirrors, providers, remoteLists, storedTokens,
-    pullSource, coordinator, cache, now, dryRun, effects,
+    pullSource, coordinator, cache, now, dryRun, effects, mirrorOnly,
   } = ctx;
   const log = ctx.log || console;
 
@@ -301,9 +301,6 @@ async function reconcilePlaylist(ctx) {
   // FINAL (not protected by augmentation). The source is authoritative only if
   // it CAN delete (trackRemoveMode !== 'Unsupported'); an add-only source
   // (Apple Music) can never prove a deletion, so it grants no drop-authority.
-  // Even the authoritative source's absence must clear the missingStreak gate:
-  // a single transient complete-fetch omission is NOT a deletion (it would
-  // resurrect for one cycle, then drop — the no-false-drop-safe direction).
   let authoritativeCopyId = null;
   if (pullSource && pullSource.providerId) {
     const sourceProvider = providerById[pullSource.providerId];
@@ -313,16 +310,34 @@ async function reconcilePlaylist(ctx) {
   } else if (playlist.sourceUrl) {
     authoritativeCopyId = 'local'; // hosted XSPF — local mirror IS the source
   }
+
+  // immediateAuthority — the source is SINGLE-AUTHORITY (a one-way mirror), so
+  // its rotate-out drops IMMEDIATELY, with NO missingStreak gate:
+  //   • 'local'    — a hosted-XSPF source (in-process, never a truncated fetch);
+  //   • !writable  — a FOLLOWED (read-only) provider source. A wrong drop
+  //                  SELF-HEALS next cycle (the source re-asserts the track), so
+  //                  the gate buys nothing but would lag/break a daily-rotating
+  //                  algorithmic playlist — a followed Daily Brew (~40 tracks/day)
+  //                  would accumulate WITHOUT BOUND under the gate (the exact
+  //                  bloat the pull-source-authority fix closed);
+  //   • mirrorOnly — the user flagged an OWNED-but-dynamic playlist (e.g. a
+  //                  SmarterPlaylists-managed Daily Brew the provider reports as
+  //                  user-owned) as one-way; the writability split alone can't
+  //                  catch it.
+  // ONLY an OWNED, non-mirror provider source keeps the gate — there a transient
+  // complete-fetch omission could lose a real user edit, so a single omission
+  // stays protected until sustained >= MISSING_STREAK_THRESHOLD cycles. The
+  // partial-fetch floor (A1) runs BEFORE this, so a truncated followed-source
+  // fetch is already degraded to changed:false and can't mass-drop here.
+  // (parachord#911 — byte-aligned with mobile 9780432 / parachord-mobile#277.)
+  const immediateAuthority = authoritativeCopyId === 'local' || !!mirrorOnly || !playlist.writable;
   const authoritativeCopy = copies.find((c) => c.id === authoritativeCopyId && c.changed);
   const authoritativeDropped = new Set();
   if (authoritativeCopy) {
     const present = new Set(authoritativeCopy.keys);
     for (const k of baselineRepr) {
       if (present.has(k)) continue;
-      // 'local' source (hosted XSPF) is in-process, never a truncated fetch —
-      // its absence is immediately authoritative. A provider source must clear
-      // the missingStreak gate first.
-      if (authoritativeCopyId === 'local' || streakEscalated(cache, authoritativeCopyId, k, keyToTrack)) {
+      if (immediateAuthority || streakEscalated(cache, authoritativeCopyId, k, keyToTrack)) {
         authoritativeDropped.add(k);
       }
     }
@@ -331,10 +346,11 @@ async function reconcilePlaylist(ctx) {
   // A6 — pending-aware augmentation. A CHANGED copy that LACKS a baseline key
   // gets that key re-added to its merge keys (so the merge doesn't read its
   // absence as a deletion) unless the absence is GENUINE deletion evidence:
-  //   - AUTHORITATIVE source copy: re-add every lacked key EXCEPT those whose
-  //     absence has streak-escalated (authoritativeDropped) — so a single
-  //     transient complete-fetch omission of the source doesn't drop the track,
-  //     but a sustained one (>= 2 cycles) finally does.
+  //   - AUTHORITATIVE source copy: re-add every lacked key EXCEPT those in
+  //     authoritativeDropped. For an OWNED source that means only streak-
+  //     escalated keys drop (a single transient omission is protected); for an
+  //     immediate-authority source (followed / hosted / mirrorOnly) ALL lacked
+  //     keys are in authoritativeDropped, so its rotate-out drops at once.
   //   - other mirror copies: re-add a lacked key only if the source didn't drop
   //     it AND it's pending for this provider (never-materialized, OR
   //     materialized but not yet missing for >= 2 consecutive complete fetches).

--- a/tests/sync/playlist-push-candidate.test.js
+++ b/tests/sync/playlist-push-candidate.test.js
@@ -8,9 +8,13 @@
 
 const {
   REEXPORT_PROVIDERS,
+  SYNC_CHANNEL_PROVIDERS,
   isPlaylistPushCandidate,
   autoMirrorsByDefault,
   isReexportOptInRequired,
+  computeSyncChannels,
+  channelGateBlocksCreate,
+  channelOverrideExcludes,
 } = require('../../sync-engine/playlist-push-candidate');
 
 const pl = (id, extra = {}) => ({ id, ...extra });
@@ -120,5 +124,92 @@ describe('opt-in gate decision (what the push loop computes)', () => {
 
   test('relink/gateway side-door: a non-LB orphan relinks freely (e.g. local- name-match)', () => {
     expect(gatedSkip(pl('local-1'), 'spotify', [])).toBe(false);
+  });
+});
+
+describe('channelGateBlocksCreate — the unified channel/opt-in gate', () => {
+  test('an OVERRIDE is authoritative — block any provider not in it', () => {
+    expect(channelGateBlocksCreate(pl('local-1'), 'applemusic', ['spotify'])).toBe(true); // AM not chosen
+    expect(channelGateBlocksCreate(pl('local-1'), 'spotify', ['spotify'])).toBe(false); // chosen
+    expect(channelGateBlocksCreate(pl('listenbrainz-1'), 'spotify', ['spotify'])).toBe(false); // LB opted in via override
+    expect(channelGateBlocksCreate(pl('listenbrainz-1'), 'applemusic', ['spotify'])).toBe(true); // LB not chosen for AM
+  });
+
+  test('an EMPTY override blocks all providers (the user turned everything off)', () => {
+    expect(channelGateBlocksCreate(pl('local-1'), 'spotify', [])).toBe(true);
+    expect(channelGateBlocksCreate(pl('local-1'), 'applemusic', [])).toBe(true);
+  });
+
+  test('NO override → default: non-LB auto-mirrors, listenbrainz-* is opt-in-gated for streaming', () => {
+    expect(channelGateBlocksCreate(pl('local-1'), 'spotify', null)).toBe(false);
+    expect(channelGateBlocksCreate(pl('local-1'), 'spotify', undefined)).toBe(false);
+    expect(channelGateBlocksCreate(pl('listenbrainz-1'), 'spotify', null)).toBe(true); // no flood
+    expect(channelGateBlocksCreate(pl('listenbrainz-1'), 'listenbrainz', null)).toBe(false); // own provider
+  });
+});
+
+describe('channelOverrideExcludes — the EDIT/update push gate (closes the disable race)', () => {
+  test('blocks ONLY when an override explicitly excludes the provider', () => {
+    expect(channelOverrideExcludes(['spotify'], 'applemusic')).toBe(true); // AM excluded → stop editing it
+    expect(channelOverrideExcludes(['spotify'], 'spotify')).toBe(false); // still chosen
+    expect(channelOverrideExcludes([], 'spotify')).toBe(true); // turned everything off
+  });
+
+  test('an already-linked mirror with NO override keeps syncing edits (unlike the create gate)', () => {
+    // Critical contract: a previously-opted-in LB→Spotify mirror with no override
+    // must KEEP getting edits — the create gate would block it (opt-in), the edit
+    // gate must not.
+    expect(channelOverrideExcludes(null, 'spotify')).toBe(false);
+    expect(channelOverrideExcludes(undefined, 'spotify')).toBe(false);
+    expect(channelGateBlocksCreate(pl('listenbrainz-1'), 'spotify', null)).toBe(true); // create: blocked
+    expect(channelOverrideExcludes(null, 'spotify')).toBe(false); // edit: allowed
+  });
+});
+
+describe('computeSyncChannels — the Sync menu channel states', () => {
+  const enabled = ['spotify', 'applemusic', 'listenbrainz'];
+
+  test('reports connected / available / enabled per provider (override authoritative)', () => {
+    const channels = computeSyncChannels(pl('listenbrainz-1'), {
+      enabledProviders: enabled,
+      override: ['spotify'], // user chose Spotify only
+      currentMirrors: ['listenbrainz'],
+    });
+    const byId = Object.fromEntries(channels.map((c) => [c.providerId, c]));
+    expect(byId.spotify).toMatchObject({ connected: true, enabled: true, available: true });
+    expect(byId.applemusic).toMatchObject({ connected: true, enabled: false, available: true });
+    expect(byId.listenbrainz).toMatchObject({ connected: true, enabled: false, available: true }); // source, available
+    expect(channels.map((c) => c.providerId)).toEqual(SYNC_CHANNEL_PROVIDERS);
+  });
+
+  test('with NO override, enabled reflects the current mirrors', () => {
+    const channels = computeSyncChannels(pl('spotify-AAA'), {
+      enabledProviders: ['spotify', 'applemusic'],
+      override: null,
+      currentMirrors: ['spotify', 'applemusic'],
+    });
+    const byId = Object.fromEntries(channels.map((c) => [c.providerId, c]));
+    expect(byId.spotify.enabled).toBe(true);
+    expect(byId.applemusic.enabled).toBe(true);
+    expect(byId.listenbrainz).toMatchObject({ connected: false, enabled: false, available: true }); // spotify-* → LB eligible
+  });
+
+  test('available=false for a provider this playlist cannot push to (e.g. applemusic-* → spotify)', () => {
+    const channels = computeSyncChannels(pl('applemusic-p.A'), { enabledProviders: enabled });
+    const byId = Object.fromEntries(channels.map((c) => [c.providerId, c]));
+    expect(byId.spotify.available).toBe(false);
+    expect(byId.applemusic.available).toBe(true); // is the source
+    expect(byId.listenbrainz.available).toBe(true);
+  });
+
+  test('the SOURCE channel is shown but is NOT a push target (locked in the menu)', () => {
+    // listenbrainz-* → LB is the source: available (shown) but not a push target.
+    const lb = computeSyncChannels(pl('listenbrainz-1'), { enabledProviders: enabled })
+      .find((c) => c.providerId === 'listenbrainz');
+    expect(lb).toMatchObject({ available: true, isSource: true, pushTarget: false });
+    // …while its streaming channels ARE push targets.
+    const sp = computeSyncChannels(pl('listenbrainz-1'), { enabledProviders: enabled })
+      .find((c) => c.providerId === 'spotify');
+    expect(sp).toMatchObject({ available: true, isSource: false, pushTarget: true });
   });
 });

--- a/tests/sync/playlist-push-candidate.test.js
+++ b/tests/sync/playlist-push-candidate.test.js
@@ -1,0 +1,124 @@
+/**
+ * Playlist push-candidate eligibility + the LB re-export opt-in gate
+ * (Parachord/parachord#911, parity with mobile ec526bb /
+ * PlaylistSelectionTest). The eligibility accept-list is the cross-engine
+ * parity anchor; the opt-in gate (autoMirrorsByDefault / isReexportOptInRequired)
+ * is the load-bearing no-auto-flood guard the renderer push loops apply.
+ */
+
+const {
+  REEXPORT_PROVIDERS,
+  isPlaylistPushCandidate,
+  autoMirrorsByDefault,
+  isReexportOptInRequired,
+} = require('../../sync-engine/playlist-push-candidate');
+
+const pl = (id, extra = {}) => ({ id, ...extra });
+
+describe('isPlaylistPushCandidate — accept-list (LB re-export added)', () => {
+  test('local-* / hosted push to any provider', () => {
+    for (const provider of ['spotify', 'applemusic', 'listenbrainz']) {
+      expect(isPlaylistPushCandidate(pl('local-123'), provider)).toBe(true);
+      expect(isPlaylistPushCandidate(pl('hosted-abc', { sourceUrl: 'https://x/y.xspf' }), provider)).toBe(true);
+    }
+  });
+
+  test('spotify-* push to applemusic + listenbrainz, NOT back to spotify', () => {
+    expect(isPlaylistPushCandidate(pl('spotify-AAA'), 'applemusic')).toBe(true);
+    expect(isPlaylistPushCandidate(pl('spotify-AAA'), 'listenbrainz')).toBe(true);
+    expect(isPlaylistPushCandidate(pl('spotify-AAA'), 'spotify')).toBe(false); // not base, not LB
+  });
+
+  test('applemusic-* push to listenbrainz only', () => {
+    expect(isPlaylistPushCandidate(pl('applemusic-p.AAA'), 'listenbrainz')).toBe(true);
+    expect(isPlaylistPushCandidate(pl('applemusic-p.AAA'), 'spotify')).toBe(false);
+    expect(isPlaylistPushCandidate(pl('applemusic-p.AAA'), 'applemusic')).toBe(false);
+  });
+
+  test('NEW: listenbrainz-* is ELIGIBLE for Spotify + Apple Music', () => {
+    expect(isPlaylistPushCandidate(pl('listenbrainz-mbid-1'), 'spotify')).toBe(true);
+    expect(isPlaylistPushCandidate(pl('listenbrainz-mbid-1'), 'applemusic')).toBe(true);
+  });
+
+  test('Spotify keeps the don\'t-write-back guard for a playlist that already has a Spotify id', () => {
+    expect(isPlaylistPushCandidate(pl('listenbrainz-mbid-1', { spotifyId: 'sp1' }), 'spotify')).toBe(false);
+    expect(isPlaylistPushCandidate(pl('local-1', { sources: { spotify: { spotifyId: 'sp1' } } }), 'spotify')).toBe(false);
+    // …but it can still go to Apple Music.
+    expect(isPlaylistPushCandidate(pl('listenbrainz-mbid-1', { spotifyId: 'sp1' }), 'applemusic')).toBe(true);
+  });
+});
+
+describe('autoMirrorsByDefault — only listenbrainz-* is opt-in', () => {
+  test('false ONLY for listenbrainz-*', () => {
+    expect(autoMirrorsByDefault(pl('listenbrainz-mbid-1'))).toBe(false);
+  });
+  test('true for local- / spotify- / applemusic- / hosted', () => {
+    expect(autoMirrorsByDefault(pl('local-1'))).toBe(true);
+    expect(autoMirrorsByDefault(pl('spotify-AAA'))).toBe(true);
+    expect(autoMirrorsByDefault(pl('applemusic-p.AAA'))).toBe(true);
+    expect(autoMirrorsByDefault(pl('hosted-abc', { sourceUrl: 'https://x' }))).toBe(true);
+    expect(autoMirrorsByDefault(pl(undefined))).toBe(true); // no id → not LB-origin
+  });
+});
+
+describe('isReexportOptInRequired — the no-auto-flood gate', () => {
+  test('TRUE for a listenbrainz-* playlist targeting a streaming provider', () => {
+    expect(isReexportOptInRequired(pl('listenbrainz-mbid-1'), 'spotify')).toBe(true);
+    expect(isReexportOptInRequired(pl('listenbrainz-mbid-1'), 'applemusic')).toBe(true);
+  });
+
+  test('FALSE for listenbrainz-* targeting listenbrainz (id-prefix guard owns that)', () => {
+    expect(isReexportOptInRequired(pl('listenbrainz-mbid-1'), 'listenbrainz')).toBe(false);
+  });
+
+  test('FALSE for non-LB playlists (they auto-mirror as before)', () => {
+    expect(isReexportOptInRequired(pl('local-1'), 'spotify')).toBe(false);
+    expect(isReexportOptInRequired(pl('spotify-AAA'), 'applemusic')).toBe(false);
+    expect(isReexportOptInRequired(pl('hosted-abc', { sourceUrl: 'https://x' }), 'spotify')).toBe(false);
+  });
+
+  test('REEXPORT_PROVIDERS is exactly the streaming services', () => {
+    expect(new Set(REEXPORT_PROVIDERS)).toEqual(new Set(['spotify', 'applemusic']));
+  });
+});
+
+describe('opt-in gate decision (what the push loop computes)', () => {
+  // The renderer push loop skips a create iff isReexportOptInRequired AND the
+  // playlist is NOT opted into this provider. These assert that combined rule.
+  const gatedSkip = (playlist, providerId, optedInProviders) =>
+    isReexportOptInRequired(playlist, providerId) && !(optedInProviders || []).includes(providerId);
+
+  test('a LB playlist with NO opt-in is skipped for Spotify/AM (no auto-flood)', () => {
+    expect(gatedSkip(pl('listenbrainz-mbid-1'), 'spotify', [])).toBe(true);
+    expect(gatedSkip(pl('listenbrainz-mbid-1'), 'applemusic', undefined)).toBe(true);
+  });
+
+  test('a LB playlist explicitly opted into a provider is NOT skipped', () => {
+    expect(gatedSkip(pl('listenbrainz-mbid-1'), 'spotify', ['spotify'])).toBe(false);
+    expect(gatedSkip(pl('listenbrainz-mbid-1'), 'applemusic', ['spotify', 'applemusic'])).toBe(false);
+  });
+
+  test('a non-LB playlist is never skipped by this gate', () => {
+    expect(gatedSkip(pl('local-1'), 'spotify', [])).toBe(false);
+    expect(gatedSkip(pl('spotify-AAA'), 'applemusic', [])).toBe(false);
+  });
+
+  // The SAME predicate must guard every main-process create/link SIDE-DOOR, not
+  // just the renderer push loops — an adversarial review found relinkOrphansFor
+  // (the "Clean up duplicates" path) auto-linked an un-opted listenbrainz-*
+  // playlist to a same-named owned Spotify/AM remote, then re-exported it via
+  // the un-gated `locallyModified` push branch. These pin the relink/gateway
+  // decision (main.js relinkOrphansFor orphan filter + sync:create-playlist).
+  test('relink/gateway side-door: an un-opted listenbrainz-* orphan is NOT a relink candidate for streaming', () => {
+    expect(gatedSkip(pl('listenbrainz-mbid-1'), 'spotify', [])).toBe(true);
+    expect(gatedSkip(pl('listenbrainz-mbid-1'), 'applemusic', [])).toBe(true);
+  });
+
+  test('relink/gateway side-door: an OPTED-IN listenbrainz-* playlist still relinks/creates', () => {
+    expect(gatedSkip(pl('listenbrainz-mbid-1'), 'spotify', ['spotify'])).toBe(false);
+  });
+
+  test('relink/gateway side-door: a non-LB orphan relinks freely (e.g. local- name-match)', () => {
+    expect(gatedSkip(pl('local-1'), 'spotify', [])).toBe(false);
+  });
+});

--- a/tests/sync/playlist-reconcile.test.js
+++ b/tests/sync/playlist-reconcile.test.js
@@ -127,6 +127,7 @@ class Harness {
     this.pullSource = null;
     this.removedLinks = [];
     this.playlist = { tracks: [], locallyModified: false, lastModified: 0, writable: true };
+    this.mirrorOnly = false;
     this.state = { baseline: { localPlaylistId: localId, tracks: [], baselineSyncedAt: this.time }, providers: {} };
   }
   add(provider, externalId) {
@@ -184,6 +185,7 @@ class Harness {
       remoteLists: this._remoteLists(),
       storedTokens: this.state.providers,
       pullSource: this.pullSource,
+      mirrorOnly: this.mirrorOnly,
       coordinator: createHydrationCoordinator({ cache: this.cache, clock: () => this.time }),
       cache: this.cache,
       now: this.time,
@@ -430,28 +432,58 @@ describe('reconcile — adversarial-review regressions (PB-1, PB-2)', () => {
   });
 });
 
-describe('reconcile — missingStreak gate (shared-root fix)', () => {
-  test('read-only authoritative source: single transient omission protected, sustained one propagates', async () => {
-    const h = new Harness('spotify-pl');
-    h.playlist.writable = false; // read-only imported source
+describe('reconcile — source-authority split (missingStreak gate scoped to OWNED sources)', () => {
+  // Set up a source-mirrored playlist: Spotify is the pull source, LB the mirror.
+  function setupSourceMirror(localId, { writable }) {
+    const h = new Harness(localId);
+    h.playlist.writable = writable;
     h.pullSource = { providerId: 'spotify', externalId: 'ext-spotify' };
     const sp = h.add(new FakeProvider('spotify', 'ByNativeId'), 'ext-spotify');
     const lb = h.add(new FakeProvider('listenbrainz', 'ByPosition'));
     h.seed([mk('m0'), mk('m1'), mk('m2')]);
-    h.warmCache('spotify', 'm2'); // m2 was materialized on the source
+    return { h, sp, lb };
+  }
 
-    // CYCLE 1 — the source's complete fetch transiently omits m2 (streak 1).
-    h.drift(sp, [mk('m0'), mk('m1')]);
+  test('V8 — followed (read-only) source rotate-out drops IMMEDIATELY (one-way mirror, no gate)', async () => {
+    const { h, sp, lb } = setupSourceMirror('spotify-pl', { writable: false });
+    // NO warmCache: the immediate-authority path bypasses the hydration cache.
+    h.drift(sp, [mk('m0'), mk('m1')]); // ONE complete fetch rotates m2 out
     await h.cycle();
-    expect(lb.remote.length).toBe(3); // m2 NOT dropped — single omission is transient
-    expect(lb.removeByPositionCalls).toEqual([]);
-    expect(h.state.baseline.tracks.length).toBe(3);
-
-    // CYCLE 2 — the source still omits m2 (streak 2 → escalates → real delete).
-    await h.cycle();
-    expect(mbidsOf(lb.remote)).toEqual(new Set(['m0', 'm1'])); // delete propagated
+    expect(mbidsOf(lb.remote)).toEqual(new Set(['m0', 'm1'])); // dropped in ONE cycle
     expect(lb.removeByPositionCalls.length).toBe(1);
     expect(h.state.baseline.tracks.length).toBe(2);
+    expect(mbidsOf(h.playlist.tracks)).toEqual(new Set(['m0', 'm1']));
+  });
+
+  test('V8b — a TRUNCATED followed-source fetch does NOT drop (partial-fetch floor before immediate authority)', async () => {
+    const { h, sp, lb } = setupSourceMirror('spotify-pl', { writable: false });
+    h.drift(sp, [mk('m0'), mk('m1')]); // remote DECLARES 2 (changed vs baseline 3)…
+    sp.truncateFetchTo = 1; // …but the FETCH returns only 1 (truncated)
+    await h.cycle();
+    expect(mbidsOf(h.playlist.tracks)).toEqual(new Set(['m0', 'm1', 'm2'])); // all 3 retained
+    expect(h.state.baseline.tracks.length).toBe(3);
+    expect(lb.remote.length).toBe(3);
+    expect(lb.removeByPositionCalls).toEqual([]);
+  });
+
+  test('owned source single transient omission is gate-protected (not dropped)', async () => {
+    const { h } = setupSourceMirror('spotify-pl', { writable: true }); // OWNED source
+    h.warmCache('spotify', 'm2'); // materialized → the gate consults its streak
+    h.drift(h.provider('spotify'), [mk('m0'), mk('m1')]); // ONE omission
+    await h.cycle();
+    expect(mbidsOf(h.playlist.tracks)).toEqual(new Set(['m0', 'm1', 'm2'])); // PROTECTED — m2 retained
+    expect(h.state.baseline.tracks.length).toBe(3);
+    expect(h.cache.select('mbid-m2', 'spotify').missingStreak).toBe(1); // stepped, not yet escalated
+  });
+
+  test('V9 — mirrorOnly flag forces an immediate one-way drop on an OWNED source despite streak 0', async () => {
+    const { h, lb } = setupSourceMirror('spotify-pl', { writable: true }); // OWNED…
+    h.mirrorOnly = true; // …but user-flagged one-way
+    h.drift(h.provider('spotify'), [mk('m0'), mk('m1')]);
+    await h.cycle();
+    expect(mbidsOf(lb.remote)).toEqual(new Set(['m0', 'm1'])); // drops in ONE cycle, no gate
+    expect(h.state.baseline.tracks.length).toBe(2);
+    expect(mbidsOf(h.playlist.tracks)).toEqual(new Set(['m0', 'm1']));
   });
 
   test('cache recordSeen resets the streak; recordMissing increments it', () => {


### PR DESCRIPTION
Desktop parity with mobile's deliberate divergence ([`9780432`](https://github.com/Parachord/parachord-mobile/commit/9780432) / [parachord-mobile#277](https://github.com/Parachord/parachord-mobile/issues/277)). **Pushed for testing — not merged** (keeping next-step N-way work on a branch per request).

## The break this fixes

#922's missingStreak gate applied to **every** authoritative source. For a **followed** (read-only) source — a Spotify Daily Brew rotating ~40 tracks/day — the gate means rotated-out tracks never escalate to a drop, so the canonical playlist **accumulates without bound** (the bloat the pull-source-authority fix closed). And the gate buys nothing there: a wrong drop on a followed source **self-heals** next cycle when the source re-asserts the track.

## What changed

**Task 1 — scope the gate** (`sync-engine/playlist-reconcile.js`):
```js
immediateAuthority = authoritativeCopyId === 'local' || mirrorOnly || !playlist.writable
```
Hosted-XSPF (`'local'`), a followed (`!writable`) provider source, or a user-flagged mirror-only playlist → drops **immediately** (single-authority one-way mirror, no gate). **Only an owned, non-mirror provider source keeps the streak gate** (a transient complete-fetch omission there could lose a real user edit). The **partial-fetch floor (A1) still runs first**, so a truncated followed-source fetch can't mass-drop. Byte-aligned with mobile.

**Task 2 — `mirrorOnly` flag** (`main.js`, `nway-reconcile-driver.js`, `preload.js`): persisted in a dedicated electron-store map `sync_playlist_mirror_only` (parallel to `sync_playlist_links`/`state`), **not** on the playlist row — a pull can't clobber it. `isPlaylistWritable` derives desktop's owned-vs-followed signal from the `source` field (`<provider>-import` = followed). The driver attaches the derived `writable` only to the per-cycle reconcile copy (never persisted) and threads `mirrorOnly`. + `nway:get/set-mirror-only` IPC + preload bridge.

**Task 3 — UI** (`app.js`): a "Mirror only (one-way)" toggle beside Local-only in the playlist sync header. `forced = followed || hostedXspf`, `effective = forced || flag`; checked = effective, **locked when forced**, with explanatory captions. User-settable only for owned playlists (covers owned-but-dynamic Daily Brews a 3rd-party app like SmarterPlaylists writes through the user's OAuth, which the provider reports as user-owned).

**Task 4 — tests** (`tests/sync/playlist-reconcile.test.js`): the old `writable=false` 2-cycle escalation vector is now an immediate one-cycle drop, rewritten into mobile's `NwaySourceAuthorityTest` shape:
- **V8** — followed source rotate-out drops in **one** cycle (no gate).
- **V8b** — a **truncated** followed-source fetch does **not** drop (floor before immediate authority).
- **owned-single-omission** — an owned source's single transient omission stays **gate-protected** (streak=1).
- **V9** — a `mirrorOnly` owned source drops **immediately** despite streak 0.

V8 + V9 verified to **FAIL against the pre-split core** (load-bearing).

## Acceptance (all met)

- Followed/hosted/mirror-only source rotate-out propagates in **one cycle** (no 2-cycle lag, no accumulation).
- An owned playlist's transient omission is still protected until sustained ≥2 cycles.
- Gate logic + partial-fetch floor stay byte-aligned with mobile.

## Notes for your test pass

- Still **dormant** — `nway_shadow_enabled`/`nway_propagate` default OFF; the gate only affects behavior once armed. The UI toggle + persistence work independently and are safe to exercise now.
- The toggle lives in the owned-playlist sync header (its primary, user-settable home). Pure-followed playlists (which have `syncedFrom`) enforce one-way in the reconcile regardless; if you want the locked chip surfaced on their detail UI too, say so and I'll add it.

## Test plan

- [x] `npx jest` → 57 suites, 1817 tests green; 21 reconcile vectors.
- [x] V8/V9 verified to fail against the pre-split reconcile.
- [ ] Manual: toggle Mirror-only on an owned synced playlist; confirm persistence survives a pull; arm shadow + `nway.shadowRun()` and inspect plans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)