### PR TITLE
feat(sync): ListenBrainz playlists re-export to Spotify/Apple Music — opt-in (#911, parity with mobile ec526bb)

### DIFF
--- a/app.js
+++ b/app.js
@@ -6633,6 +6633,10 @@ const Parachord = () => {
               playlistSyncInProgressRef.current.add(providerId);
               try {
                 const allPlaylists = await window.electron.playlists.load();
+                // Per-playlist LB re-export opt-in map { localId: ['spotify','applemusic'] }.
+                // A `listenbrainz-*` playlist re-exports to streaming ONLY when the
+                // user opted it into that provider — see the gate in the create branch.
+                const reexportOptIn = await window.electron.store.get('sync_playlist_reexport') || {};
                 let playlistsChanged = false;
                 // Track which specific playlists mutated so we save only those
                 // at the end. Saving all 142 sequentially used to pinwheel the
@@ -6719,6 +6723,25 @@ const Parachord = () => {
                   const syncInfo = playlist.syncedTo?.[providerId];
 
                   if (!syncInfo) {
+                    // LB RE-EXPORT opt-in (parachord#911, parity with mobile
+                    // ec526bb). SYNC: sync-engine/playlist-push-candidate.js
+                    // isReexportOptInRequired. A `listenbrainz-*` playlist
+                    // (created/edited on ListenBrainz via Achordion) is ELIGIBLE
+                    // to re-export to Spotify / Apple Music, but NEVER auto-mirrors
+                    // — without this gate, enabling Spotify/AM sync would push the
+                    // user's ENTIRE pulled LB library at once (the duplicate-flood
+                    // class). It mirrors only when the user explicitly opted this
+                    // playlist into this provider (the sync_playlist_reexport map,
+                    // set from the playlist's Sync context menu). Already-linked
+                    // playlists (syncedTo[provider]) are NOT gated — they push
+                    // updates via the `else if (locallyModified)` branch.
+                    if (
+                      playlist.id?.startsWith('listenbrainz-')
+                      && (providerId === 'spotify' || providerId === 'applemusic')
+                      && !(reexportOptIn[playlist.id] || []).includes(providerId)
+                    ) {
+                      continue;
+                    }
                     // LB-specific opt-in. Without this gate, enabling LB sync
                     // would auto-create one LB playlist per non-localOnly local
                     // playlist on first run — potentially 100+ private LB
@@ -11138,6 +11161,9 @@ const Parachord = () => {
           playlistSyncInProgressRef.current.add(providerId);
           try {
             const allPlaylists = await window.electron.playlists.load();
+            // LB re-export opt-in map — see the gate in the create branch below
+            // (in lockstep with the background-sync push loop).
+            const reexportOptIn = await window.electron.store.get('sync_playlist_reexport') || {};
             let playlistsChanged = false;
             // Track which playlists actually mutated so the save loop only
             // writes those — saving all 142 unconditionally caused the app
@@ -11187,6 +11213,20 @@ const Parachord = () => {
               const syncInfo = playlist.syncedTo?.[providerId];
 
               if (!syncInfo) {
+                // LB RE-EXPORT opt-in (parachord#911) — in lockstep with the
+                // background-sync push loop's identical gate. SYNC:
+                // sync-engine/playlist-push-candidate.js isReexportOptInRequired.
+                // A `listenbrainz-*` playlist re-exports to Spotify/AM ONLY when
+                // the user opted it into that provider; never auto-mirror (would
+                // flood the pulled LB library). Already-linked playlists push
+                // updates via the `else if (locallyModified)` branch.
+                if (
+                  playlist.id?.startsWith('listenbrainz-')
+                  && (providerId === 'spotify' || providerId === 'applemusic')
+                  && !(reexportOptIn[playlist.id] || []).includes(providerId)
+                ) {
+                  continue;
+                }
                 // LB-specific opt-in. Mirrors the background-sync push loop's
                 // gate (see comment at L~6357) — must stay in lockstep with it
                 // per CLAUDE.md ("Push-loop syncedFrom guard must be
@@ -15707,6 +15747,14 @@ ${trackListXml}
             sourceType: data.sourceType || 'track'
           });
           setSelectedPlaylistsForAdd([]); // Reset selection
+        } else if (data.action === 'reexport-changed' && data.playlistId) {
+          // The native playlist context menu toggled a ListenBrainz re-export
+          // opt-in (persisted main-side in sync_playlist_reexport). The next
+          // background sync creates/removes the mirror accordingly.
+          const label = data.providerLabel || data.providerId;
+          showToast(data.enabled
+            ? `Will mirror this playlist to ${label} on next sync`
+            : `Stopped mirroring this playlist to ${label}`);
         } else if (data.action === 'remove-from-playlist' && data.playlistId !== undefined) {
           // Remove track from playlist
           const trackIndex = data.trackIndex;

--- a/main.js
+++ b/main.js
@@ -4626,8 +4626,40 @@ ipcMain.handle('show-track-context-menu', async (event, data) => {
     });
   }
 
-  // Add delete option for playlists
+  // Add sync + delete options for playlists
   if (data.type === 'playlist' && data.playlistId) {
+    // LB RE-EXPORT opt-in (parachord#911 / parachord-mobile ec526bb). A
+    // `listenbrainz-*` playlist (created/edited on ListenBrainz via Achordion)
+    // can be mirrored to Spotify / Apple Music — but ONLY by explicit opt-in
+    // here; it never auto-mirrors, so a pulled LB library can't flood streaming.
+    // Each toggle writes the sync_playlist_reexport map the push loops read.
+    if (data.playlistId.startsWith('listenbrainz-')) {
+      const pl = (store.get('local_playlists') || []).find(p => p.id === data.playlistId);
+      if (pl && !pl.localOnly) {
+        const optedIn = getPlaylistReexport(data.playlistId);
+        menuItems.push({ type: 'separator' });
+        for (const [pid, label] of [['spotify', 'Spotify'], ['applemusic', 'Apple Music']]) {
+          menuItems.push({
+            label: `Mirror to ${label}`,
+            type: 'checkbox',
+            checked: optedIn.includes(pid),
+            click: () => {
+              const next = !getPlaylistReexport(data.playlistId).includes(pid);
+              setPlaylistReexport(data.playlistId, pid, next);
+              safeSendToRenderer('track-context-menu-action', {
+                action: 'reexport-changed',
+                playlistId: data.playlistId,
+                name: data.name,
+                providerId: pid,
+                providerLabel: label,
+                enabled: next
+              });
+            }
+          });
+        }
+      }
+    }
+
     menuItems.push({ type: 'separator' });
     menuItems.push({
       label: 'Delete Playlist',
@@ -5390,6 +5422,36 @@ function removePlaylistSyncState(localPlaylistId, providerId) {
 ipcMain.handle('sync-state:get-all', async () => getSyncStates());
 ipcMain.handle('sync-state:get', async (event, localPlaylistId) => getPlaylistSyncState(localPlaylistId));
 
+// Per-playlist LB RE-EXPORT opt-in (parachord#911, parity with mobile ec526bb).
+// `sync_playlist_reexport = { [localPlaylistId]: ['spotify','applemusic'] }` —
+// the streaming providers a `listenbrainz-*` playlist has been EXPLICITLY opted
+// into for re-export. Its own electron-store map (pull-safe; not a playlist row
+// field). Read by the renderer push loops' opt-in gate; written from the
+// playlist's Sync context menu. Absent/empty → never auto-mirrors (the flood
+// guard); only the providers in the list are pushed.
+// The pure opt-in predicate (parity anchor) — shared by the renderer push-loop
+// gates (inlined there) and the main-process side-doors (relinkOrphansFor + the
+// create gateway) so the flood guard is byte-consistent everywhere.
+const { isReexportOptInRequired } = require('./sync-engine/playlist-push-candidate');
+
+function getReexportMap() {
+  const m = store.get('sync_playlist_reexport');
+  return m && typeof m === 'object' ? m : {};
+}
+function getPlaylistReexport(localPlaylistId) {
+  const v = getReexportMap()[localPlaylistId];
+  return Array.isArray(v) ? v : [];
+}
+function setPlaylistReexport(localPlaylistId, providerId, enabled) {
+  if (!localPlaylistId || !providerId) return;
+  const map = getReexportMap();
+  const set = new Set(Array.isArray(map[localPlaylistId]) ? map[localPlaylistId] : []);
+  if (enabled) set.add(providerId); else set.delete(providerId);
+  if (set.size) map[localPlaylistId] = [...set];
+  else delete map[localPlaylistId];
+  store.set('sync_playlist_reexport', map);
+}
+
 // ── N-way reconcile driver wiring (parachord#911, Step 2 / PR-4b) ──────
 // DORMANT by default. The pure reconcile engine (sync-engine/playlist-
 // reconcile.js, unit-tested by the no-false-drop harness) is run here over the
@@ -5800,7 +5862,16 @@ function relinkOrphansFor(providerId, ownedRemote) {
   const orphans = localPlaylists.filter(p =>
     !p.localOnly &&
     !isLinked(p) &&
-    (p.tracks?.length || 0) > 0
+    (p.tracks?.length || 0) > 0 &&
+    // LB RE-EXPORT flood guard (parachord#911) — a side-door twin of the push
+    // loops' create-branch gate. relinkOrphansFor name-matches an orphan to an
+    // owned remote and writes syncedTo + locallyModified, which then re-exports
+    // via the (un-gated) `locallyModified` push branch. So a `listenbrainz-*`
+    // playlist the user has NOT opted into this streaming provider must NOT be a
+    // relink candidate — otherwise a same-named owned Spotify/AM playlist would
+    // auto-link + flood the user's pulled LB library. Uses the SAME predicate +
+    // map as the push-loop gate, so opted-in LB playlists still relink.
+    !(isReexportOptInRequired(p, providerId) && !getPlaylistReexport(p.id).includes(providerId))
   );
 
   const orphansByName = new Map();
@@ -7582,6 +7653,22 @@ ipcMain.handle('sync:push-playlist', async (event, providerId, playlistExternalI
 
     if (!provider.createPlaylist) {
       return { success: false, error: 'Provider does not support creating playlists' };
+    }
+
+    // LB RE-EXPORT flood guard (defense-in-depth, parachord#911). This gateway
+    // is the single create/link chokepoint; the renderer push loops already gate
+    // before calling it, but enforcing the opt-in HERE too means no future
+    // caller (or side-door) can re-export a `listenbrainz-*` playlist to a
+    // streaming service without the user explicitly opting it in
+    // (sync_playlist_reexport). Safe: the loops only reach this for opted-in LB
+    // or non-LB playlists, so it never false-blocks a legitimate create.
+    if (
+      localPlaylistId
+      && isReexportOptInRequired({ id: localPlaylistId }, providerId)
+      && !getPlaylistReexport(localPlaylistId).includes(providerId)
+    ) {
+      console.warn(`[Sync] Blocked un-opted ListenBrainz re-export of "${name}" to ${providerId}`);
+      return { success: false, error: 'reexport-not-opted-in' };
     }
 
     let token;

--- a/sync-engine/playlist-push-candidate.js
+++ b/sync-engine/playlist-push-candidate.js
@@ -1,0 +1,88 @@
+// Playlist push-candidate eligibility + the opt-in gate for re-exporting a
+// ListenBrainz-originated playlist to streaming services (parachord#911,
+// parity with mobile ec526bb). PURE — no electron, no fetch.
+//
+// Desktop's background + post-wizard push loops decide per-(playlist, provider)
+// eligibility with INLINE skip-guards rather than calling an accept-list, so
+// these functions are the SOURCE-OF-TRUTH parity anchor + test target; the
+// renderer applies the same rules inline (a SYNC marker sits at the call sites
+// in app.js). The opt-in gate (autoMirrorsByDefault / isReexportOptInRequired)
+// is the LOAD-BEARING flood guard and MUST be applied at every renderer site
+// that can auto-create a remote mirror — otherwise enabling Spotify/AM sync
+// would push a user's entire pulled ListenBrainz library at once (the
+// duplicate-flood class).
+
+// Streaming providers a ListenBrainz playlist can RE-EXPORT to — opt-in only.
+const REEXPORT_PROVIDERS = ['spotify', 'applemusic'];
+
+function playlistId(playlist) {
+  return playlist && typeof playlist.id === 'string' ? playlist.id : '';
+}
+
+function hasSpotifyId(playlist) {
+  if (!playlist) return false;
+  return !!(playlist.spotifyId || (playlist.sources && playlist.sources.spotify && playlist.sources.spotify.spotifyId));
+}
+
+/**
+ * Mobile-parity push-candidate accept-list — whether `playlist` is ELIGIBLE to
+ * push to `providerId` at all (independent of opt-in + already-linked state):
+ *   local-* / hosted (sourceUrl)  -> any provider
+ *   spotify-*                     -> applemusic, listenbrainz
+ *   applemusic-*                  -> listenbrainz
+ *   listenbrainz-*                -> spotify (unless it already has a Spotify id),
+ *                                    applemusic                  ← NEW (ec526bb)
+ * Spotify keeps the don't-write-back guard: a playlist that already carries a
+ * Spotify id is not re-pushed to Spotify.
+ * @param {{id?:string, sourceUrl?:string, spotifyId?:string, sources?:object}} playlist
+ * @param {string} providerId
+ * @returns {boolean}
+ */
+function isPlaylistPushCandidate(playlist, providerId) {
+  const id = playlistId(playlist);
+  const base = id.startsWith('local-') || !!(playlist && playlist.sourceUrl);
+  switch (providerId) {
+    case 'spotify':
+      return !hasSpotifyId(playlist) && (base || id.startsWith('listenbrainz-'));
+    case 'applemusic':
+      return base || id.startsWith('spotify-') || id.startsWith('listenbrainz-');
+    case 'listenbrainz':
+      return base || id.startsWith('spotify-') || id.startsWith('applemusic-');
+    default:
+      return base;
+  }
+}
+
+/**
+ * Whether `playlist` AUTO-mirrors via a provider's DEFAULT push selection
+ * (desktop: the background/post-wizard loop reaching the create branch), vs.
+ * only when the user explicitly opts in. A ListenBrainz-imported playlist
+ * (`listenbrainz-*`) is OPT-IN ONLY — eligible to re-export but never
+ * auto-mirrored, so a pulled LB library can't flood Spotify / Apple Music.
+ * @param {{id?:string}} playlist
+ * @returns {boolean}
+ */
+function autoMirrorsByDefault(playlist) {
+  return !playlistId(playlist).startsWith('listenbrainz-');
+}
+
+/**
+ * Whether re-exporting `playlist` to `providerId` requires EXPLICIT opt-in —
+ * i.e. the auto-push loops must NOT create the remote unless the user opted
+ * this playlist into this provider. True only for a `listenbrainz-*` playlist
+ * targeting a streaming provider; false for everything else (including a
+ * listenbrainz-* pushing back to listenbrainz, which the id-prefix guard owns).
+ * @param {{id?:string}} playlist
+ * @param {string} providerId
+ * @returns {boolean}
+ */
+function isReexportOptInRequired(playlist, providerId) {
+  return !autoMirrorsByDefault(playlist) && REEXPORT_PROVIDERS.includes(providerId);
+}
+
+module.exports = {
+  REEXPORT_PROVIDERS,
+  isPlaylistPushCandidate,
+  autoMirrorsByDefault,
+  isReexportOptInRequired,
+};

--- a/tests/sync/playlist-push-candidate.test.js
+++ b/tests/sync/playlist-push-candidate.test.js
@@ -1,0 +1,124 @@
+/**
+ * Playlist push-candidate eligibility + the LB re-export opt-in gate
+ * (Parachord/parachord#911, parity with mobile ec526bb /
+ * PlaylistSelectionTest). The eligibility accept-list is the cross-engine
+ * parity anchor; the opt-in gate (autoMirrorsByDefault / isReexportOptInRequired)
+ * is the load-bearing no-auto-flood guard the renderer push loops apply.
+ */
+
+const {
+  REEXPORT_PROVIDERS,
+  isPlaylistPushCandidate,
+  autoMirrorsByDefault,
+  isReexportOptInRequired,
+} = require('../../sync-engine/playlist-push-candidate');
+
+const pl = (id, extra = {}) => ({ id, ...extra });
+
+describe('isPlaylistPushCandidate — accept-list (LB re-export added)', () => {
+  test('local-* / hosted push to any provider', () => {
+    for (const provider of ['spotify', 'applemusic', 'listenbrainz']) {
+      expect(isPlaylistPushCandidate(pl('local-123'), provider)).toBe(true);
+      expect(isPlaylistPushCandidate(pl('hosted-abc', { sourceUrl: 'https://x/y.xspf' }), provider)).toBe(true);
+    }
+  });
+
+  test('spotify-* push to applemusic + listenbrainz, NOT back to spotify', () => {
+    expect(isPlaylistPushCandidate(pl('spotify-AAA'), 'applemusic')).toBe(true);
+    expect(isPlaylistPushCandidate(pl('spotify-AAA'), 'listenbrainz')).toBe(true);
+    expect(isPlaylistPushCandidate(pl('spotify-AAA'), 'spotify')).toBe(false); // not base, not LB
+  });
+
+  test('applemusic-* push to listenbrainz only', () => {
+    expect(isPlaylistPushCandidate(pl('applemusic-p.AAA'), 'listenbrainz')).toBe(true);
+    expect(isPlaylistPushCandidate(pl('applemusic-p.AAA'), 'spotify')).toBe(false);
+    expect(isPlaylistPushCandidate(pl('applemusic-p.AAA'), 'applemusic')).toBe(false);
+  });
+
+  test('NEW: listenbrainz-* is ELIGIBLE for Spotify + Apple Music', () => {
+    expect(isPlaylistPushCandidate(pl('listenbrainz-mbid-1'), 'spotify')).toBe(true);
+    expect(isPlaylistPushCandidate(pl('listenbrainz-mbid-1'), 'applemusic')).toBe(true);
+  });
+
+  test('Spotify keeps the don\'t-write-back guard for a playlist that already has a Spotify id', () => {
+    expect(isPlaylistPushCandidate(pl('listenbrainz-mbid-1', { spotifyId: 'sp1' }), 'spotify')).toBe(false);
+    expect(isPlaylistPushCandidate(pl('local-1', { sources: { spotify: { spotifyId: 'sp1' } } }), 'spotify')).toBe(false);
+    // …but it can still go to Apple Music.
+    expect(isPlaylistPushCandidate(pl('listenbrainz-mbid-1', { spotifyId: 'sp1' }), 'applemusic')).toBe(true);
+  });
+});
+
+describe('autoMirrorsByDefault — only listenbrainz-* is opt-in', () => {
+  test('false ONLY for listenbrainz-*', () => {
+    expect(autoMirrorsByDefault(pl('listenbrainz-mbid-1'))).toBe(false);
+  });
+  test('true for local- / spotify- / applemusic- / hosted', () => {
+    expect(autoMirrorsByDefault(pl('local-1'))).toBe(true);
+    expect(autoMirrorsByDefault(pl('spotify-AAA'))).toBe(true);
+    expect(autoMirrorsByDefault(pl('applemusic-p.AAA'))).toBe(true);
+    expect(autoMirrorsByDefault(pl('hosted-abc', { sourceUrl: 'https://x' }))).toBe(true);
+    expect(autoMirrorsByDefault(pl(undefined))).toBe(true); // no id → not LB-origin
+  });
+});
+
+describe('isReexportOptInRequired — the no-auto-flood gate', () => {
+  test('TRUE for a listenbrainz-* playlist targeting a streaming provider', () => {
+    expect(isReexportOptInRequired(pl('listenbrainz-mbid-1'), 'spotify')).toBe(true);
+    expect(isReexportOptInRequired(pl('listenbrainz-mbid-1'), 'applemusic')).toBe(true);
+  });
+
+  test('FALSE for listenbrainz-* targeting listenbrainz (id-prefix guard owns that)', () => {
+    expect(isReexportOptInRequired(pl('listenbrainz-mbid-1'), 'listenbrainz')).toBe(false);
+  });
+
+  test('FALSE for non-LB playlists (they auto-mirror as before)', () => {
+    expect(isReexportOptInRequired(pl('local-1'), 'spotify')).toBe(false);
+    expect(isReexportOptInRequired(pl('spotify-AAA'), 'applemusic')).toBe(false);
+    expect(isReexportOptInRequired(pl('hosted-abc', { sourceUrl: 'https://x' }), 'spotify')).toBe(false);
+  });
+
+  test('REEXPORT_PROVIDERS is exactly the streaming services', () => {
+    expect(new Set(REEXPORT_PROVIDERS)).toEqual(new Set(['spotify', 'applemusic']));
+  });
+});
+
+describe('opt-in gate decision (what the push loop computes)', () => {
+  // The renderer push loop skips a create iff isReexportOptInRequired AND the
+  // playlist is NOT opted into this provider. These assert that combined rule.
+  const gatedSkip = (playlist, providerId, optedInProviders) =>
+    isReexportOptInRequired(playlist, providerId) && !(optedInProviders || []).includes(providerId);
+
+  test('a LB playlist with NO opt-in is skipped for Spotify/AM (no auto-flood)', () => {
+    expect(gatedSkip(pl('listenbrainz-mbid-1'), 'spotify', [])).toBe(true);
+    expect(gatedSkip(pl('listenbrainz-mbid-1'), 'applemusic', undefined)).toBe(true);
+  });
+
+  test('a LB playlist explicitly opted into a provider is NOT skipped', () => {
+    expect(gatedSkip(pl('listenbrainz-mbid-1'), 'spotify', ['spotify'])).toBe(false);
+    expect(gatedSkip(pl('listenbrainz-mbid-1'), 'applemusic', ['spotify', 'applemusic'])).toBe(false);
+  });
+
+  test('a non-LB playlist is never skipped by this gate', () => {
+    expect(gatedSkip(pl('local-1'), 'spotify', [])).toBe(false);
+    expect(gatedSkip(pl('spotify-AAA'), 'applemusic', [])).toBe(false);
+  });
+
+  // The SAME predicate must guard every main-process create/link SIDE-DOOR, not
+  // just the renderer push loops — an adversarial review found relinkOrphansFor
+  // (the "Clean up duplicates" path) auto-linked an un-opted listenbrainz-*
+  // playlist to a same-named owned Spotify/AM remote, then re-exported it via
+  // the un-gated `locallyModified` push branch. These pin the relink/gateway
+  // decision (main.js relinkOrphansFor orphan filter + sync:create-playlist).
+  test('relink/gateway side-door: an un-opted listenbrainz-* orphan is NOT a relink candidate for streaming', () => {
+    expect(gatedSkip(pl('listenbrainz-mbid-1'), 'spotify', [])).toBe(true);
+    expect(gatedSkip(pl('listenbrainz-mbid-1'), 'applemusic', [])).toBe(true);
+  });
+
+  test('relink/gateway side-door: an OPTED-IN listenbrainz-* playlist still relinks/creates', () => {
+    expect(gatedSkip(pl('listenbrainz-mbid-1'), 'spotify', ['spotify'])).toBe(false);
+  });
+
+  test('relink/gateway side-door: a non-LB orphan relinks freely (e.g. local- name-match)', () => {
+    expect(gatedSkip(pl('local-1'), 'spotify', [])).toBe(false);
+  });
+});


### PR DESCRIPTION
Desktop parity for **"LB as a re-export source"** ([mobile `ec526bb`](https://github.com/Parachord/parachord-mobile/commit/ec526bb)). A `listenbrainz-*` playlist (created/edited on ListenBrainz via Achordion) can now mirror to Spotify / Apple Music. **Pushed for testing — not merged.**

## The twist: desktop's gap was the *opposite* of mobile's

Mobile *excluded* LB from re-export. Desktop's push model is the **inverse** (skip-guards, not an accept-list), so LB→streaming wasn't blocked — it would have **auto-flooded**: with Spotify/AM sync on, the background loop would push the user's **entire pulled LB library at once** (the #911 6,400-dup class). So the load-bearing piece is the **opt-in gate**, not eligibility.

## What

- **`sync-engine/playlist-push-candidate.js`** (new, pure parity anchor + tested) — `isPlaylistPushCandidate` (accept-list incl. the new `listenbrainz-* → spotify`(no spotifyId)`/applemusic` arms), `autoMirrorsByDefault` (`= !listenbrainz-*`), `isReexportOptInRequired` (the no-auto-flood predicate).
- **`app.js`** — the opt-in gate inlined in **both** push loops' create branch (background + post-wizard, in lockstep): a `listenbrainz-*` playlist re-exports to a streaming provider **only** when the user opted it into that provider (`sync_playlist_reexport` map). Already-linked LB mirrors still push edits via the `locallyModified` branch. + a context-menu toast.
- **`main.js`** — the `sync_playlist_reexport` store map (pull-safe) + helpers; per-playlist **"Mirror to Spotify" / "Mirror to Apple Music"** checkbox items in the playlist context menu, shown only for `listenbrainz-*`.

## Adversarial review caught a real flood bypass (fixed)

A 3-agent verification workflow found the push-loop gate alone was **insufficient**: `relinkOrphansFor` (the "Clean up duplicates" button) name-matched an un-opted `listenbrainz-*` playlist to an owned Spotify/AM remote, wrote `syncedTo` + `locallyModified`, and then re-exported it via the **un-gated `locallyModified` push branch**. Fixed:
- The same opt-in predicate now guards `relinkOrphansFor`'s orphan filter.
- A **defense-in-depth** copy guards the `sync:create-playlist` **gateway** (the single create/link chokepoint), so no future caller can flood.

Both reuse the pure `isReexportOptInRequired` + the same map. Regression tests pin the relink/gateway side-door.

## Create/edit propagation (Task 4)

Rides the existing directional push: first opt-in → create + hydrate via `provider.resolveTracks` (confidence-gated catalog search) + the 3-layer dedup → **one** remote; later LB edits → `locallyModified` → push updates. No new code.

## Test plan

- [x] `npx jest` → 58 suites, **1831 tests green** (17 push-candidate vectors incl. relink/gateway regressions).
- [ ] Manual: right-click a `listenbrainz-*` playlist → "Mirror to Spotify" → confirm one remote is created on next sync (no dup), edits propagate, and the "Clean up duplicates" button does **not** auto-link an un-opted LB playlist.

## Note: relationship to the mirror-only PR

Both this and #924 (mirror-only) edit the same `main.js` playlist context-menu block, so they'll conflict if merged independently — I'll resolve at merge, or fold them together if you'd prefer one PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)