### PR TITLE
feat(sync): N-way mutual-exclusion guard — sync_engine_mode (#911)

### DIFF
--- a/app.js
+++ b/app.js
@@ -6658,7 +6658,14 @@ const Parachord = () => {
               // Guard with per-provider mutex to prevent concurrent creation
               // across background + manual sync paths for the same provider.
               // A different provider's in-flight push doesn't gate this one.
-              if (playlistSyncInProgressRef.current.has(providerId)) {
+              // N-way mutual exclusion (parachord#911): in 'new' mode N-way owns
+              // playlist sync, so the legacy push loop stands down. main.js's
+              // create/push IPC handlers also gate this as the authoritative
+              // chokepoint; skipping here avoids the wasted resolution work.
+              const engineMode = await window.electron.store.get('sync_engine_mode');
+              if (engineMode === 'new') {
+                console.log(`[Sync] sync_engine_mode=new — N-way owns playlists; skipping legacy playlist push for ${providerId}`);
+              } else if (playlistSyncInProgressRef.current.has(providerId)) {
                 console.log(`[Sync] Playlist sync already in progress for ${providerId}, skipping background playlist sync`);
               } else {
               playlistSyncInProgressRef.current.add(providerId);
@@ -11249,7 +11256,12 @@ const Parachord = () => {
         // Guard with per-provider mutex (parachord#831). Concurrent push for
         // the SAME (local, provider) pair from the background sync loop is
         // the race; different providers don't race with each other.
-        if (playlistSyncInProgressRef.current.has(providerId)) {
+        // N-way mutual exclusion (parachord#911): stand down the legacy
+        // post-wizard create loop in 'new' mode (see the background loop above).
+        const engineMode = await window.electron.store.get('sync_engine_mode');
+        if (engineMode === 'new') {
+          console.log(`[Sync] sync_engine_mode=new — N-way owns playlists; skipping legacy playlist create for ${providerId}`);
+        } else if (playlistSyncInProgressRef.current.has(providerId)) {
           console.log(`[Sync] Playlist sync already in progress for ${providerId}, skipping manual playlist creation`);
         } else {
           playlistSyncInProgressRef.current.add(providerId);

--- a/main.js
+++ b/main.js
@@ -5613,6 +5613,19 @@ ipcMain.handle('sync:set-channel', async (event, localPlaylistId, providerId, en
 function isNwayShadowEnabled() { return store.get('nway_shadow_enabled') === true; }
 function isNwayPropagateEnabled() { return store.get('nway_propagate') === true; }
 
+// Per-client sync-engine mode (parachord#911 migration). `legacyPlaylistSyncEnabled`
+// is false ONLY in 'new' mode, where N-way owns playlist sync and the legacy
+// playlist push/create/import paths must stand down. Library/collection sync is
+// never gated here. require() is cached, so the lazy require is cheap.
+function getSyncEngineMode() {
+  const { normalizeEngineMode } = require('./sync-engine/sync-engine-mode');
+  return normalizeEngineMode(store.get('sync_engine_mode'));
+}
+function legacyPlaylistSyncEnabled() {
+  const { legacyPlaylistSyncEnabled: fn } = require('./sync-engine/sync-engine-mode');
+  return fn(store.get('sync_engine_mode'));
+}
+
 // Per-playlist MIRROR-ONLY flag (parachord#911 / parachord-mobile#277). When
 // set, the playlist is reconciled as a ONE-WAY mirror FROM its source: the
 // source is single-authority and its rotate-out drops IMMEDIATELY (no
@@ -7158,8 +7171,16 @@ ipcMain.handle('sync:start', async (event, providerId, options = {}) => {
     // (e.g. Android) auto-appears here. Spotify/Apple Music keep the opt-IN model
     // (only playlists in selectedPlaylistIds). Suppression + an explicit channel
     // override still exclude individual playlists on every provider.
+    // N-way mutual exclusion (parachord#911): in 'new' mode the N-way reconcile
+    // owns inbound playlist import (via its pull-source path), so the legacy
+    // inbound playlist phase stands down. Library sync (tracks/albums/artists)
+    // above is unaffected — N-way is playlist-only.
+    const legacyPlaylists = legacyPlaylistSyncEnabled();
+    if (!legacyPlaylists) {
+      console.log('[Sync] sync_engine_mode=new — N-way owns playlists; skipping legacy inbound playlist sync');
+    }
     const importAll = providerId === 'listenbrainz';
-    if (settings.syncPlaylists && (importAll || settings.selectedPlaylistIds?.length > 0) && provider.capabilities.playlists) {
+    if (legacyPlaylists && settings.syncPlaylists && (importAll || settings.selectedPlaylistIds?.length > 0) && provider.capabilities.playlists) {
       // Load current playlists
       const currentPlaylists = store.get('local_playlists') || [];
 
@@ -7744,6 +7765,14 @@ ipcMain.handle('sync:fetch-playlist-tracks', async (event, providerId, playlistE
 
 // Push local playlist changes to the sync provider
 ipcMain.handle('sync:push-playlist', async (event, providerId, playlistExternalId, tracks, metadata) => {
+  // N-way mutual exclusion (parachord#911). In 'new' mode the N-way reconcile
+  // owns all remote playlist writes; the legacy push path must not also write,
+  // or the two engines fight over the shared remote. This is the authoritative
+  // chokepoint (every legacy remote playlist write flows through here) — the
+  // renderer push loops also skip earlier, but this catches any other caller.
+  if (!legacyPlaylistSyncEnabled()) {
+    return { success: true, skipped: 'nway-active' };
+  }
   const provider = SyncEngine.getProvider(providerId);
   if (!provider || !provider.capabilities.playlists) {
     return { success: false, error: 'Provider does not support playlists' };
@@ -7880,6 +7909,12 @@ ipcMain.handle('sync:push-playlist', async (event, providerId, playlistExternalI
 
   // Create a new playlist on a remote service from a local playlist
   ipcMain.handle('sync:create-playlist', async (event, providerId, name, description, tracks, localPlaylistId = null) => {
+    // N-way mutual exclusion (parachord#911). In 'new' mode N-way owns remote
+    // playlist creation; the legacy create gateway stands down so the two
+    // engines don't both create remotes for the same local playlist.
+    if (!legacyPlaylistSyncEnabled()) {
+      return { success: true, skipped: 'nway-active' };
+    }
     const provider = SyncEngine.getProvider(providerId);
     if (!provider || !provider.capabilities.playlists) {
       return { success: false, error: 'Provider does not support playlists' };

--- a/sync-engine/sync-engine-mode.js
+++ b/sync-engine/sync-engine-mode.js
@@ -1,0 +1,41 @@
+// Per-client sync-engine selection (parachord#911 — legacy → N-way migration).
+//
+// Stored as electron-store key `sync_engine_mode`. LOCAL and authoritative for
+// THIS client only — Parachord has no user account, so there is no cross-client
+// coordinator; each client's mode is its own. Fresh-install default is a
+// build-time constant ('legacy' for existing clients; new mobile builds ship
+// 'new'). See docs/plans/2026-06-28-legacy-to-nway-sync-migration.md.
+//
+//   'legacy' (default) — legacy sync drives; N-way dormant.
+//   'shadow'           — legacy drives; N-way computes + logs a dry-run plan, no writes.
+//   'new'              — N-way drives; legacy PLAYLIST push/create/import stands down.
+//
+// Mutual exclusion is scoped to PLAYLIST sync. Library / collection sync
+// (tracks / albums / artists) is unaffected by the mode — N-way is playlist-only.
+
+const SYNC_ENGINE_MODES = ['legacy', 'shadow', 'new'];
+
+function normalizeEngineMode(raw) {
+  return SYNC_ENGINE_MODES.includes(raw) ? raw : 'legacy';
+}
+
+// Legacy playlist sync (outbound create/push AND inbound import) runs in every
+// mode EXCEPT 'new'. In 'new' the N-way reconcile is the sole playlist
+// authority, so the legacy paths must stand down to avoid double-writing the
+// shared remotes and the local playlist state.
+function legacyPlaylistSyncEnabled(modeOrRaw) {
+  return normalizeEngineMode(modeOrRaw) !== 'new';
+}
+
+// N-way performs REAL writes only in 'new'. In 'shadow' it computes a dry-run
+// plan (compute + log, zero writes).
+function nwayWritesEnabled(modeOrRaw) {
+  return normalizeEngineMode(modeOrRaw) === 'new';
+}
+
+module.exports = {
+  SYNC_ENGINE_MODES,
+  normalizeEngineMode,
+  legacyPlaylistSyncEnabled,
+  nwayWritesEnabled,
+};

--- a/tests/sync/sync-engine-mode.test.js
+++ b/tests/sync/sync-engine-mode.test.js
@@ -1,0 +1,55 @@
+/**
+ * Per-client sync-engine mode + the N-way mutual-exclusion contract
+ * (parachord#911). Legacy playlist sync stands down ONLY in 'new'; library
+ * sync is never gated by this (asserted at the call sites, documented here).
+ */
+
+const {
+  SYNC_ENGINE_MODES,
+  normalizeEngineMode,
+  legacyPlaylistSyncEnabled,
+  nwayWritesEnabled,
+} = require('../../sync-engine/sync-engine-mode');
+
+describe('sync-engine-mode', () => {
+  test('the three modes', () => {
+    expect(SYNC_ENGINE_MODES).toEqual(['legacy', 'shadow', 'new']);
+  });
+
+  describe('normalizeEngineMode — default legacy, anything unknown → legacy', () => {
+    test.each(['legacy', 'shadow', 'new'])('passes through %s', (m) => {
+      expect(normalizeEngineMode(m)).toBe(m);
+    });
+    test.each([undefined, null, '', 'NEW', 'nway', 'off', 0, true, {}])(
+      'coerces %p to legacy', (bad) => {
+        expect(normalizeEngineMode(bad)).toBe('legacy');
+      }
+    );
+  });
+
+  describe('legacyPlaylistSyncEnabled — on except in new', () => {
+    test('legacy → enabled', () => expect(legacyPlaylistSyncEnabled('legacy')).toBe(true));
+    test('shadow → enabled (legacy still drives)', () => expect(legacyPlaylistSyncEnabled('shadow')).toBe(true));
+    test('new → DISABLED (N-way owns playlists)', () => expect(legacyPlaylistSyncEnabled('new')).toBe(false));
+    test('unknown/absent → enabled (safe default = legacy)', () => {
+      expect(legacyPlaylistSyncEnabled(undefined)).toBe(true);
+      expect(legacyPlaylistSyncEnabled('garbage')).toBe(true);
+    });
+  });
+
+  describe('nwayWritesEnabled — real writes only in new', () => {
+    test('legacy → no writes', () => expect(nwayWritesEnabled('legacy')).toBe(false));
+    test('shadow → no writes (dry-run only)', () => expect(nwayWritesEnabled('shadow')).toBe(false));
+    test('new → writes', () => expect(nwayWritesEnabled('new')).toBe(true));
+    test('unknown/absent → no writes', () => {
+      expect(nwayWritesEnabled(undefined)).toBe(false);
+      expect(nwayWritesEnabled('garbage')).toBe(false);
+    });
+  });
+
+  test('invariant: legacy and N-way writes are never both on for playlists', () => {
+    for (const m of [...SYNC_ENGINE_MODES, undefined, 'garbage']) {
+      expect(legacyPlaylistSyncEnabled(m) && nwayWritesEnabled(m)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
Phase 1 of the legacy → N-way sync migration ([plan](https://github.com/Parachord/parachord/blob/main/docs/plans/2026-06-28-legacy-to-nway-sync-migration.md)). The safe, self-contained first step: a per-client `sync_engine_mode` and the guard that makes the legacy playlist sync **stand down** in `new` mode, so the two engines never write the shared remotes at once.

## What
- **`sync-engine/sync-engine-mode.js`** (new, pure, unit-tested): `normalizeEngineMode` (default `legacy`, unknown → `legacy`), `legacyPlaylistSyncEnabled` (false **only** in `new`), `nwayWritesEnabled` (true only in `new`). 22 tests incl. the `never-both-on` invariant.
- **main.js — the authoritative chokepoints:** `sync:create-playlist` and `sync:push-playlist` (every legacy remote playlist write flows through these) return `{ success: true, skipped: 'nway-active' }` in `new`. `sync:start` skips its **inbound playlist phase**, while **keeping library/collection sync** (tracks/albums/artists) — N-way is playlist-only.
- **app.js:** the two renderer push loops (background-sync + post-wizard) skip early in `new` to avoid wasted track-resolution work; the main.js gates remain the safety net.

## Granularity (deliberate)
Only **playlist** sync is gated. Library/collection sync is never touched by the mode, because N-way doesn't do collection sync — gating it would regress loved-tracks/library import for `new`-mode users.

## Safety
Default is `legacy`; unknown values coerce to `legacy`. So this is **behavior-neutral for every current user** — the guard engages only once a client sets `sync_engine_mode = 'new'` (no UI to do that yet; that's the next step). Full suite green: **1878 tests**.

## Not in this PR
The preview → Accept/Report/Cancel migration UI (next step, has real UX decisions). This PR is just the mechanism it will drive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)