### PR TITLE
docs: protocol-schema + CLAUDE.md catch up to #930 / #932

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1051,7 +1051,7 @@ Custom-scheme deep links handled at app.js's protocol switch (search `switch (co
 |---|---|---|
 | `parachord://play` | `artist` + `title` | None |
 | `parachord://play/album` | `mbid` / `spotify` / `applemusic` / `url` / `tracks` / `artist`+`title` | None |
-| `parachord://play/playlist` | `url` / `tracks` (optional `title`, `creator`, `shuffle`) | None |
+| `parachord://play/playlist` | `url` (hosted XSPF/JSPF/JSON tracklist **or** provider playlist page — see below) / `tracks` (optional `title`, `creator`, `shuffle`) | None |
 | `parachord://play/radio` | `url` (also reused as refill) / `tracks`+`refill` / `artist`[+`title`] | None |
 | `parachord://listen-along` | `service`=`listenbrainz`\|`lastfm`, `user`=`<username>` | None |
 | `parachord://import` | `url` / `tracks` | Required (writes to library) |
@@ -1059,6 +1059,10 @@ Custom-scheme deep links handled at app.js's protocol switch (search `switch (co
 | `parachord://control/<action>`, `queue/<action>`, `shuffle/<state>`, `volume/<level>`, etc. | varies | None |
 
 **Shared input resolution** (`resolveProtocolPlayInput`, ~L10495): all `play-*` commands feed through one helper that turns `mbid`/provider IDs/url/tracks/artist+title into a normalized `{ displayName, tracks: [{artist, title, album?, mbid?, isrc?}], albumArt? }`. Priority: mbid → spotify → applemusic → url → tracks → artist+title. `opts.allowMbid` / `allowProviderId` / `allowArtistTitleAlbum` gate per-command (album-only shapes silently fall through for non-album commands).
+
+**`play/playlist?url=` provider sniffing** (`classifyPlaylistUrl` in `tests/helpers/playlist-url-classify.js`, tests at `tests/protocol/playlist-url-classify.test.js`): host-sniffs `open.spotify.com` / `music.apple.com` / `soundcloud.com` / `on.soundcloud.com` (short link — main-process `HEAD` follows the 302, re-validates final host) / `achordion.xyz/playlist/<mbid>` (fetched from `https://achordion.xyz/api/playlist/<mbid>/xspf`; the page itself is Vercel bot-challenged). Anything else falls through to the existing hosted-tracklist parse. **Sniffing is gated to `play/playlist` only** — `play/album?url=` and `play/radio?url=` stay tracklist-document-only. Public doc: [`docs/protocol-schema.md` § Play Playlist § Provider URL sniffing](docs/protocol-schema.md). Landed in PR #932 for parachord#930; the website worker's matching path-form bounce in [parachord-website#102](https://github.com/Parachord/parachord-website/pull/102).
+
+**Universal / App Links (HTTPS share form).** Every `parachord://<verb>` URL has a byte-identical `https://parachord.com/<verb>` form. The website worker reconstructs `parachord://` from incoming HTTPS by stripping the host and prefixing the scheme — same path, same query. **The deep link must be the canonical path form** (`parachord://play/playlist?url=...`, not `parachord://play?type=playlist&url=...`); the desktop and mobile parsers read the play sub-action from the path segment, not from `?type=`. The web worker formerly leaked the `?type=` form during internal normalization and silently broke every HTTPS bounce — see [parachord-website#102](https://github.com/Parachord/parachord-website/pull/102) for the inverse-normalization fix. Defense-in-depth: this client also accepts the play sub-action via `segments[0] || params.type` to remain robust against any future re-normalization. URL conventions reference: [parachord-website/CLAUDE.md](https://github.com/Parachord/parachord-website/blob/main/CLAUDE.md).
 
 **Tracklist parser** (`window.parseProtocolTracklist`, ~L33048; SYNCed with `tests/helpers/tracklist-parser.js`): auto-detects XSPF (XML, DOMParser) / JSPF / generic JSON tracklist. JSPF identifier strings are MBID-validated (`/^[a-f0-9-]{36}$/i`). Inline tracks capped at 500; bodies capped at 100KB.
 

--- a/docs/protocol-schema.md
+++ b/docs/protocol-schema.md
@@ -26,6 +26,20 @@ The HTTP endpoint is recommended for:
 - Raycast/Alfred extensions
 - Any programmatic access
 
+### 3. Universal / App Links (Shareable HTTPS)
+
+Every `parachord://<verb>` URL has an equivalent `https://parachord.com/<verb>` form — byte-identical path and query. This is the shareable form (works in emails, SMS, Slack, social posts where custom schemes get stripped):
+
+```
+parachord://play/playlist?url=https%3A%2F%2Fopen.spotify.com%2Fplaylist%2F<id>
+↔
+https://parachord.com/play/playlist?url=https%3A%2F%2Fopen.spotify.com%2Fplaylist%2F<id>
+```
+
+Tapped on mobile (iOS Universal Links / Android App Links) or macOS (Associated Domains) with the app installed: the OS routes directly to Parachord with the URL above. Without the app installed: parachord.com renders a landing page with a "Get Parachord" CTA and an auto-trigger script that attempts the `parachord://` bounce.
+
+The website worker that serves these landing pages and the `.well-known/assetlinks.json` + `.well-known/apple-app-site-association` files: [parachord-website](https://github.com/Parachord/parachord-website). URL conventions are documented in [its CLAUDE.md](https://github.com/Parachord/parachord-website/blob/main/CLAUDE.md).
+
 ## Quick Reference
 
 | Category | Example URL |
@@ -209,13 +223,13 @@ parachord://play/album?mbid=b1392450-e666-3926-a536-22c65f834433
 Play a list of tracks. Same input shapes as `play/album` but without the album-only identifiers (`mbid`, `spotify`, `applemusic`).
 
 ```
-parachord://play/playlist?url={xspf_or_json_url}
+parachord://play/playlist?url={xspf_or_json_url_or_provider_playlist_page}
 parachord://play/playlist?tracks={base64_json}&title={display_name}
 ```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `url` | Either `url` or `tracks` | URL to a hosted XSPF or JSPF/JSON tracklist |
+| `url` | Either `url` or `tracks` | URL to a hosted tracklist document (XSPF / JSPF / JSON), **or** a provider playlist page (see "Provider URL sniffing" below) |
 | `tracks` | " | Base64-encoded JSON array (max 100KB encoded, 500 tracks) |
 | `title` | No | Display name for the playlist context |
 | `creator` | No | Attribution shown in the playback context |
@@ -223,10 +237,32 @@ parachord://play/playlist?tracks={base64_json}&title={display_name}
 
 > Use `parachord://import` instead if you want the playlist saved to the user's library. `play/playlist` only plays — nothing persists.
 
-**Example:**
+#### Provider URL sniffing
+
+`play/playlist?url=` accepts both **hosted tracklist documents** (XSPF / JSPF / JSON — the original shape) and **provider playlist page URLs**. The host is sniffed and routed accordingly. **Sniffing is gated to `play/playlist` only** — `play/album?url=` and `play/radio?url=` stay tracklist-document-only by design.
+
+| URL host | Resolved via |
+|---|---|
+| `open.spotify.com/playlist/<id>` | Spotify playlist import |
+| `music.apple.com/<region>/playlist/<slug>/<id>` | Apple Music playlist import |
+| `soundcloud.com/<user>/sets/<slug>` | SoundCloud playlist import |
+| `on.soundcloud.com/<short-id>` | Short-link — app follows the 302 to `soundcloud.com/<user>/sets/...` itself, then re-validates the final host before importing. The website does NOT pre-resolve the short link. |
+| `achordion.xyz/playlist/<mbid>` | Fetched from `https://achordion.xyz/api/playlist/<mbid>/xspf` (public, returns XSPF) — the page itself is bot-challenged by Vercel; only the `/api/` route is reachable from the app's IP. |
+| anything else | Falls back to the original behavior: fetch the URL and parse as XSPF / JSPF / JSON tracklist. |
+
+A pure host classifier helper lives in [`tests/helpers/playlist-url-classify.js`](../tests/helpers/playlist-url-classify.js) with tests in [`tests/protocol/playlist-url-classify.test.js`](../tests/protocol/playlist-url-classify.test.js).
+
+**Examples:**
 ```
 parachord://play/playlist?url=https%3A%2F%2Fexample.com%2Fmix.xspf
+parachord://play/playlist?url=https%3A%2F%2Fopen.spotify.com%2Fplaylist%2F37i9dQZF1DXcBWIGoYBM5M
+parachord://play/playlist?url=https%3A%2F%2Fmusic.apple.com%2Fus%2Fplaylist%2Ftodays-hits%2Fpl.f4d106fed2bd41149aaacabb233eb5eb
+parachord://play/playlist?url=https%3A%2F%2Fsoundcloud.com%2Fjherskowitz%2Fsets%2Ffrozen-in-time-2026
+parachord://play/playlist?url=https%3A%2F%2Fon.soundcloud.com%2FDrk2sCLhCHVNugYtAP
+parachord://play/playlist?url=https%3A%2F%2Fachordion.xyz%2Fplaylist%2Fc2accebd-ccd1-42c6-8ce7-ec0e8cf6cd13
 ```
+
+The HTTPS share form of any of these (e.g. `https://parachord.com/play/playlist?url=https%3A%2F%2Fopen.spotify.com%2F...`) is byte-identical and works in any context that strips custom schemes — see [Universal / App Links](#3-universal--app-links-shareable-https) above.
 
 ### Play Radio
 


### PR DESCRIPTION
The \`play/playlist?url=\` doc was stale: still described \`url\` as "URL to a hosted XSPF or JSPF/JSON tracklist", which was true at the original schema design but no longer reflects reality after [#932](https://github.com/Parachord/parachord/pull/932) (the #930 fix that added provider-page sniffing).

Doc-only — no behavior change.

## \`docs/protocol-schema.md\`

- **New "Access Method 3: Universal / App Links (Shareable HTTPS)"** — documents that every \`parachord://<verb>\` URL has a byte-identical \`https://parachord.com/<verb>\` equivalent, with the cross-refs to the website worker and the install-required vs install-not behavior. Plus a pointer to [parachord-website/CLAUDE.md](https://github.com/Parachord/parachord-website/blob/main/CLAUDE.md) for the URL contract.
- **Play Playlist § Provider URL sniffing** — new subsection listing every host the client recognizes:

  | URL host | Resolved via |
  |---|---|
  | \`open.spotify.com/playlist/<id>\` | Spotify playlist import |
  | \`music.apple.com/<region>/playlist/<slug>/<id>\` | Apple Music playlist import |
  | \`soundcloud.com/<user>/sets/<slug>\` | SoundCloud playlist import |
  | \`on.soundcloud.com/<short-id>\` | Short-link redirect-follow, re-validates final host |
  | \`achordion.xyz/playlist/<mbid>\` | \`/api/playlist/<mbid>/xspf\` endpoint |
  | anything else | Original XSPF / JSPF / JSON tracklist parse |

  Plus the explicit callout that sniffing is **gated to \`play/playlist\` only** — \`play/album?url=\` and \`play/radio?url=\` keep their existing tracklist-document-only behavior by design.
- Examples block updated to cover all 6 URL shapes.
- Cross-ref to [\`tests/helpers/playlist-url-classify.js\`](../tests/helpers/playlist-url-classify.js) so anyone wanting to verify the classifier behavior has the unit-test source.

## \`CLAUDE.md\`

- \`play/playlist\` row in the protocol-surface table notes the dual \`url\` shape.
- New short paragraph documenting the classifier + the gated-to-playlist scope.
- New paragraph on Universal / App Links HTTPS form covering the canonical-path-form contract (no \`?type=\`) and the defense-in-depth this client accepts (\`segments[0] || params.type\`). References [parachord-website#102](https://github.com/Parachord/parachord-website/pull/102) (the website worker's inverse-normalization fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)