### PR TITLE
feat(sync): LB rate-limit hardening — lbRequest retry/backoff + circuit breaker (#868)

### DIFF
--- a/app.js
+++ b/app.js
@@ -6699,6 +6699,25 @@ const Parachord = () => {
                 const SYNC_IPC_DELAY_MS = 250;
                 const breathe = () => new Promise(r => setTimeout(r, SYNC_IPC_DELAY_MS));
 
+                // LB circuit breaker (parachord#868). After 3 consecutive
+                // ListenBrainz write failures in this push-loop run, stop — the
+                // LB API is rate-limited or unreachable (each call already
+                // retried with backoff via lbRequest), so grinding through the
+                // rest only wastes calls. Resume next cycle. Counts LB only;
+                // resets on any LB success; other providers are unaffected.
+                let lbConsecutiveFailures = 0;
+                const noteLbOutcome = (ok) => {
+                  if (providerId !== 'listenbrainz') return false;
+                  if (ok) { lbConsecutiveFailures = 0; return false; }
+                  lbConsecutiveFailures += 1;
+                  if (lbConsecutiveFailures >= 3) {
+                    console.warn('[Sync] LB circuit breaker tripped (3 consecutive failures) — deferring to next cycle');
+                    showToast('ListenBrainz rate-limited or unreachable; will resume next sync cycle', 'warning');
+                    return true;
+                  }
+                  return false;
+                };
+
                 for (const playlist of allPlaylists) {
                   // Cancel-on-focus: drop out mid-push if the user returned
                   // (parachord#799). Anything already pushed stays; the
@@ -6823,6 +6842,7 @@ const Parachord = () => {
                     }
                     // Playlist not yet created on this provider — create it
                     console.log(`[Sync] Creating playlist "${playlist.title}" on ${providerId}`);
+                    let createOk = false;
                     try {
                       const result = await window.electron.sync.createPlaylist(
                         providerId,
@@ -6844,11 +6864,13 @@ const Parachord = () => {
                         };
                         playlistsChanged = true;
                         modifiedPlaylistIds.add(playlist.id);
+                        createOk = true;
                         console.log(`[Sync] Created playlist "${playlist.title}" on ${providerId}: ${result.externalId}`);
                       }
                     } catch (err) {
                       console.warn(`[Sync] Failed to create playlist "${playlist.title}" on ${providerId}:`, err.message);
                     }
+                    if (noteLbOutcome(createOk)) break;
                     await breathe();
                   } else if (playlist.locallyModified) {
                     // CHANNEL gate for the EDIT branch (parachord#911). SYNC:
@@ -6864,6 +6886,7 @@ const Parachord = () => {
                     }
                     // Playlist exists remotely and has local changes — push updates
                     console.log(`[Sync] Pushing updates for "${playlist.title}" to ${providerId}`);
+                    let pushOk = false;
                     try {
                       // Resolve tracks to provider-specific URIs before pushing
                       let tracksForPush = playlist.tracks || [];
@@ -6891,11 +6914,13 @@ const Parachord = () => {
                         };
                         playlistsChanged = true;
                         modifiedPlaylistIds.add(playlist.id);
+                        pushOk = true;
                       } else if (pushResult?.error === 'PLAYLIST_NOT_FOUND' || pushResult?.error?.includes('404')) {
                         // Remote playlist was deleted
                         playlist.syncedTo[providerId].pendingAction = 'remote-deleted';
                         playlistsChanged = true;
                         modifiedPlaylistIds.add(playlist.id);
+                        pushOk = true; // definitive outcome, not a rate-limit failure
                         console.warn(`[Sync] Remote playlist "${playlist.title}" was deleted on ${providerId}`);
                       }
                     } catch (err) {
@@ -6903,9 +6928,11 @@ const Parachord = () => {
                         playlist.syncedTo[providerId].pendingAction = 'remote-deleted';
                         playlistsChanged = true;
                         modifiedPlaylistIds.add(playlist.id);
+                        pushOk = true; // remote gone — definitive, not a rate-limit failure
                       }
                       console.warn(`[Sync] Failed to push playlist "${playlist.title}" to ${providerId}:`, err.message);
                     }
+                    if (noteLbOutcome(pushOk)) break;
                     await breathe();
                   }
                 }
@@ -11355,6 +11382,26 @@ const Parachord = () => {
             const SYNC_IPC_DELAY_MS = 250;
             const breathe = () => new Promise(r => setTimeout(r, SYNC_IPC_DELAY_MS));
 
+            // LB circuit breaker (parachord#868) — lockstep with the
+            // background-sync push loop. After 3 consecutive ListenBrainz write
+            // failures this run, stop (LB rate-limited/unreachable; each call
+            // already retried with backoff). Resume next cycle. The wizard's
+            // manual sync is more user-visible, so this is the loop that most
+            // benefits from not silently grinding through failing creates while
+            // the wizard reports "complete."
+            let lbConsecutiveFailures = 0;
+            const noteLbOutcome = (ok) => {
+              if (providerId !== 'listenbrainz') return false;
+              if (ok) { lbConsecutiveFailures = 0; return false; }
+              lbConsecutiveFailures += 1;
+              if (lbConsecutiveFailures >= 3) {
+                console.warn('[Sync] LB circuit breaker tripped (3 consecutive failures) — deferring to next cycle');
+                showToast('ListenBrainz rate-limited or unreachable; will resume next sync cycle', 'warning');
+                return true;
+              }
+              return false;
+            };
+
             for (const playlist of allPlaylists) {
               // Yield to the renderer's idle scheduler before each iteration
               // so user interactions get responsive frames mid-sync. See
@@ -11442,6 +11489,7 @@ const Parachord = () => {
                 }
                 // Playlist not yet created on this provider — create it
                 console.log(`[Sync] Creating playlist "${playlist.title}" on ${providerId}`);
+                let createOk = false;
                 try {
                   const createResult = await window.electron.sync.createPlaylist(
                     providerId,
@@ -11463,10 +11511,12 @@ const Parachord = () => {
                     };
                     playlistsChanged = true;
                     modifiedPlaylistIds.add(playlist.id);
+                    createOk = true;
                   }
                 } catch (err) {
                   console.warn(`[Sync] Failed to create playlist "${playlist.title}" on ${providerId}:`, err.message);
                 }
+                if (noteLbOutcome(createOk)) break;
                 await breathe();
               } else if (playlist.locallyModified) {
                 // CHANNEL gate for the EDIT branch (parachord#911) — lockstep with
@@ -11478,6 +11528,7 @@ const Parachord = () => {
                 }
                 // Playlist exists remotely and has local changes — push updates
                 console.log(`[Sync] Pushing updates for "${playlist.title}" to ${providerId}`);
+                let pushOk = false;
                 try {
                   // Resolve tracks to provider-specific URIs before pushing
                   let tracksForPush = playlist.tracks || [];
@@ -11505,10 +11556,12 @@ const Parachord = () => {
                     };
                     playlistsChanged = true;
                     modifiedPlaylistIds.add(playlist.id);
+                    pushOk = true;
                   } else if (pushResult?.error === 'PLAYLIST_NOT_FOUND' || pushResult?.error?.includes('404')) {
                     playlist.syncedTo[providerId].pendingAction = 'remote-deleted';
                     playlistsChanged = true;
                     modifiedPlaylistIds.add(playlist.id);
+                    pushOk = true; // definitive outcome, not a rate-limit failure
                     console.warn(`[Sync] Remote playlist "${playlist.title}" was deleted on ${providerId}`);
                   }
                 } catch (err) {
@@ -11516,9 +11569,11 @@ const Parachord = () => {
                     playlist.syncedTo[providerId].pendingAction = 'remote-deleted';
                     playlistsChanged = true;
                     modifiedPlaylistIds.add(playlist.id);
+                    pushOk = true; // remote gone — definitive, not a rate-limit failure
                   }
                   console.warn(`[Sync] Failed to push playlist "${playlist.title}" to ${providerId}:`, err.message);
                 }
+                if (noteLbOutcome(pushOk)) break;
                 await breathe();
               }
             }

--- a/sync-providers/listenbrainz.js
+++ b/sync-providers/listenbrainz.js
@@ -37,6 +37,42 @@ function authHeaders(token) {
   };
 }
 
+const LB_MAX_RETRIES = 3;
+const lbSleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Authenticated LB API request with retry-with-backoff (parachord#868). Mirrors
+// spotify.js's spotifyRequest: a 429 honors `Retry-After`; 502/503/504 and
+// network errors use exponential backoff `min(1000·2^n, 30000)`; max
+// LB_MAX_RETRIES. Returns the final Response so callers keep their own non-OK
+// handling (e.g. the 404 → remoteDeleted check in updatePlaylistTracks) — retries
+// only absorb transient blips on a single batch, never mask a real 4xx.
+async function lbRequest(endpoint, token, options = {}, _retry = 0) {
+  const url = endpoint.startsWith('http') ? endpoint : `${LB_BASE}${endpoint}`;
+  const { method = 'GET', body } = options;
+  let res;
+  try {
+    res = await fetch(url, {
+      method,
+      headers: authHeaders(token),
+      body: body === undefined ? undefined : (typeof body === 'string' ? body : JSON.stringify(body)),
+    });
+  } catch (err) {
+    if (_retry >= LB_MAX_RETRIES) throw err;
+    await lbSleep(Math.min(1000 * 2 ** _retry, 30000));
+    return lbRequest(endpoint, token, options, _retry + 1);
+  }
+  if (res.status === 429 && _retry < LB_MAX_RETRIES) {
+    const ra = parseInt(res.headers.get('Retry-After') || '5', 10);
+    await lbSleep((Number.isFinite(ra) ? ra : 5) * 1000);
+    return lbRequest(endpoint, token, options, _retry + 1);
+  }
+  if ([502, 503, 504].includes(res.status) && _retry < LB_MAX_RETRIES) {
+    await lbSleep(Math.min(1000 * 2 ** _retry, 30000));
+    return lbRequest(endpoint, token, options, _retry + 1);
+  }
+  return res;
+}
+
 // Per-token cache of the LB username so a single sync run (which makes N
 // playlist-create + N playlist-update calls) doesn't fire 2N /1/validate-token
 // GETs in quick succession. Without this cache, syncing 142 playlists meant
@@ -56,7 +92,7 @@ async function getUserName(token) {
   const tokenPreview = token ? `${String(token).slice(0, 8)}...(len=${String(token).length})` : 'NULL/EMPTY';
   let res;
   try {
-    res = await fetch(`${LB_BASE}/1/validate-token`, { headers: authHeaders(token) });
+    res = await lbRequest('/1/validate-token', token);
   } catch (err) {
     console.warn(`[LB] validate-token fetch threw for token ${tokenPreview}:`, err && err.message ? err.message : err);
     throw err;
@@ -194,9 +230,7 @@ async function fetchPlaylists(token, _onProgress, _refreshToken) {
   return { playlists };
 }
 async function fetchPlaylistTracks(playlistMbid, token, _onProgress, _refreshToken) {
-  const res = await fetch(`${LB_BASE}/1/playlist/${encodeURIComponent(playlistMbid)}`, {
-    headers: authHeaders(token),
-  });
+  const res = await lbRequest(`/1/playlist/${encodeURIComponent(playlistMbid)}`, token);
   if (!res.ok) throw new Error(`LB fetchPlaylistTracks returned ${res.status}`);
   const data = await res.json();
   const tracks = Array.isArray(data?.playlist?.track) ? data.playlist.track : [];
@@ -246,11 +280,7 @@ async function createPlaylist(name, description, token) {
       track: [],
     },
   };
-  const res = await fetch(`${LB_BASE}/1/playlist/create`, {
-    method: 'POST',
-    headers: authHeaders(token),
-    body: JSON.stringify(body),
-  });
+  const res = await lbRequest('/1/playlist/create', token, { method: 'POST', body });
   if (!res.ok) {
     const text = await res.text().catch(() => '');
     throw new Error(`LB createPlaylist returned ${res.status}: ${text.slice(0, 200)}`);
@@ -294,9 +324,7 @@ async function updatePlaylistTracks(playlistMbid, tracks, token, opts = {}) {
   let remoteSnapshotDate = null;
   let remoteTracks = [];
   let currentLen = 0;
-  const cur = await fetch(`${LB_BASE}/1/playlist/${encodeURIComponent(playlistMbid)}`, {
-    headers: authHeaders(token),
-  });
+  const cur = await lbRequest(`/1/playlist/${encodeURIComponent(playlistMbid)}`, token);
   if (cur.status === 404) {
     return { snapshotId: null, unresolvedTracks, remoteDeleted: true };
   }
@@ -404,10 +432,9 @@ async function updatePlaylistTracks(playlistMbid, tracks, token, opts = {}) {
 
   // ── Step 4: Clear remote (same pattern as the rest of the file) ───
   if (currentLen > 0) {
-    const delRes = await fetch(`${LB_BASE}/1/playlist/${encodeURIComponent(playlistMbid)}/item/delete`, {
+    const delRes = await lbRequest(`/1/playlist/${encodeURIComponent(playlistMbid)}/item/delete`, token, {
       method: 'POST',
-      headers: authHeaders(token),
-      body: JSON.stringify({ index: 0, count: currentLen }),
+      body: { index: 0, count: currentLen },
     });
     if (!delRes.ok) {
       const text = await delRes.text().catch(() => '');
@@ -419,10 +446,9 @@ async function updatePlaylistTracks(playlistMbid, tracks, token, opts = {}) {
   const BATCH = 100;
   for (let i = 0; i < resolvedTracks.length; i += BATCH) {
     const batch = resolvedTracks.slice(i, i + BATCH);
-    const addRes = await fetch(`${LB_BASE}/1/playlist/${encodeURIComponent(playlistMbid)}/item/add`, {
+    const addRes = await lbRequest(`/1/playlist/${encodeURIComponent(playlistMbid)}/item/add`, token, {
       method: 'POST',
-      headers: authHeaders(token),
-      body: JSON.stringify({ playlist: { track: batch } }),
+      body: { playlist: { track: batch } },
     });
     if (!addRes.ok) {
       const text = await addRes.text().catch(() => '');
@@ -433,9 +459,7 @@ async function updatePlaylistTracks(playlistMbid, tracks, token, opts = {}) {
   // ── Step 6: Re-fetch fresh snapshot anchor ─────────────────────────
   let newSnapshotId = null;
   try {
-    const cur = await fetch(`${LB_BASE}/1/playlist/${encodeURIComponent(playlistMbid)}`, {
-      headers: authHeaders(token),
-    });
+    const cur = await lbRequest(`/1/playlist/${encodeURIComponent(playlistMbid)}`, token);
     if (cur.ok) {
       const data = await cur.json();
       newSnapshotId = data?.playlist?.extension?.['https://musicbrainz.org/doc/jspf#playlist']?.last_modified_at
@@ -453,11 +477,7 @@ async function updatePlaylistDetails(playlistMbid, details, token) {
       annotation: details?.description ?? '',
     },
   };
-  const res = await fetch(`${LB_BASE}/1/playlist/edit/${encodeURIComponent(playlistMbid)}`, {
-    method: 'POST',
-    headers: authHeaders(token),
-    body: JSON.stringify(body),
-  });
+  const res = await lbRequest(`/1/playlist/edit/${encodeURIComponent(playlistMbid)}`, token, { method: 'POST', body });
   if (!res.ok) {
     const text = await res.text().catch(() => '');
     // Don't throw — see CLAUDE.md "Apple Music fallback behavior" rationale.
@@ -469,10 +489,7 @@ async function updatePlaylistDetails(playlistMbid, details, token) {
   return { success: true };
 }
 async function deletePlaylist(playlistMbid, token) {
-  const res = await fetch(`${LB_BASE}/1/playlist/${encodeURIComponent(playlistMbid)}/delete`, {
-    method: 'POST',
-    headers: authHeaders(token),
-  });
+  const res = await lbRequest(`/1/playlist/${encodeURIComponent(playlistMbid)}/delete`, token, { method: 'POST' });
   if (!res.ok) {
     return { success: false, reason: `status-${res.status}` };
   }
@@ -507,10 +524,9 @@ async function removePlaylistTracksByPosition(playlistMbid, positions, token) {
     .filter((p) => Number.isInteger(p) && p >= 0)
     .sort((a, b) => b - a); // descending — delete from the back forward
   for (const index of sorted) {
-    const res = await fetch(`${LB_BASE}/1/playlist/${encodeURIComponent(playlistMbid)}/item/delete`, {
+    const res = await lbRequest(`/1/playlist/${encodeURIComponent(playlistMbid)}/item/delete`, token, {
       method: 'POST',
-      headers: authHeaders(token),
-      body: JSON.stringify({ index, count: 1 }),
+      body: { index, count: 1 },
     });
     if (!res.ok) {
       const text = await res.text().catch(() => '');
@@ -520,9 +536,7 @@ async function removePlaylistTracksByPosition(playlistMbid, positions, token) {
   // Re-fetch the fresh snapshot anchor (same pattern as updatePlaylistTracks).
   let snapshotId = null;
   try {
-    const cur = await fetch(`${LB_BASE}/1/playlist/${encodeURIComponent(playlistMbid)}`, {
-      headers: authHeaders(token),
-    });
+    const cur = await lbRequest(`/1/playlist/${encodeURIComponent(playlistMbid)}`, token);
     if (cur.ok) {
       const data = await cur.json();
       snapshotId =
@@ -541,7 +555,7 @@ async function removePlaylistTracksByPosition(playlistMbid, positions, token) {
 async function checkAuth(token) {
   if (!token) return false;
   try {
-    const res = await fetch(`${LB_BASE}/1/validate-token`, { headers: authHeaders(token) });
+    const res = await lbRequest('/1/validate-token', token);
     if (!res.ok) return false;
     const data = await res.json();
     return !!data?.valid;
@@ -569,6 +583,7 @@ async function resolveTracks(tracks, token) {
 
 module.exports = {
   resolveTracks,
+  lbRequest, // exported for retry-behavior tests (parachord#868)
   id: 'listenbrainz',
   // Sibling providers (spotify.js, applemusic.js) export `displayName`, and
   // main.js's sync-provider listing reads `p.displayName` (main.js:5756).

--- a/tests/sync/lb-request-retry.test.js
+++ b/tests/sync/lb-request-retry.test.js
@@ -1,0 +1,102 @@
+/**
+ * lbRequest retry-with-backoff (parachord#868). Mirrors spotifyRequest: 429
+ * honors Retry-After; 5xx + network errors back off exponentially; capped at
+ * LB_MAX_RETRIES (3); non-transient statuses (404/401) return immediately; the
+ * final Response is returned even after exhausted retries so callers keep their
+ * own non-OK handling. Fake timers keep the backoff from slowing the suite.
+ */
+
+const { lbRequest } = require('../../sync-providers/listenbrainz');
+
+function res(status, headers = {}) {
+  const low = {};
+  for (const [k, v] of Object.entries(headers)) low[k.toLowerCase()] = v;
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: (h) => (h.toLowerCase() in low ? low[h.toLowerCase()] : null) },
+    text: async () => '',
+    json: async () => ({}),
+  };
+}
+
+describe('lbRequest retry-with-backoff (#868)', () => {
+  let origFetch;
+  beforeEach(() => { jest.useFakeTimers(); origFetch = global.fetch; });
+  afterEach(() => { jest.useRealTimers(); global.fetch = origFetch; });
+
+  test('returns immediately on 2xx (no retry)', async () => {
+    global.fetch = jest.fn().mockResolvedValue(res(200));
+    const p = lbRequest('/1/x', 'tok');
+    await jest.runAllTimersAsync();
+    expect((await p).status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('retries on 429 honoring Retry-After, then succeeds', async () => {
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce(res(429, { 'Retry-After': '1' }))
+      .mockResolvedValueOnce(res(200));
+    const p = lbRequest('/1/x', 'tok');
+    await jest.runAllTimersAsync();
+    expect((await p).status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('retries on 503 with exponential backoff, then succeeds', async () => {
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce(res(503))
+      .mockResolvedValueOnce(res(503))
+      .mockResolvedValueOnce(res(200));
+    const p = lbRequest('/1/x', 'tok');
+    await jest.runAllTimersAsync();
+    expect((await p).status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+  });
+
+  test('gives up after LB_MAX_RETRIES (3) and returns the final 429', async () => {
+    global.fetch = jest.fn().mockResolvedValue(res(429, { 'Retry-After': '1' }));
+    const p = lbRequest('/1/x', 'tok');
+    await jest.runAllTimersAsync();
+    expect((await p).status).toBe(429);
+    expect(global.fetch).toHaveBeenCalledTimes(4); // initial + 3 retries
+  });
+
+  test('does NOT retry a non-transient 404 (caller handles remote-deleted)', async () => {
+    global.fetch = jest.fn().mockResolvedValue(res(404));
+    const p = lbRequest('/1/x', 'tok');
+    await jest.runAllTimersAsync();
+    expect((await p).status).toBe(404);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('does NOT retry a 401 (auth failure surfaces to caller)', async () => {
+    global.fetch = jest.fn().mockResolvedValue(res(401));
+    const p = lbRequest('/1/x', 'tok');
+    await jest.runAllTimersAsync();
+    expect((await p).status).toBe(401);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('retries network errors, then re-throws after max retries', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('ECONNRESET'));
+    const p = lbRequest('/1/x', 'tok').catch((e) => e);
+    await jest.runAllTimersAsync();
+    const out = await p;
+    expect(out).toBeInstanceOf(Error);
+    expect(out.message).toBe('ECONNRESET');
+    expect(global.fetch).toHaveBeenCalledTimes(4);
+  });
+
+  test('sends Token auth + serializes object body', async () => {
+    global.fetch = jest.fn().mockResolvedValue(res(200));
+    const p = lbRequest('/1/playlist/create', 'mytoken', { method: 'POST', body: { a: 1 } });
+    await jest.runAllTimersAsync();
+    await p;
+    const [url, init] = global.fetch.mock.calls[0];
+    expect(url).toContain('/1/playlist/create');
+    expect(init.method).toBe('POST');
+    expect(init.headers.Authorization).toBe('Token mytoken');
+    expect(init.body).toBe(JSON.stringify({ a: 1 }));
+  });
+});


### PR DESCRIPTION
Closes the two remaining critical-tier items from #793 (via #868) that were still missing in `sync-providers/listenbrainz.js`.

## 1. Retry-with-backoff
New `lbRequest(endpoint, token, options)` mirrors `spotify.js`'s `spotifyRequest`:
- **429** → honors `Retry-After`
- **502/503/504 + network errors** → exponential backoff `min(1000·2^n, 30000)`
- capped at **3 retries**
- returns the **final Response** so callers keep their own non-OK handling (the `404`→remote-deleted check, `401` surfacing) — retries only absorb transient blips, never mask a real 4xx

Every LB API call site now routes through it: create / `updatePlaylistTracks` (all 4 fetches) / `updatePlaylistDetails` / `deletePlaylist` / `removePlaylistTracksByPosition` / `fetchPlaylistTracks` / `validate-token`. **8 fake-timer tests** cover retry/backoff/cap/non-retry(404,401)/throw/auth+body-serialization.

## 2. Per-loop circuit breaker
Both push loops (background-sync ~L6700 + post-wizard IIFE ~L11385) count consecutive LB write failures and, after **3**, stop the loop and toast `ListenBrainz rate-limited or unreachable; will resume next sync cycle` instead of grinding through 15 more failing creates. Resets on any LB success; definitive `remote-deleted` (404) outcomes don't count toward it; other providers are unaffected.

428 sync tests green.

Note: the structural mass-cascade is already prevented by staggered sync (#800) — these protect against transient blips on a single batch, the scenario #793 flagged but #807 didn't cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)