### PR TITLE
smart-links: iOS Universal Links — AASA + /api/lookup (#927, #928)

### DIFF
--- a/smart-links/functions/api/create.js
+++ b/smart-links/functions/api/create.js
@@ -51,6 +51,11 @@ export async function onRequestPost({ request, env, waitUntil }) {
       albumArt: data.albumArt || null,
       type,
       urls: data.urls || null,
+      // The wrapped `parachord://` action this link was created from, when the
+      // share sends it (mobile #138). /api/lookup returns it so the app can
+      // dispatch a PRECISE in-app action instead of falling back to the web
+      // page. Forward-compatible: null until the mobile share starts sending it.
+      deeplink: data.deeplink || null,
       createdAt: Date.now()
     };
 

--- a/smart-links/functions/api/lookup.js
+++ b/smart-links/functions/api/lookup.js
@@ -1,0 +1,31 @@
+// GET /api/lookup?id=<shortId> — resolve a smart link back to its stored payload.
+// The read-side counterpart to create.js: the iOS app calls this when a user
+// opens go.parachord.com/<id> so it can dispatch the in-app action (mobile #138).
+// Returns the raw stored payload as-is (the same shape create.js wrote to KV):
+// { title, artist, creator, albumArt, type, urls, tracks, deeplink, createdAt, enrichedAt }.
+
+const CORS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+};
+
+export async function onRequestGet({ request, env }) {
+  const id = new URL(request.url).searchParams.get('id');
+  if (!id) {
+    return Response.json({ error: 'Missing id' }, { status: 400, headers: CORS });
+  }
+
+  const raw = await env.LINKS.get(id);
+  if (!raw) {
+    return Response.json({ error: 'Not found' }, { status: 404, headers: CORS });
+  }
+
+  // Pass the stored JSON through verbatim (it's already a JSON string in KV).
+  return new Response(raw, { headers: { ...CORS, 'Content-Type': 'application/json' } });
+}
+
+// CORS preflight (mirrors create.js).
+export async function onRequestOptions() {
+  return new Response(null, { headers: CORS });
+}

--- a/smart-links/public/.well-known/apple-app-site-association
+++ b/smart-links/public/.well-known/apple-app-site-association
@@ -1,0 +1,12 @@
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": ["YR3XETE537.com.parachord.ios"],
+        "components": [
+          { "/": "/*", "comment": "All go.parachord.com short links open in app" }
+        ]
+      }
+    ]
+  }
+}

--- a/smart-links/public/_headers
+++ b/smart-links/public/_headers
@@ -1,0 +1,5 @@
+# Apple App Site Association — the file has no extension, so Cloudflare Pages
+# serves it as application/octet-stream by default. iOS requires JSON (and a
+# 200, HTTPS, no redirect), so force the Content-Type here.
+/.well-known/apple-app-site-association
+  Content-Type: application/json


### PR DESCRIPTION
Closes #927, closes #928. The two halves of iOS smart-link deep linking for `go.parachord.com` (the dedicated `smart-links/` Cloudflare Pages app), so a tapped `go.parachord.com/<id>` both opens the app and resolves to an in-app action. Supports mobile [#124](https://github.com/Parachord/parachord-mobile/issues/124) / [#138](https://github.com/Parachord/parachord-mobile/issues/138).

## #927 — AASA (routes the link to the app)
- `smart-links/public/.well-known/apple-app-site-association` — extensionless JSON claiming all paths (`/*`), appID `YR3XETE537.com.parachord.ios`.
- `smart-links/public/_headers` — forces `Content-Type: application/json` on that path. Pages serves the extensionless file as `application/octet-stream` by default, which iOS rejects.

## #928 — `/api/lookup` (resolves the link to an action)
- `smart-links/functions/api/lookup.js` — `GET /api/lookup?id=` returns the stored KV payload verbatim (read-side counterpart to `create.js`), with CORS `*` + an `OPTIONS` preflight. 400 on missing id, 404 on unknown id. This is option 2 from the issue — the minimum that unblocks mobile #138.
- `create.js` now also persists a `deeplink` field when the share sends it (issue's recommended option 1, forward-compatible). `lookup` returns it so the app can dispatch a precise `parachord://` action instead of the web-page fallback. `null` until the mobile share starts sending it — small mobile follow-up.

## ⚠️ Verify before merge
- **Team ID `YR3XETE537`** — taken from the issue. Confirm against Apple Developer → Membership. A wrong Team ID silently breaks domain association.

## Post-deploy verification (acceptance)
Both require the live Pages deploy, so they can't run in CI here:
- `curl -sI https://go.parachord.com/.well-known/apple-app-site-association` → 200, HTTPS, no redirect, `Content-Type: application/json`; body matches the JSON.
- `GET https://go.parachord.com/api/lookup?id=<valid>` → 200 JSON payload, CORS `*`; `?id=<missing>` → 404; no `id` → 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)