### PR TITLE
fix(protocol): open parachord://play/playlist?url=<provider> (#930)

### DIFF
--- a/app.js
+++ b/app.js
@@ -217,6 +217,37 @@ window.isPublicHttpUrl = (urlString) => {
   return true;
 };
 
+// Classify a parachord://play/playlist?url=<url> target so the protocol handler
+// knows how to turn it into tracks (parachord#930). Provider playlist *pages*
+// (Spotify / Apple Music / SoundCloud) are NOT tracklist documents — they have
+// to go through the resolver lookupPlaylist path — and two hosts need a special
+// pre-step. Pure: no I/O, no resolver dependency (the orchestrator does the
+// fetching/sniffing). Returns one of:
+//   { kind: 'achordion', xspfUrl }  — achordion.xyz/playlist/<mbid> → its public XSPF API
+//   { kind: 'soundcloud-short' }    — on.soundcloud.com/<id> → needs a redirect-follow first
+//   { kind: 'standard' }            — everything else: try resolver lookupPlaylist, else parse as a tracklist document
+//
+// SYNC: tests/helpers/playlist-url-classify.js — keep byte-identical with the body below.
+window.classifyPlaylistUrl = (urlString) => {
+  let u;
+  try { u = new URL(urlString); } catch { return { kind: 'standard' }; }
+  const host = u.hostname.toLowerCase();
+
+  // Achordion playlist page → its public, un-challenged XSPF endpoint. The MBID
+  // in /playlist/<mbid> is the ListenBrainz playlist id Achordion mirrors.
+  if (host === 'achordion.xyz' || host === 'www.achordion.xyz') {
+    const m = u.pathname.match(/^\/playlist\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\/?$/i);
+    if (m) return { kind: 'achordion', xspfUrl: `https://achordion.xyz/api/playlist/${m[1].toLowerCase()}/xspf` };
+    return { kind: 'standard' };
+  }
+
+  // SoundCloud short link → 302s to the canonical /sets/ URL. getUrlType()
+  // can't classify it (no /sets/ segment), so it must be resolved first.
+  if (host === 'on.soundcloud.com') return { kind: 'soundcloud-short' };
+
+  return { kind: 'standard' };
+};
+
 // Resolver match validation + minimum confidence threshold.
 //
 // SYNC: tests/helpers/confidence-scoring.js — keep these helpers byte-identical
@@ -12260,6 +12291,91 @@ const Parachord = () => {
   useEffect(() => {
     if (!window.electron?.onProtocolUrl) return;
 
+    // Turn a provider playlist *page* URL (Spotify / Apple Music / SoundCloud /
+    // Achordion) into a normalized { displayName, tracks, albumArt? }, mirroring
+    // the mobile DeepLinkHandler contract for parachord://play/playlist?url=
+    // <provider-url> (parachord#930). These URLs are web pages, not tracklist
+    // documents, so feeding them to parseProtocolTracklist finds zero tracks —
+    // they must go through the resolver lookupPlaylist path (the same one
+    // handleImportPlaylistFromUrl uses). Returns null when the URL isn't a
+    // recognized provider playlist page, so the caller falls back to parsing it
+    // as a hosted tracklist document (XSPF/JSPF/JSON).
+    const resolveProviderPlaylistUrl = async (rawUrl) => {
+      const classified = window.classifyPlaylistUrl(rawUrl);
+
+      // Achordion → its public XSPF endpoint, then the standard tracklist parser.
+      if (classified.kind === 'achordion') {
+        const resp = await fetch(classified.xspfUrl, {
+          redirect: 'error',
+          headers: buildProtocolFetchHeaders(classified.xspfUrl),
+        });
+        if (!resp.ok) throw new Error(`Achordion playlist fetch failed: ${resp.status}`);
+        const body = await resp.text();
+        if (body.length > 100 * 1024) throw new Error('Playlist response too large (max 100KB)');
+        return window.parseProtocolTracklist(body, resp.headers.get('content-type') || 'application/xspf+xml');
+      }
+
+      // SoundCloud short link → resolve the redirect to the canonical /sets/ URL
+      // via the main process (a renderer fetch to SoundCloud is CORS-blocked),
+      // then sniff the resolver below. Re-run the SSRF guard on the resolved URL
+      // (proxy-fetch doesn't re-validate each redirect hop) and require it to
+      // land back on SoundCloud.
+      let url = rawUrl;
+      if (classified.kind === 'soundcloud-short') {
+        let canonical = null;
+        try {
+          const res = await window.electron.proxyFetch(rawUrl, { method: 'HEAD' });
+          canonical = res && res.finalUrl;
+        } catch { /* leave canonical null → throw below */ }
+        let canonHost = '';
+        try { canonHost = new URL(canonical).hostname.toLowerCase(); } catch { canonHost = ''; }
+        if (!canonical || !window.isPublicHttpUrl(canonical) ||
+            !(canonHost === 'soundcloud.com' || canonHost.endsWith('.soundcloud.com'))) {
+          throw new Error('Could not resolve SoundCloud link');
+        }
+        url = canonical;
+      }
+
+      // Resolver-sniffable provider playlist (Spotify / Apple Music / SoundCloud
+      // canonical). Same lookupPlaylist path handleImportPlaylistFromUrl uses.
+      const loader = resolverLoaderRef.current;
+      const resolverId = loader && loader.findResolverForUrl(url);
+      if (resolverId && loader.getUrlType(url) === 'playlist') {
+        const config = await getResolverConfig(resolverId);
+        const result = await loader.lookupPlaylist(url, config);
+        const playlist = result && result.playlist;
+        const tracks = ((playlist && playlist.tracks) || [])
+          .map(t => {
+            const out = { artist: t.artist, title: t.title };
+            if (t.album) out.album = t.album;
+            if (t.spotifyId) out.spotifyId = t.spotifyId;
+            if (t.appleMusicId) out.appleMusicId = t.appleMusicId;
+            if (t.isrc) out.isrc = t.isrc;
+            return out;
+          })
+          .filter(t => t.artist && t.title);
+        if (tracks.length === 0) {
+          throw new Error(`Could not load playlist from ${resolverId}. Make sure ${resolverId} is connected and the playlist is accessible.`);
+        }
+        const name = playlist.name || playlist.title || 'Playlist';
+        const owner = playlist.owner || playlist.creator || playlist.artist;
+        const albumArt = playlist.albumArt || playlist.image || playlist.artwork;
+        return {
+          displayName: owner ? `${name} — ${owner}` : name,
+          tracks,
+          ...(albumArt ? { albumArt } : {}),
+        };
+      }
+
+      // Short link resolved but the canonical URL isn't a recognized playlist
+      // page — surface it rather than letting the caller HTML-parse the page.
+      if (classified.kind === 'soundcloud-short') {
+        throw new Error('SoundCloud link is not a playlist');
+      }
+
+      return null; // not a provider playlist page → caller parses as a tracklist document
+    };
+
     // Resolve any of the protocol play-input shapes into a normalized tracklist.
     // Used by parachord://play-album, play-playlist, play-radio.
     //
@@ -12276,6 +12392,7 @@ const Parachord = () => {
         allowMbid = false,
         allowProviderId = false,
         allowArtistTitleAlbum = false,
+        allowProviderPlaylist = false,
       } = opts;
 
       // 1. MBID — MusicBrainz release-group lookup (album only).
@@ -12343,10 +12460,19 @@ const Parachord = () => {
         };
       }
 
-      // 3. URL (XSPF or JSON).
+      // 3. URL — provider playlist page, or a hosted tracklist document.
       if (params.url) {
         if (!window.isPublicHttpUrl(params.url)) {
           throw new Error('Invalid URL: must be public http/https');
+        }
+        // play/playlist: a provider playlist *page* (Spotify/Apple Music/
+        // SoundCloud/Achordion) resolves via the provider import path
+        // (parachord#930). Returns null for non-provider URLs, which then fall
+        // through to the tracklist-document parse below. Gated to playlist only
+        // so album/radio keep their existing XSPF/JSON-document behavior.
+        if (allowProviderPlaylist) {
+          const fromProvider = await resolveProviderPlaylistUrl(params.url);
+          if (fromProvider) return fromProvider;
         }
         const resp = await fetch(params.url, {
           redirect: 'error',
@@ -12497,6 +12623,7 @@ const Parachord = () => {
                   allowMbid: playKind === 'album',
                   allowProviderId: playKind === 'album',
                   allowArtistTitleAlbum: playKind === 'album',
+                  allowProviderPlaylist: playKind === 'playlist',
                 });
                 if (!tracks || tracks.length === 0) {
                   showToast(`Nothing to play: ${displayName || 'Untitled'}`);

--- a/app.js
+++ b/app.js
@@ -12562,7 +12562,7 @@ const Parachord = () => {
         // they complete instantly and a toast would just be noise.
         const slowCommands = new Set(['play', 'import', 'chat', 'listen-along']);
         if (slowCommands.has(command)) {
-          const playKind = command === 'play' ? segments[0] : null;
+          const playKind = command === 'play' ? (segments[0] || params.type) : null;
           let ackMessage;
           if (command === 'play' && playKind === 'album') ackMessage = 'Loading album…';
           else if (command === 'play' && playKind === 'playlist') ackMessage = 'Loading playlist…';
@@ -12615,7 +12615,13 @@ const Parachord = () => {
           case 'play': {
             // Sub-action routes: parachord://play/album, play/playlist, play/radio.
             // No sub-action: parachord://play?artist=X&title=Y (single-track play).
-            const playKind = segments[0];
+            // The sub-action is normally the path segment, but also accept a
+            // ?type= query param as a fallback so the query form
+            // (parachord://play?type=playlist&url=…) routes the same as the path
+            // form. The website's HTTPS bounce can emit either shape depending
+            // on deploy timing (parachord#930); a non-matching type just falls
+            // through to the single-track path, unchanged.
+            const playKind = segments[0] || params.type;
 
             if (playKind === 'album' || playKind === 'playlist') {
               try {

--- a/main.js
+++ b/main.js
@@ -4124,7 +4124,7 @@ ipcMain.handle('proxy-fetch', async (event, url, options = {}) => {
       console.log('Proxy fetch failed with status:', response.status);
       const errorText = await response.text();
       console.log('Error response body:', errorText.substring(0, 500));
-      return { success: false, status: response.status, error: `HTTP ${response.status}`, text: errorText };
+      return { success: false, status: response.status, error: `HTTP ${response.status}`, text: errorText, finalUrl: response.url };
     }
 
     // Handle arraybuffer response type (for audio/binary data)
@@ -4133,7 +4133,7 @@ ipcMain.handle('proxy-fetch', async (event, url, options = {}) => {
       console.log('Proxy fetch got arraybuffer, size:', arrayBuffer.byteLength);
       // Convert ArrayBuffer to base64 for IPC transfer
       const base64 = Buffer.from(arrayBuffer).toString('base64');
-      return { success: true, status: response.status, data: base64 };
+      return { success: true, status: response.status, data: base64, finalUrl: response.url };
     }
 
     const text = await response.text();
@@ -4147,7 +4147,10 @@ ipcMain.handle('proxy-fetch', async (event, url, options = {}) => {
       console.log('No track_id found in response');
     }
 
-    return { success: true, status: response.status, text };
+    // finalUrl exposes the post-redirect URL (Node fetch follows redirects by
+    // default) so callers can resolve short links — e.g. on.soundcloud.com →
+    // canonical soundcloud.com/.../sets/... for parachord://play/playlist (#930).
+    return { success: true, status: response.status, text, finalUrl: response.url };
   } catch (error) {
     console.error('Proxy fetch error:', error);
     return { success: false, error: error.message };

--- a/tests/helpers/playlist-url-classify.js
+++ b/tests/helpers/playlist-url-classify.js
@@ -1,0 +1,25 @@
+// SYNC MIRROR of app.js `window.classifyPlaylistUrl` (parachord#930).
+// Keep the function BODY byte-identical with app.js. This is the test-side
+// source of truth for the parachord://play/playlist?url= routing decision.
+
+function classifyPlaylistUrl(urlString) {
+  let u;
+  try { u = new URL(urlString); } catch { return { kind: 'standard' }; }
+  const host = u.hostname.toLowerCase();
+
+  // Achordion playlist page → its public, un-challenged XSPF endpoint. The MBID
+  // in /playlist/<mbid> is the ListenBrainz playlist id Achordion mirrors.
+  if (host === 'achordion.xyz' || host === 'www.achordion.xyz') {
+    const m = u.pathname.match(/^\/playlist\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\/?$/i);
+    if (m) return { kind: 'achordion', xspfUrl: `https://achordion.xyz/api/playlist/${m[1].toLowerCase()}/xspf` };
+    return { kind: 'standard' };
+  }
+
+  // SoundCloud short link → 302s to the canonical /sets/ URL. getUrlType()
+  // can't classify it (no /sets/ segment), so it must be resolved first.
+  if (host === 'on.soundcloud.com') return { kind: 'soundcloud-short' };
+
+  return { kind: 'standard' };
+}
+
+module.exports = { classifyPlaylistUrl };

--- a/tests/protocol/playlist-url-classify.test.js
+++ b/tests/protocol/playlist-url-classify.test.js
@@ -1,0 +1,87 @@
+/**
+ * parachord://play/playlist?url=<provider-url> routing classification
+ * (parachord#930). Covers the five test URLs from the issue plus edge cases.
+ * The orchestrator (resolveProviderPlaylistUrl in app.js) does the actual
+ * fetching/resolver-sniffing; this verifies the pure routing DECISION only.
+ */
+
+const { classifyPlaylistUrl } = require('../helpers/playlist-url-classify');
+
+describe('classifyPlaylistUrl', () => {
+  describe('Achordion → public XSPF endpoint', () => {
+    test('playlist page maps to /api/playlist/<mbid>/xspf', () => {
+      expect(classifyPlaylistUrl(
+        'https://achordion.xyz/playlist/c2accebd-ccd1-42c6-8ce7-ec0e8cf6cd13'
+      )).toEqual({
+        kind: 'achordion',
+        xspfUrl: 'https://achordion.xyz/api/playlist/c2accebd-ccd1-42c6-8ce7-ec0e8cf6cd13/xspf',
+      });
+    });
+
+    test('www. host is accepted', () => {
+      expect(classifyPlaylistUrl(
+        'https://www.achordion.xyz/playlist/c2accebd-ccd1-42c6-8ce7-ec0e8cf6cd13'
+      ).kind).toBe('achordion');
+    });
+
+    test('uppercase MBID is lowercased in the API URL', () => {
+      expect(classifyPlaylistUrl(
+        'https://achordion.xyz/playlist/C2ACCEBD-CCD1-42C6-8CE7-EC0E8CF6CD13'
+      ).xspfUrl).toBe('https://achordion.xyz/api/playlist/c2accebd-ccd1-42c6-8ce7-ec0e8cf6cd13/xspf');
+    });
+
+    test('trailing slash is tolerated', () => {
+      expect(classifyPlaylistUrl(
+        'https://achordion.xyz/playlist/c2accebd-ccd1-42c6-8ce7-ec0e8cf6cd13/'
+      ).kind).toBe('achordion');
+    });
+
+    test('non-UUID achordion path falls back to standard (not a playlist mbid)', () => {
+      expect(classifyPlaylistUrl('https://achordion.xyz/playlist/not-a-uuid')).toEqual({ kind: 'standard' });
+      expect(classifyPlaylistUrl('https://achordion.xyz/about')).toEqual({ kind: 'standard' });
+    });
+
+    test('an extra path segment after the mbid is not treated as a playlist page', () => {
+      expect(classifyPlaylistUrl(
+        'https://achordion.xyz/playlist/c2accebd-ccd1-42c6-8ce7-ec0e8cf6cd13/extra'
+      )).toEqual({ kind: 'standard' });
+    });
+  });
+
+  describe('SoundCloud short link → redirect-follow', () => {
+    test('on.soundcloud.com is flagged for redirect resolution', () => {
+      expect(classifyPlaylistUrl('https://on.soundcloud.com/Drk2sCLhCHVNugYtAP'))
+        .toEqual({ kind: 'soundcloud-short' });
+    });
+  });
+
+  describe('standard (resolver lookupPlaylist, else tracklist document)', () => {
+    test('Spotify playlist page', () => {
+      expect(classifyPlaylistUrl('https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M'))
+        .toEqual({ kind: 'standard' });
+    });
+    test('Apple Music playlist page', () => {
+      expect(classifyPlaylistUrl(
+        'https://music.apple.com/us/playlist/todays-hits/pl.f4d106fed2bd41149aaacabb233eb5eb'
+      )).toEqual({ kind: 'standard' });
+    });
+    test('SoundCloud canonical set URL', () => {
+      expect(classifyPlaylistUrl('https://soundcloud.com/jherskowitz/sets/frozen-in-time-2026'))
+        .toEqual({ kind: 'standard' });
+    });
+    test('hosted XSPF document URL', () => {
+      expect(classifyPlaylistUrl('https://example.com/my-playlist.xspf'))
+        .toEqual({ kind: 'standard' });
+    });
+    test('a non-short soundcloud subdomain is NOT treated as a short link', () => {
+      // Only on.soundcloud.com is the short-link host; api/m/etc. are not.
+      expect(classifyPlaylistUrl('https://m.soundcloud.com/jherskowitz/sets/x'))
+        .toEqual({ kind: 'standard' });
+    });
+    test('malformed URL is safe (falls back to standard, no throw)', () => {
+      expect(classifyPlaylistUrl('not a url')).toEqual({ kind: 'standard' });
+      expect(classifyPlaylistUrl('')).toEqual({ kind: 'standard' });
+      expect(classifyPlaylistUrl(undefined)).toEqual({ kind: 'standard' });
+    });
+  });
+});


### PR DESCRIPTION
Fixes #930.

## Root cause
`parachord://play/playlist?url=...` opened the app but played nothing. The handler exists ([app.js](app.js) `resolveProtocolPlayInput`), but its `url` branch fetched the URL and fed the body straight to `parseProtocolTracklist`, which only understands **XSPF/JSPF/JSON tracklist documents**. The website's `url=` points at provider playlist **web pages**, so:

- `open.spotify.com/playlist/…`, `music.apple.com/…/playlist/…`, `soundcloud.com/…/sets/…`, `achordion.xyz/playlist/…` → HTML → parser finds 0 tracks → "Nothing to play."
- `on.soundcloud.com/…` short links → `redirect:'error'` threw before parsing.

(The handler, scheme registration, and main→renderer forwarding were all fine — it was purely the `url=` parsing assumption.)

## Fix
Sniff the provider and route through the import path, **gated to `play/playlist` only** so `album`/`radio` keep their tracklist-document behavior:

| URL | Handling |
|---|---|
| Spotify / Apple Music / SoundCloud canonical | `resolverLoader.lookupPlaylist` — the same path `handleImportPlaylistFromUrl` already uses |
| `on.soundcloud.com/<id>` | resolve the redirect to the canonical `/sets/` URL via the main process (renderer fetch is CORS-blocked), re-run the SSRF guard, require it to land on `soundcloud.com`, then sniff |
| `achordion.xyz/playlist/<mbid>` | its public `/api/playlist/<mbid>/xspf` endpoint, then the standard tracklist parser |
| anything else | unchanged — parse as a hosted tracklist document (XSPF/JSPF/JSON) |

`main.js`: `proxy-fetch` now returns `finalUrl` (`response.url` after redirects) so the renderer can resolve the SoundCloud short link.

## Safety
- Provider sniffing only runs for `play/playlist` (`allowProviderPlaylist` opt); album/radio untouched.
- SoundCloud redirect resolution re-validates with `isPublicHttpUrl` **and** requires a `soundcloud.com` final host (proxy-fetch doesn't re-validate each redirect hop).
- 100KB body cap preserved on the Achordion fetch.

## Tests
Routing decision extracted to a pure module-scope helper `window.classifyPlaylistUrl`, mirrored byte-for-byte in `tests/helpers/playlist-url-classify.js` (SYNC-checked) and covered by `tests/protocol/playlist-url-classify.test.js` — the issue's five URLs plus edges (uppercase/trailing-slash MBID, non-UUID achordion path, `m.soundcloud.com` ≠ short link, malformed URL). Full suite green: **1827 tests**.

## Manual verification (please test in-app)
Each should open the app and start playing the playlist:
- `parachord://play/playlist?url=https%3A%2F%2Fopen.spotify.com%2Fplaylist%2F37i9dQZF1DXcBWIGoYBM5M`
- `parachord://play/playlist?url=https%3A%2F%2Fmusic.apple.com%2Fus%2Fplaylist%2Ftodays-hits%2Fpl.f4d106fed2bd41149aaacabb233eb5eb`
- `parachord://play/playlist?url=https%3A%2F%2Fsoundcloud.com%2Fjherskowitz%2Fsets%2Ffrozen-in-time-2026`
- `parachord://play/playlist?url=https%3A%2F%2Fon.soundcloud.com%2FDrk2sCLhCHVNugYtAP`
- `parachord://play/playlist?url=https%3A%2F%2Fachordion.xyz%2Fplaylist%2Fc2accebd-ccd1-42c6-8ce7-ec0e8cf6cd13`

(`open 'parachord://...'` on macOS / `start` on Windows / `xdg-open` on Linux.) Spotify/Apple Music need the respective service connected for `lookupPlaylist`.

Android already handles this shape (mobile #123/#124), so this is desktop reaching parity — no mobile ticket needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)