### PR TITLE
feat(sync): N-way migration preview — preview/approve/report (#911)

### DIFF
--- a/app.js
+++ b/app.js
@@ -55158,7 +55158,7 @@ useEffect(() => {
                   ),
                   // Show Tutorial Now button
                   React.createElement('div', {
-                    className: 'flex items-center justify-between py-3'
+                    className: 'flex items-center justify-between py-3 border-b border-gray-100'
                   },
                     React.createElement('div', null,
                       React.createElement('div', {
@@ -55174,6 +55174,23 @@ useEffect(() => {
                       },
                       className: 'px-3 py-1.5 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-lg hover:bg-indigo-100 transition-colors'
                     }, 'Show')
+                  ),
+                  // Use new sync — N-way migration preview (parachord#911)
+                  React.createElement('div', {
+                    className: 'flex items-center justify-between py-3'
+                  },
+                    React.createElement('div', null,
+                      React.createElement('div', {
+                        className: 'text-sm font-medium text-gray-900'
+                      }, 'Use new sync'),
+                      React.createElement('div', {
+                        className: 'text-xs text-gray-500 mt-0.5'
+                      }, 'Preview the new sync engine and switch this device over')
+                    ),
+                    React.createElement('button', {
+                      onClick: () => startNwayMigration(),
+                      className: 'px-3 py-1.5 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-lg hover:bg-indigo-100 transition-colors'
+                    }, 'Preview')
                   )
                 ),
 
@@ -55412,21 +55429,6 @@ useEffect(() => {
                       cursor: 'pointer'
                     }
                   }, 'Copy Diagnostic Log')
-                ),
-
-                // Developer — N-way sync migration (parachord#911). Opens the
-                // preview: dry-run reconcile, see the exact diff, then switch.
-                React.createElement('div', { style: { marginBottom: '24px' } },
-                  React.createElement('p', {
-                    style: { fontSize: '11px', fontWeight: '600', color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: '8px' }
-                  }, 'Developer'),
-                  React.createElement('p', {
-                    style: { fontSize: '12px', color: 'var(--text-secondary)', marginBottom: '12px' }
-                  }, 'Preview the new sync engine and switch this device over. You see exactly what would change before anything is written.'),
-                  React.createElement('button', {
-                    onClick: () => startNwayMigration(),
-                    style: { fontSize: '12px', color: 'var(--accent-primary)', fontWeight: '500', textDecoration: 'none', background: 'transparent', border: '1px solid var(--accent-primary)', borderRadius: '6px', padding: '6px 12px', cursor: 'pointer' }
-                  }, 'Use new sync…')
                 ),
 
                 // Copyright

--- a/app.js
+++ b/app.js
@@ -8133,6 +8133,57 @@ const Parachord = () => {
   // (parachord#911). { show, playlistId, playlistName, providerId, providerLabel }
   const [syncChannelDisableDialog, setSyncChannelDisableDialog] = useState({ show: false });
 
+  // N-way migration preview (parachord#911). The "Use new sync" dev toggle opens
+  // this: run a compute-only reconcile, render the named diff, and only on Accept
+  // flip sync_engine_mode to 'new'. { show, loading, summary, error, recomputed }.
+  const [nwayMigrationDialog, setNwayMigrationDialog] = useState({ show: false });
+
+  // Open the preview: forced dry-run reconcile → render model.
+  const startNwayMigration = async () => {
+    setNwayMigrationDialog({ show: true, loading: true });
+    try {
+      const out = await window.electron.nway.preview();
+      if (!out || out.error) {
+        setNwayMigrationDialog({ show: true, loading: false, error: (out && out.error) || 'Preview failed' });
+        return;
+      }
+      if (out.skipped) {
+        setNwayMigrationDialog({ show: true, loading: false, error: `Preview unavailable (${out.skipped})` });
+        return;
+      }
+      setNwayMigrationDialog({ show: true, loading: false, summary: window.summarizeMigrationPlan(out) });
+    } catch (e) {
+      setNwayMigrationDialog({ show: true, loading: false, error: (e && e.message) || 'Preview failed' });
+    }
+  };
+
+  // Accept: recompute first (the remote may have drifted since preview). If the
+  // removal count changed, re-show the fresh diff instead of committing blind.
+  const acceptNwayMigration = async () => {
+    setNwayMigrationDialog((d) => ({ ...d, loading: true }));
+    let fresh = null;
+    try { const out = await window.electron.nway.preview(); if (out && !out.error && !out.skipped) fresh = window.summarizeMigrationPlan(out); } catch {}
+    const shown = nwayMigrationDialog.summary;
+    if (fresh && shown && fresh.totalRemoves !== shown.totalRemoves) {
+      setNwayMigrationDialog({ show: true, loading: false, summary: fresh, recomputed: true });
+      showToast('The remote changed — review the updated diff before switching', 'info');
+      return;
+    }
+    try { await window.electron.store.set('sync_engine_mode', 'new'); } catch {}
+    setNwayMigrationDialog({ show: false });
+    showToast('Switched to new sync on this device');
+  };
+
+  // Report: copy the full diff (GitHub truncates long prefilled bodies) and open a
+  // prefilled issue. Does not switch.
+  const reportNwayMigration = async () => {
+    const report = window.buildMigrationReport(nwayMigrationDialog.summary, { appVersion });
+    try { await navigator.clipboard.writeText(report.body); } catch {}
+    if (window.electron?.shell?.openExternal) window.electron.shell.openExternal(report.githubUrl);
+    setNwayMigrationDialog({ show: false });
+    showToast('Diff copied to clipboard — opening a GitHub issue');
+  };
+
   // The remote services a playlist mirrors to/from (source + push mirrors) that
   // could be cleaned up on delete. Returns [{ providerId, externalId, role }].
   const getPlaylistMirrorTargets = (playlist) => {
@@ -55363,6 +55414,21 @@ useEffect(() => {
                   }, 'Copy Diagnostic Log')
                 ),
 
+                // Developer — N-way sync migration (parachord#911). Opens the
+                // preview: dry-run reconcile, see the exact diff, then switch.
+                React.createElement('div', { style: { marginBottom: '24px' } },
+                  React.createElement('p', {
+                    style: { fontSize: '11px', fontWeight: '600', color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: '8px' }
+                  }, 'Developer'),
+                  React.createElement('p', {
+                    style: { fontSize: '12px', color: 'var(--text-secondary)', marginBottom: '12px' }
+                  }, 'Preview the new sync engine and switch this device over. You see exactly what would change before anything is written.'),
+                  React.createElement('button', {
+                    onClick: () => startNwayMigration(),
+                    style: { fontSize: '12px', color: 'var(--accent-primary)', fontWeight: '500', textDecoration: 'none', background: 'transparent', border: '1px solid var(--accent-primary)', borderRadius: '6px', padding: '6px 12px', cursor: 'pointer' }
+                  }, 'Use new sync…')
+                ),
+
                 // Copyright
                 React.createElement('p', {
                   style: {
@@ -63027,6 +63093,71 @@ useEffect(() => {
               cursor: 'pointer'
             }
           }, 'Cancel')
+        )
+      )
+    ),
+
+    // N-way migration preview (parachord#911): "switch to new sync?" with the
+    // exact dry-run diff and Accept / Report / Cancel.
+    nwayMigrationDialog.show && React.createElement('div', {
+      className: 'fixed inset-0 flex items-center justify-center z-[60]',
+      style: { backgroundColor: 'rgba(0,0,0,0.45)', backdropFilter: 'blur(4px)' },
+      onClick: () => { if (!nwayMigrationDialog.loading) setNwayMigrationDialog({ show: false }); }
+    },
+      React.createElement('div', {
+        style: { backgroundColor: 'var(--card-bg)', borderRadius: '16px', boxShadow: '0 4px 24px rgba(0,0,0,0.15), 0 12px 48px rgba(0,0,0,0.1)', maxWidth: '560px', width: '100%', margin: '0 16px', maxHeight: '82vh', display: 'flex', flexDirection: 'column', overflow: 'hidden' },
+        onClick: (e) => e.stopPropagation()
+      },
+        React.createElement('div', { style: { padding: '22px 24px 12px', flexShrink: 0 } },
+          React.createElement('h3', { style: { fontSize: '17px', fontWeight: '600', color: 'var(--text-primary)', marginBottom: '6px' } }, 'Switch to new sync on this device?'),
+          React.createElement('p', { style: { fontSize: '13px', color: 'var(--text-secondary)', lineHeight: '1.5' } }, "We ran the new sync against your library without writing anything. Here's exactly what it would change.")
+        ),
+        React.createElement('div', { style: { overflowY: 'auto', padding: '0 24px', flex: '1 1 auto' } },
+          (() => {
+            const d = nwayMigrationDialog;
+            if (d.loading) return React.createElement('p', { style: { padding: '16px 0', fontSize: '13px', color: 'var(--text-secondary)', textAlign: 'center' } }, 'Checking your playlists…');
+            if (d.error) return React.createElement('p', { style: { padding: '8px 0 16px', fontSize: '13px', color: '#dc2626' } }, `Couldn't run the preview: ${d.error}`);
+            const s = d.summary;
+            if (!s) return null;
+            const banner = (bg, border, color, text) => React.createElement('div', { style: { backgroundColor: bg, border: `1px solid ${border}`, borderRadius: '8px', padding: '9px 11px', marginBottom: '12px' } }, React.createElement('span', { style: { fontSize: '12px', color, lineHeight: '1.45' } }, text));
+            const rows = [];
+            if (d.recomputed) rows.push(banner('rgba(245,158,11,0.12)', 'rgba(245,158,11,0.4)', '#b45309', 'The remote changed since you opened this. This is the updated diff.'));
+            if (s.hasRemoves) rows.push(banner('rgba(220,38,38,0.10)', 'rgba(220,38,38,0.35)', '#b91c1c', `${s.totalRemoves} track${s.totalRemoves === 1 ? '' : 's'} would be removed. Review the removals before you accept.`));
+            if (!s.hasChanges && !s.protected.length) {
+              rows.push(React.createElement('p', { key: 'noop', style: { fontSize: '13px', color: 'var(--text-secondary)', padding: '4px 0 14px' } }, 'No changes needed — your playlists are already in sync. Safe to switch.'));
+            } else if (s.hasChanges) {
+              rows.push(React.createElement('p', { key: 'sum', style: { fontSize: '12px', color: 'var(--text-tertiary)', padding: '2px 0 8px' } }, `${s.noopCount} playlist${s.noopCount === 1 ? '' : 's'} already match. ${s.changed.length} need${s.changed.length === 1 ? 's' : ''} changes:`));
+            }
+            s.changed.forEach((pl, pi) => {
+              const hasRem = pl.providers.some((p) => p.removes.length);
+              const provNodes = [];
+              pl.providers.forEach((p, ppi) => {
+                provNodes.push(React.createElement('div', { key: `h${ppi}`, style: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: ppi ? '8px' : '6px' } },
+                  React.createElement('span', { style: { fontSize: '11px', color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.04em' } }, p.providerId),
+                  React.createElement('span', { style: { fontSize: '11px', color: 'var(--text-tertiary)' } }, `${p.adds.length ? '+' + p.adds.length : ''}${p.adds.length && p.removes.length ? ' · ' : ''}${p.removes.length ? '−' + p.removes.length : ''}`)
+                ));
+                p.removes.forEach((t, ti) => provNodes.push(React.createElement('div', { key: `r${ppi}-${ti}`, style: { fontSize: '13px', color: '#dc2626', padding: '2px 0' } }, `−  ${t.artist}${t.artist && t.title ? ' — ' : ''}${t.title}`)));
+                p.adds.forEach((t, ti) => provNodes.push(React.createElement('div', { key: `a${ppi}-${ti}`, style: { fontSize: '13px', color: '#16a34a', padding: '2px 0' } }, `+  ${t.artist}${t.artist && t.title ? ' — ' : ''}${t.title}`)));
+              });
+              rows.push(React.createElement('div', { key: `pl${pi}`, style: { padding: '10px 12px', marginBottom: '8px', borderRadius: '10px', backgroundColor: hasRem ? 'rgba(220,38,38,0.06)' : 'rgba(127,127,127,0.06)', borderLeft: hasRem ? '3px solid #dc2626' : '3px solid transparent' } },
+                React.createElement('div', { style: { fontSize: '14px', fontWeight: '500', color: 'var(--text-primary)' } }, pl.displayName),
+                ...provNodes
+              ));
+            });
+            s.protected.forEach((pp, pi) => {
+              rows.push(React.createElement('div', { key: `prot${pi}`, style: { padding: '8px 12px', marginBottom: '8px' } },
+                React.createElement('div', { style: { fontSize: '14px', fontWeight: '500', color: 'var(--text-primary)' } }, `${pp.displayName} — protected`),
+                React.createElement('div', { style: { fontSize: '12px', color: 'var(--text-secondary)', lineHeight: '1.45' } }, pp.reason === 'total-wipe' ? "New sync declined a full-replace it couldn't verify, and left it untouched. Your tracks are safe." : 'New sync skipped an unverifiable change and left it untouched.')
+              ));
+            });
+            return React.createElement('div', { style: { paddingBottom: '8px' } }, ...rows);
+          })()
+        ),
+        React.createElement('div', { style: { padding: '14px 24px 18px', borderTop: '1px solid var(--border-subtle)', display: 'flex', gap: '8px', alignItems: 'center', flexShrink: 0 } },
+          React.createElement('span', { style: { fontSize: '11px', color: 'var(--text-tertiary)', marginRight: 'auto' } }, 'Disables the old sync here. Reversible anytime.'),
+          React.createElement('button', { onClick: () => setNwayMigrationDialog({ show: false }), style: { padding: '8px 14px', fontSize: '13px', fontWeight: '500', color: 'var(--text-secondary)', backgroundColor: 'transparent', border: '1px solid var(--border-subtle)', borderRadius: '8px', cursor: 'pointer' } }, 'Cancel'),
+          (nwayMigrationDialog.summary && (nwayMigrationDialog.summary.hasChanges || nwayMigrationDialog.summary.protected.length)) && React.createElement('button', { onClick: () => reportNwayMigration(), style: { padding: '8px 14px', fontSize: '13px', fontWeight: '500', color: 'var(--text-primary)', backgroundColor: 'transparent', border: '1px solid var(--border-subtle)', borderRadius: '8px', cursor: 'pointer' } }, 'Report a problem'),
+          React.createElement('button', { onClick: () => acceptNwayMigration(), disabled: nwayMigrationDialog.loading || !nwayMigrationDialog.summary, style: { padding: '8px 14px', fontSize: '13px', fontWeight: '500', color: '#ffffff', backgroundColor: (nwayMigrationDialog.loading || !nwayMigrationDialog.summary) ? '#9ca3af' : '#7c3aed', border: 'none', borderRadius: '8px', cursor: (nwayMigrationDialog.loading || !nwayMigrationDialog.summary) ? 'default' : 'pointer' } }, (nwayMigrationDialog.summary && !nwayMigrationDialog.summary.hasChanges) ? 'Switch' : 'Accept changes and switch')
         )
       )
     ),

--- a/app.js
+++ b/app.js
@@ -63112,7 +63112,15 @@ useEffect(() => {
       },
         React.createElement('div', { style: { padding: '22px 24px 12px', flexShrink: 0 } },
           React.createElement('h3', { style: { fontSize: '17px', fontWeight: '600', color: 'var(--text-primary)', marginBottom: '6px' } }, 'Switch to new sync on this device?'),
-          React.createElement('p', { style: { fontSize: '13px', color: 'var(--text-secondary)', lineHeight: '1.5' } }, "We ran the new sync against your library without writing anything. Here's exactly what it would change.")
+          React.createElement('p', { style: { fontSize: '13px', color: 'var(--text-secondary)', lineHeight: '1.5' } },
+            'We ran the ',
+            React.createElement('a', {
+              href: '#',
+              onClick: (e) => { e.preventDefault(); if (window.electron?.shell?.openExternal) window.electron.shell.openExternal('https://parachord.com/blog/2026/06/25/keeping-playlists-in-sync/'); },
+              style: { color: 'var(--accent-primary)', textDecoration: 'none', fontWeight: '500' }
+            }, 'new sync'),
+            " against your library without writing anything. Here's exactly what it would change."
+          )
         ),
         React.createElement('div', { style: { overflowY: 'auto', padding: '0 24px', flex: '1 1 auto' } },
           (() => {

--- a/index.html
+++ b/index.html
@@ -1143,6 +1143,9 @@
   <!-- MusicKit JS Web Integration -->
   <script src="musickit-web.js"></script>
 
+  <!-- N-way migration preview shaping (parachord#911) -->
+  <script src="migration-plan.js"></script>
+
   <!-- App (has emoji icon fallbacks built-in) -->
   <script src="app.js"></script>
 </body>

--- a/main.js
+++ b/main.js
@@ -5688,11 +5688,15 @@ function nwayMirrorsOf(playlist) {
   return m;
 }
 
-async function runNwayShadowReconcile() {
-  if (!isNwayShadowEnabled()) return { skipped: 'shadow-disabled' };
+async function runNwayShadowReconcile(options = {}) {
+  // `force` bypasses the nway_shadow_enabled dev gate (the migration preview runs
+  // a reconcile on demand without requiring the dev flag); `forceDryRun` pins it
+  // to compute-only regardless of nway_propagate (the preview NEVER writes).
+  const { force = false, forceDryRun = false } = options;
+  if (!force && !isNwayShadowEnabled()) return { skipped: 'shadow-disabled' };
   const { bindProviderToken, makeStoreEffects, runNwayReconcileCycle, createHydrationCache } =
     require('./sync-engine/nway-reconcile-driver');
-  const dryRun = !isNwayPropagateEnabled();
+  const dryRun = forceDryRun ? true : !isNwayPropagateEnabled();
   const now = Date.now();
   const states = getSyncStates();
   const playlists = store.get('local_playlists') || [];
@@ -5790,11 +5794,27 @@ async function runNwayShadowReconcile() {
     try { store.set('nway_hydration_cache', Object.fromEntries(cache.entries())); } catch {}
   }
   console.log(`[nway-shadow] cycle done (dryRun=${dryRun}): ${out.results.length} planned across ${out.cycles}, ${out.errors.length} error(s)`);
-  return { dryRun, ...out };
+  // Enrich each result with the playlist's display name so the migration preview
+  // (#911) can render a human diff without a second lookup. The reconcile core is
+  // store-agnostic and only knows localId; the name lives on the playlist object.
+  const results = (out.results || []).map((r) => {
+    const pl = r && r.localId ? playlistById.get(r.localId) : null;
+    return { ...r, displayName: (pl && (pl.title || pl.name)) || (r && r.localId) || 'Playlist' };
+  });
+  return { dryRun, ...out, results };
 }
 
 ipcMain.handle('nway:shadow-run', async () => {
   try { return await runNwayShadowReconcile(); }
+  catch (e) { return { error: e && e.message }; }
+});
+
+// Migration preview (#911): a forced, compute-only reconcile that returns the
+// named per-target diff regardless of the dev flags. Never writes. The "Use new
+// sync" toggle calls this, renders the diff, and only on Accept flips
+// sync_engine_mode to 'new'.
+ipcMain.handle('nway:preview', async () => {
+  try { return await runNwayShadowReconcile({ force: true, forceDryRun: true }); }
   catch (e) { return { error: e && e.message }; }
 });
 

--- a/migration-plan.js
+++ b/migration-plan.js
@@ -1,0 +1,107 @@
+// Pure shaping for the legacy → N-way migration preview (parachord#911).
+// Consumes the shadow reconcile output ({ results, cycles, errors }, where each
+// result already carries displayName + a named per-target diff) and produces:
+//   1. summarizeMigrationPlan — the render model for the preview modal.
+//   2. buildMigrationReport   — a GitHub-issue title/body/url for "Report a problem".
+// No I/O, no DOM. Loaded via a <script> tag for the renderer (attaches to window)
+// and required directly by jest. See docs/plans/2026-06-28-legacy-to-nway-sync-migration.md.
+
+function trackLabel(t) {
+  const artist = (t && t.artist) || '';
+  const title = (t && t.title) || '';
+  if (artist && title) return `${artist} — ${title}`;
+  return title || artist || 'Unknown track';
+}
+
+// Shadow output → render model. NOOP playlists aren't in `results` (the reconcile
+// core returns null for them and the driver drops nulls), so noopCount is derived
+// from the cycle count. 'would-push' with an empty effective diff is also a noop.
+function summarizeMigrationPlan(shadowOutput) {
+  const out = shadowOutput || {};
+  const results = Array.isArray(out.results) ? out.results : [];
+  const cycles = typeof out.cycles === 'number' ? out.cycles : results.length;
+  const errors = Array.isArray(out.errors) ? out.errors : [];
+
+  const changed = [];
+  const protectedList = [];
+  let totalAdds = 0;
+  let totalRemoves = 0;
+
+  for (const r of results) {
+    if (!r) continue;
+    if (r.status === 'would-push') {
+      const providers = (r.perTarget || [])
+        .map((t) => ({
+          providerId: t.providerId,
+          adds: Array.isArray(t.addTracks) ? t.addTracks : [],
+          removes: Array.isArray(t.removeTracks) ? t.removeTracks : [],
+        }))
+        .filter((p) => p.adds.length || p.removes.length);
+      if (providers.length) {
+        for (const p of providers) { totalAdds += p.adds.length; totalRemoves += p.removes.length; }
+        changed.push({ localId: r.localId, displayName: r.displayName || r.localId, providers });
+      }
+    } else if (r.status === 'total-wipe-abort') {
+      protectedList.push({ localId: r.localId, displayName: r.displayName || r.localId, reason: 'total-wipe' });
+    } else if (r.status === 'partial-abort') {
+      protectedList.push({ localId: r.localId, displayName: r.displayName || r.localId, reason: 'partial' });
+    }
+  }
+
+  const accountedNonNoop = results.length;
+  return {
+    changed,
+    protected: protectedList,
+    noopCount: Math.max(0, cycles - accountedNonNoop),
+    totalAdds,
+    totalRemoves,
+    hasRemoves: totalRemoves > 0,
+    hasChanges: changed.length > 0,
+    errorCount: errors.length,
+    cycles,
+  };
+}
+
+// Render model → a prefilled GitHub issue. The renderer ALSO copies `body` to the
+// clipboard before opening `githubUrl`, because GitHub truncates very long
+// prefilled bodies in the URL — the clipboard copy is the complete record.
+function buildMigrationReport(summary, opts) {
+  const s = summary || {};
+  const o = opts || {};
+  const appVersion = o.appVersion || 'unknown';
+  const lines = [];
+  lines.push('The new-sync preview showed a diff that looks wrong. Reporting it instead of accepting (parachord#911).');
+  lines.push('');
+  lines.push('## What looks wrong');
+  lines.push('<!-- e.g. these tracks should not be removed — tell us what is off -->');
+  lines.push('');
+  lines.push('## Preview diff');
+  lines.push(`- App version: ${appVersion}`);
+  lines.push(`- Playlists with changes: ${s.changed ? s.changed.length : 0}`);
+  lines.push(`- Would add: ${s.totalAdds || 0} track(s)`);
+  lines.push(`- Would remove: ${s.totalRemoves || 0} track(s)`);
+  if (s.protected && s.protected.length) lines.push(`- Safety aborts: ${s.protected.length}`);
+  lines.push('');
+  for (const pl of (s.changed || [])) {
+    lines.push(`### ${pl.displayName}`);
+    for (const p of pl.providers) {
+      for (const t of p.removes) lines.push(`- remove · ${p.providerId} · ${trackLabel(t)}`);
+      for (const t of p.adds) lines.push(`- add · ${p.providerId} · ${trackLabel(t)}`);
+    }
+    lines.push('');
+  }
+  const body = lines.join('\n');
+  const title = `New sync preview looks wrong (${s.totalRemoves || 0} remove(s), v${appVersion})`;
+  const githubUrl = 'https://github.com/Parachord/parachord/issues/new'
+    + `?title=${encodeURIComponent(title)}`
+    + `&body=${encodeURIComponent(body)}`
+    + `&labels=${encodeURIComponent('sync')}`;
+  return { title, body, githubUrl };
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { summarizeMigrationPlan, buildMigrationReport, trackLabel };
+} else if (typeof window !== 'undefined') {
+  window.summarizeMigrationPlan = summarizeMigrationPlan;
+  window.buildMigrationReport = buildMigrationReport;
+}

--- a/preload.js
+++ b/preload.js
@@ -43,6 +43,8 @@ contextBridge.exposeInMainWorld('electron', {
   // triggers one reconcile cycle for validation (shadow = compute + log only).
   nway: {
     shadowRun: () => ipcRenderer.invoke('nway:shadow-run'),
+    // Migration preview (#911): forced compute-only reconcile → named diff.
+    preview: () => ipcRenderer.invoke('nway:preview'),
   },
 
   // Spotify operations

--- a/sync-engine/playlist-reconcile.js
+++ b/sync-engine/playlist-reconcile.js
@@ -402,19 +402,53 @@ async function reconcilePlaylist(ctx) {
 
   const providerTargets = pushTargets.filter((t) => t !== 'local');
 
-  // A12 — SHADOW stop. Compute the per-target would-be diff from known keys
-  // (no extra fetch) and report; no writes, no baseline advance.
+  // A12 — SHADOW stop. Compute the per-target would-be diff EXACTLY the way the
+  // real push (A13) would, so the migration preview (#911) shows precisely what
+  // the executor would write — including track NAMES. materializeToProvider
+  // diffs `computeMaterializeDiff(canonical, remote)` and maps the diff's own
+  // keyspace back to tracks; we mirror that here, but stop at the diff (no write,
+  // no baseline advance). A target's `remote` is its A1-fetched copy.tracks when
+  // present (a changed mirror), otherwise a fresh fetch — which is what makes an
+  // UNCHANGED-mirror removal nameable (its tracks aren't in the A1 copy). Shadow
+  // is interactive, so the extra fetch for unchanged targets is acceptable.
+  const previewName = (t) => {
+    if (!t) return { artist: '', title: '' };
+    const artist = t.artist || t.artistName
+      || (Array.isArray(t.artists) ? t.artists.map((a) => (a && a.name) || a).filter(Boolean).join(', ') : '')
+      || '';
+    return { artist, title: t.title || t.name || t.trackTitle || '' };
+  };
   if (dryRun) {
-    const perTarget = providerTargets.map((id) => {
+    const perTarget = [];
+    for (const id of providerTargets) {
       const copy = copies.find((c) => c.id === id);
-      const have = new Set(copy ? copy.keys : []);
-      const addKeys = mergedRepr.filter((k) => !have.has(k)).length;
-      const removeKeys = (copy ? copy.keys : []).filter((k) => !mergedSet.has(k)).length;
-      return { providerId: id, addKeys, removeKeys };
-    });
+      let remote = copy && Array.isArray(copy.tracks) && copy.tracks.length ? copy.tracks : [];
+      if (!remote.length && providerById[id] && mirrorMap[id]) {
+        try {
+          const f = await providerById[id].fetchPlaylistTracks(mirrorMap[id]);
+          remote = Array.isArray(f) ? f : [];
+        } catch (e) {
+          log.warn('[nway-shadow] preview name-fetch failed', { localId, id, error: e && e.message });
+        }
+      }
+      const diff = computeMaterializeDiff(mergedTracks, remote);
+      const keyToCanonical = {};
+      diff.canonicalKeys.forEach((k, i) => { if (!(k in keyToCanonical)) keyToCanonical[k] = mergedTracks[i]; });
+      const keyToRemote = {};
+      diff.remoteKeys.forEach((k, i) => { if (!(k in keyToRemote)) keyToRemote[k] = remote[i]; });
+      perTarget.push({
+        providerId: id,
+        addKeys: diff.addKeys.length,
+        removeKeys: diff.removeKeys.length,
+        addTracks: diff.addKeys.map((k) => previewName(keyToCanonical[k])),
+        removeTracks: diff.removeKeys.map((k) => previewName(keyToRemote[k])),
+      });
+    }
     log.info('[nway-shadow]', {
       localId, status: 'would-push', mergedSize: mergedTracks.length,
-      pushTargets: providerTargets, perTarget, baselineWouldAdvanceTo: mergedTracks.length,
+      pushTargets: providerTargets,
+      perTarget: perTarget.map((p) => ({ providerId: p.providerId, addKeys: p.addKeys, removeKeys: p.removeKeys })),
+      baselineWouldAdvanceTo: mergedTracks.length,
     });
     return { status: 'would-push', localId, mergedSize: mergedTracks.length, pushTargets: providerTargets, perTarget };
   }

--- a/tests/sync/migration-plan.test.js
+++ b/tests/sync/migration-plan.test.js
@@ -1,0 +1,96 @@
+/**
+ * Migration preview shaping (parachord#911): shadow output → render model, and
+ * render model → GitHub-issue report.
+ */
+
+const { summarizeMigrationPlan, buildMigrationReport } = require('../../migration-plan');
+
+const wouldPush = (localId, displayName, perTarget) => ({ status: 'would-push', localId, displayName, perTarget });
+
+describe('summarizeMigrationPlan', () => {
+  test('all-noop fleet: nothing changed, nothing protected', () => {
+    const s = summarizeMigrationPlan({ results: [], cycles: 20, errors: [] });
+    expect(s.hasChanges).toBe(false);
+    expect(s.hasRemoves).toBe(false);
+    expect(s.noopCount).toBe(20);
+    expect(s.totalAdds).toBe(0);
+    expect(s.totalRemoves).toBe(0);
+  });
+
+  test('classifies adds, removes, and tallies totals', () => {
+    const s = summarizeMigrationPlan({
+      cycles: 3,
+      results: [
+        wouldPush('spotify-a', 'Road trip', [
+          { providerId: 'spotify', addKeys: 2, removeKeys: 0,
+            addTracks: [{ artist: 'A', title: 'x' }, { artist: 'B', title: 'y' }], removeTracks: [] },
+        ]),
+        wouldPush('applemusic-b', 'Chill mix', [
+          { providerId: 'applemusic', addKeys: 0, removeKeys: 1,
+            addTracks: [], removeTracks: [{ artist: 'K', title: 'z' }] },
+        ]),
+      ],
+    });
+    expect(s.hasChanges).toBe(true);
+    expect(s.changed).toHaveLength(2);
+    expect(s.totalAdds).toBe(2);
+    expect(s.totalRemoves).toBe(1);
+    expect(s.hasRemoves).toBe(true);
+    expect(s.noopCount).toBe(1); // 3 cycles - 2 non-noop results
+    expect(s.changed[0].providers[0].adds).toHaveLength(2);
+    expect(s.changed[1].providers[0].removes[0]).toEqual({ artist: 'K', title: 'z' });
+  });
+
+  test('a would-push whose every target diff is empty is NOT counted as a change', () => {
+    const s = summarizeMigrationPlan({
+      cycles: 1,
+      results: [wouldPush('spotify-a', 'Empty diff', [{ providerId: 'spotify', addTracks: [], removeTracks: [] }])],
+    });
+    expect(s.hasChanges).toBe(false);
+    expect(s.changed).toHaveLength(0);
+  });
+
+  test('surfaces safety aborts as protected (not as changes)', () => {
+    const s = summarizeMigrationPlan({
+      cycles: 2,
+      results: [
+        { status: 'total-wipe-abort', localId: 'spotify-w', displayName: 'Liked songs' },
+        { status: 'partial-abort', localId: 'applemusic-p', displayName: 'Deep cuts' },
+      ],
+    });
+    expect(s.hasChanges).toBe(false);
+    expect(s.protected).toHaveLength(2);
+    expect(s.protected[0]).toEqual({ localId: 'spotify-w', displayName: 'Liked songs', reason: 'total-wipe' });
+    expect(s.protected[1].reason).toBe('partial');
+  });
+
+  test('counts errors from the shadow output', () => {
+    const s = summarizeMigrationPlan({ results: [], cycles: 1, errors: [{ localId: 'x', error: 'boom' }] });
+    expect(s.errorCount).toBe(1);
+  });
+});
+
+describe('buildMigrationReport', () => {
+  const summary = {
+    changed: [{ displayName: 'Chill mix', providers: [{ providerId: 'applemusic', adds: [], removes: [{ artist: 'Khruangbin', title: 'May ninth' }] }] }],
+    protected: [], totalAdds: 0, totalRemoves: 1, hasRemoves: true, hasChanges: true,
+  };
+
+  test('builds a titled, labeled GitHub new-issue URL with the diff in the body', () => {
+    const { title, body, githubUrl } = buildMigrationReport(summary, { appVersion: '1.2.3' });
+    expect(title).toContain('1 remove');
+    expect(title).toContain('1.2.3');
+    expect(body).toContain('Khruangbin — May ninth');
+    expect(body).toContain('App version: 1.2.3');
+    expect(githubUrl.startsWith('https://github.com/Parachord/parachord/issues/new?')).toBe(true);
+    expect(githubUrl).toContain(`title=${encodeURIComponent(title)}`);
+    expect(githubUrl).toContain('labels=sync');
+    expect(decodeURIComponent(githubUrl)).toContain('Khruangbin — May ninth');
+  });
+
+  test('tolerates missing appVersion + empty summary', () => {
+    const { body, githubUrl } = buildMigrationReport({}, {});
+    expect(body).toContain('App version: unknown');
+    expect(githubUrl.startsWith('https://github.com/')).toBe(true);
+  });
+});

--- a/tests/sync/playlist-reconcile.test.js
+++ b/tests/sync/playlist-reconcile.test.js
@@ -513,9 +513,29 @@ describe('reconcile — shadow (dryRun) mode', () => {
     expect(r.mergedSize).toBe(3);
     expect(r.pushTargets).toEqual(['spotify']);
     expect(r.perTarget[0]).toMatchObject({ providerId: 'spotify', addKeys: 1, removeKeys: 0 });
+    // The migration preview (#911) needs track NAMES, not just counts.
+    expect(r.perTarget[0].addTracks).toEqual([{ artist: 'artist-added', title: 'title-added' }]);
+    expect(r.perTarget[0].removeTracks).toEqual([]);
     // No side effects: remote, local, baseline all untouched.
     expect(sp.remote.length).toBe(2);
     expect(sp.addCalls).toEqual([]);
     expect(h.state.baseline.tracks.length).toBe(baselineBefore);
+  });
+
+  test('would-push names REMOVED tracks even from an unchanged mirror (the preview\'s danger signal)', async () => {
+    const h = new Harness();
+    const sp = h.add(new FakeProvider('spotify', 'ByNativeId'));
+    h.seed([mk('m0'), mk('m1')]);
+    // Local removes m1; spotify's snapshot is UNCHANGED, so its A1 copy is built
+    // tracks:[] — the name must come from the preview's fresh fetch.
+    h.editLocal([mk('m0')]);
+    const r = await h.cycle({ dryRun: true });
+    expect(r.status).toBe('would-push');
+    expect(r.perTarget[0]).toMatchObject({ providerId: 'spotify', addKeys: 0, removeKeys: 1 });
+    expect(r.perTarget[0].removeTracks).toEqual([{ artist: 'artist-m1', title: 'title-m1' }]);
+    expect(r.perTarget[0].addTracks).toEqual([]);
+    // Still a dry run: nothing written to the remote.
+    expect(sp.removeByNativeIdCalls).toEqual([]);
+    expect(sp.remote.length).toBe(2);
   });
 });


### PR DESCRIPTION
Phase 1 cont. of the legacy → N-way migration ([plan](https://github.com/Parachord/parachord/blob/main/docs/plans/2026-06-28-legacy-to-nway-sync-migration.md), follows #938). This PR is the **tested backend** for the preview → approve/report flow. The React modal + Developer-settings toggle is the remaining piece (see "Next").

## What's here (all tested, behavior-neutral)
- **Named per-target diff in shadow mode.** `playlist-reconcile.js`'s dryRun branch now computes the diff the **same way the real push does** (`computeMaterializeDiff(mergedTracks, remote)` with the diff's own keyspace mapped back to tracks), so the preview mirrors the executor exactly and carries track **names**. Removed-track names on an **unchanged** mirror (the identity-mismatch case — the most important to show) come from the same fresh per-target fetch the real push uses. Full sync suite green (Group-4 / no-false-drop / partial-fetch all pass).
- **`nway:preview` IPC** + `window.electron.nway.preview()` — a forced, compute-only reconcile that returns the named diff regardless of the dev flags and never writes. Shadow results enriched with playlist `displayName`.
- **`migration-plan.js`** (loaded via index.html, exported for jest): `summarizeMigrationPlan` (shadow output → render model: changed / protected / noop / totals) and `buildMigrationReport` (prefilled GitHub-issue title/body/url for "Report a problem").

## Tests
412 sync tests green, incl. new reconcile name cases (add + unchanged-mirror remove) and 7 migration-plan cases.

## Why backend-first
The reconcile change touches the most invariant-laden code in the tree; I wanted it landed and proven against the full no-false-drop suite on its own, mirroring the executor rather than re-deriving the diff. The remaining UI is render-only and best built with the app running.

## Next (same branch or follow-up)
The "Use new sync" toggle (Developer settings) → `nway.preview()` → the diff modal (the [mockup](https://github.com/Parachord/parachord/issues) we settled) → Accept (set `sync_engine_mode = 'new'`, recompute-on-accept) / Report (build + clipboard + open GitHub issue) / Cancel. All-or-nothing, prefilled GitHub issue, Developer-settings home — per the decisions captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)