### PR TITLE
feat(sync): N-way norm-bridge guard + no-false-drop harness — full P3 identity gate (#911)

### DIFF
--- a/sync-engine/playlist-key-unify.js
+++ b/sync-engine/playlist-key-unify.js
@@ -33,8 +33,21 @@ const { validIsrc, validMbid, deriveNorm } = require('./playlist-merge');
 //   always present). Use `trackTiers()` below to derive this shape from a
 //   raw track object.
 //
-// Match: two tracks are the SAME if they share ANY tier value (isrc OR mbid
-//   OR norm), transitively (union-find).
+// Match (two-phase norm-bridge guard, parachord#911 P3 —
+//   docs/plans/2026-06-28-nway-norm-bridge-guard.md, mobile#289):
+//   1. STRONG phase (unconditional): union by equal ISRC, then equal MBID.
+//      A shared MBID may legitimately span two DIFFERENT ISRCs (same recording,
+//      reissue/market re-registration) → they become ONE component.
+//   2. NORM phase (guarded), per norm group, counting the COMPONENTS that carry
+//      an ISRC after the strong phase (NOT distinct ISRC values):
+//        - cIsrc ≤ 1 → stronger ISRC identity is absent or agrees → union the
+//          whole group (keeps norm↔isrc / norm↔mbid cross-service dedup).
+//        - cIsrc ≥ 2 → ≥2 disagreeing ISRC identities → NEVER collapse via norm;
+//          union only the ISRC-free (mbid-only + pure-norm) nodes among
+//          themselves (leaves each strong component intact; transitivity-safe).
+//   MBID DISAGREEMENT NEVER BLOCKS the norm bridge — recording-MBID varies for
+//   the same song across services/enrichment; blocking it re-introduces the
+//   2026-06-22 false-REMOVE data-loss class. Only ISRC is a hard discriminator.
 // Representative: per equivalence class, the strongest tier PRESENT in the
 //   class — `isrc-<v>` else `mbid-<v>` else `norm-<v>` — using the
 //   lexicographically-smallest value within that tier (deterministic
@@ -44,19 +57,15 @@ const { validIsrc, validMbid, deriveNorm } = require('./playlist-merge');
 //   preserved (a within-list collision repeats the same repr; the merge
 //   dedups downstream).
 //
-// TODO(parachord#911): the norm-bridge guard from
-//   docs/plans/2026-06-21-nway-key-consistency-design.md is NOT implemented
-//   here — norm unifies even across tracks carrying DIFFERENT confident
-//   ISRCs/MBIDs (the doc's rule: "norm may bridge only when the stronger ids
-//   are absent or already agree; never override a confident isrc/mbid
-//   disagreement"). Two genuinely different recordings sharing `artist|title`
-//   but with different confident ISRCs would wrongly merge. ACCEPTED RISK for
-//   now: this matches the current cross-engine fixture contract (the 8
-//   key-unify fixtures don't pin the guard, so Kotlin has no guard either —
-//   we stay in byte-parity) AND N-way real-writes are OFF, so a false-merge
-//   cannot reach a remote. The guard + its fixtures must be added to BOTH
-//   engines together before real-writes are armed. (The blank-norm collapse,
-//   `norm='|'` from blank artist+title, is the same accepted residual.)
+// CROSS-ENGINE CONTRACT: tests/fixtures/nway-merge/key-unify-fixtures.json (16
+//   cases, vendored verbatim from parachord-mobile docs/nway-key-unify-
+//   fixtures.json) is the source of truth; Kotlin NwayKeyUnify.unifyTrackKeys
+//   must produce identical output on every case. Two behaviors are explicit in
+//   the fixture _semantics but NOT yet fixture-pinned — both implemented here
+//   per the text: (a) "component carries an ISRC" is GLOBAL (an ISRC-bearing
+//   member outside the evaluated norm group still counts, via the post-strong
+//   snapshot below); (b) the weak set is ISRC-FREE (mbid-only nodes join it),
+//   not pure-norm-only.
 //
 // @param {Array<Array<{isrc?:string|null, mbid?:string|null, norm:string}>>} lists
 // @returns {string[][]}
@@ -92,17 +101,57 @@ function unifyTrackKeys(lists) {
     if (ra !== rb) parent[Math.max(ra, rb)] = Math.min(ra, rb);
   };
 
-  // Union any two tracks sharing a tier value (isrc / mbid / norm).
-  const firstByTier = new Map(); // `${tier}:${value}` -> first track index
+  // ── Phase 1: STRONG (unconditional) — union equal ISRC, then equal MBID.
+  const byIsrc = new Map();
   tracks.forEach((t, i) => {
-    const pairs = [['isrc', t.isrc], ['mbid', t.mbid], ['norm', t.norm]];
-    for (const [tier, val] of pairs) {
-      if (val == null || val === '') continue;
-      const key = `${tier}:${val}`;
-      if (firstByTier.has(key)) union(i, firstByTier.get(key));
-      else firstByTier.set(key, i);
-    }
+    if (!t.isrc) return;
+    if (byIsrc.has(t.isrc)) union(i, byIsrc.get(t.isrc));
+    else byIsrc.set(t.isrc, i);
   });
+  const byMbid = new Map();
+  tracks.forEach((t, i) => {
+    if (!t.mbid) return;
+    if (byMbid.has(t.mbid)) union(i, byMbid.get(t.mbid));
+    else byMbid.set(t.mbid, i);
+  });
+
+  // Snapshot the post-strong-phase component of each track, and whether that
+  // component carries an ISRC ANYWHERE (global — an ISRC-bearing member in a
+  // different norm group still makes the component an ISRC identity). The guard
+  // decisions below read this snapshot, never live find(), so a norm-phase union
+  // in one group can't shift another group's component count (order-independent,
+  // matching the _semantics "components that exist after the strong phase").
+  const strongRoot = tracks.map((_, i) => find(i));
+  const compHasIsrc = new Set();
+  tracks.forEach((t, i) => { if (t.isrc) compHasIsrc.add(strongRoot[i]); });
+
+  // ── Phase 2: NORM (guarded), per norm group.
+  const groups = new Map(); // norm -> [trackIdx]
+  tracks.forEach((t, i) => {
+    if (!t.norm) return;
+    if (!groups.has(t.norm)) groups.set(t.norm, []);
+    groups.get(t.norm).push(i);
+  });
+  for (const members of groups.values()) {
+    // cIsrc = distinct post-strong components in this group that carry an ISRC.
+    const isrcRoots = new Set();
+    for (const i of members) {
+      if (compHasIsrc.has(strongRoot[i])) isrcRoots.add(strongRoot[i]);
+    }
+    if (isrcRoots.size <= 1) {
+      // Stronger identity absent or agrees → union the whole group.
+      for (let k = 1; k < members.length; k++) union(members[0], members[k]);
+    } else {
+      // ≥2 disagreeing ISRC identities → bridge only the ISRC-free nodes among
+      // themselves; leave each strong component intact. "ISRC-free" is a
+      // COMPONENT property, not the node's own field: an mbid-only node whose
+      // component carries an ISRC (bridged via MBID in the strong phase) already
+      // belongs to a strong identity, so it must NOT act as a norm bridge —
+      // including it would drag a pure-norm node into that conflicting ISRC.
+      const weak = members.filter((i) => !compHasIsrc.has(strongRoot[i]));
+      for (let k = 1; k < weak.length; k++) union(weak[0], weak[k]);
+    }
+  }
 
   // Representative per class.
   const reprByRoot = new Map();

--- a/tests/fixtures/nway-merge/key-unify-fixtures.json
+++ b/tests/fixtures/nway-merge/key-unify-fixtures.json
@@ -1,11 +1,13 @@
 {
-  "_about": "Canonical cross-engine vectors for N-way cross-copy KEY UNIFICATION (Phase 4 prerequisite). Runs BEFORE the merge: it rewrites each copy's tracklist to canonical representative keys so the same song matches across services, THEN docs/nway-playlist-merge-fixtures.json's merge runs on the representatives. BOTH the Kotlin (mobile, shared/.../sync/NwayKeyUnify.kt) and JS (desktop) implementations MUST produce `expected` for each case. Mobile's NwayKeyUnifyTest is a 1:1 transcription.",
+  "_about": "Canonical cross-engine vectors for N-way cross-copy KEY UNIFICATION (Phase 4 prerequisite). Runs BEFORE the merge: it rewrites each copy's tracklist to canonical representative keys so the same song matches across services, THEN docs/nway-playlist-merge-fixtures.json's merge runs on the representatives. BOTH the Kotlin (mobile, shared/.../sync/NwayKeyUnify.kt) and JS (desktop, playlist-key-unify.js) implementations MUST produce `expected` for each case. Mobile's NwayKeyUnifyTest is a 1:1 transcription. Design: docs/plans/2026-06-28-nway-norm-bridge-guard.md (parachord#911 P3).",
   "_semantics": {
-    "input": "`lists` = baseline + each copy, in order. Each track is {isrc?, mbid?, norm}: isrc validated+UPPERCASED (^[A-Z]{2}[A-Z0-9]{3}[0-9]{7}$) or null; mbid trim+lowercase or null; norm = '<artist>|<title>' lower+trim, always present.",
-    "match": "Two tracks are the SAME if they share ANY tier value (isrc OR mbid OR norm), transitively (union-find). norm bridges an un-enriched track to its mbid twin AND bridges two different recording-MBIDs of the same song.",
+    "input": "`lists` = baseline + each copy, in order. Each track is {isrc?, mbid?, norm}: isrc validated+UPPERCASED (^[A-Z]{2}[A-Z0-9]{3}[0-9]{7}$) or null; mbid trim+lowercase or null; norm = '<artist>|<title>' lower+trim, remaster-suffix stripped, always present.",
+    "match_strong": "STRONG PHASE (unconditional): union by equal ISRC, then equal MBID. A shared MBID may legitimately span two different ISRCs (same recording, reissue/market re-registration) — they become ONE component.",
+    "match_norm_guard": "NORM PHASE per norm-group, counting COMPONENTS that carry an ISRC after the strong phase (NOT distinct ISRC VALUES): if <=1 ISRC-bearing component, the norm tier unions the whole group (closes norm<->mbid / norm<->isrc cross-service dedup); if >=2 disagreeing ISRC identities, NEVER collapse them via norm — union only the ISRC-free (mbid-only + pure-norm) nodes among themselves.",
+    "match_mbid_rule": "MBID DISAGREEMENT NEVER BLOCKS the norm bridge. Recording-MBID varies for the same song across services/enrichment; blocking it would re-introduce the 2026-06-22 false-REMOVE data-loss class (see norm_bridges_recording_mbid_variance). Only ISRC is a hard discriminator.",
     "representative": "Per equivalence class, the strongest tier present — 'isrc-<v>' else 'mbid-<v>' else 'norm-<v>' — using the LEXICOGRAPHICALLY-SMALLEST value within that tier. Deterministic regardless of input order. A singleton class yields exactly the single canonical key.",
-    "residual": "Two genuinely different recordings sharing an identical norm unify via norm (accepted, rare). Guarding the norm bridge on disagreeing ISRCs is a tracked refinement.",
-    "output": "Each input list rewritten to its representative keys, order + length preserved (a within-list norm collision collapses to the same repr; the downstream merge dedups)."
+    "residual": "ISRC-only is INTENTIONAL — do NOT tighten it back to a symmetric guard by adding a cMbid conflict clause. Accepted tradeoff: two GENUINELY-DISTINCT recordings with different MBIDs, the same norm, and NO ISRC on either will union (false-merge one away). This is accepted because same-song-with-different-recording-MBID is the COMMON case (LB mapper vs MB search vs per-service enrichment) and blocking it on MBID is the strictly worse, false-REMOVE failure (2026-06-22 data-loss incident — see norm_bridges_recording_mbid_variance / guard_v2 / V12); a genuinely-distinct recording almost always carries an ISRC anyway, so this corner is rare. ISRC is a deliberate distinct-recording assignment; recording-MBID is too granular to signal 'distinct track' for playlist identity.",
+    "output": "Each input list rewritten to its representative keys, order + length preserved."
   },
   "cases": [
     {
@@ -23,6 +25,7 @@
     },
     {
       "name": "norm_bridges_recording_mbid_variance",
+      "_note": "MBID-variance bridge (2026-06-22 false-remove fix): two DIFFERENT recording-MBIDs of the same song, no ISRC, same norm → UNION. The norm guard must NOT separate these (that is the data-loss class). Pins match_mbid_rule.",
       "lists": [
         [{ "mbid": "rec-a", "norm": "song|x" }],
         [{ "mbid": "rec-b", "norm": "song|x" }]
@@ -47,7 +50,7 @@
     },
     {
       "name": "isrc_bridges_when_mbid_and_norm_both_differ",
-      "_note": "Reconciliation-redesign incident case: same recording across services with a DIFFERENT recording-MBID AND a drifted normalized title (remaster suffix). Neither mbid nor norm matches; only the ISRC bridges them. Without the persisted isrc tier these were union-removed → data loss.",
+      "_note": "Reconciliation-redesign incident case: same recording across services with a DIFFERENT recording-MBID AND a drifted normalized title (remaster suffix). Same ISRC → strong phase unions them.",
       "lists": [
         [{ "isrc": "USABC1234567", "mbid": "rec-a", "norm": "the cranberries|zombie" }],
         [{ "isrc": "USABC1234567", "mbid": "rec-b", "norm": "the cranberries|zombie - 2025 remastered" }]
@@ -66,6 +69,51 @@
       "name": "order_independent_determinism",
       "lists": [[{ "mbid": "b", "norm": "s|x" }, { "mbid": "a", "norm": "s|x" }]],
       "expected": [["mbid-a", "mbid-a"]]
+    },
+    {
+      "name": "guard_v1_disagreeing_isrc_same_norm_separate",
+      "_note": "Audit D-Nway-4: two 'Intro' by The xx (album cut / single edit), different ISRCs, same norm. Today's un-guarded engine collapses these to one repr; the guard keeps them separate.",
+      "lists": [[{ "isrc": "GBBKS0700116", "norm": "the xx|intro" }, { "isrc": "GBBKS1300999", "norm": "the xx|intro" }]],
+      "expected": [["isrc-GBBKS0700116", "isrc-GBBKS1300999"]]
+    },
+    {
+      "name": "guard_v3_original_vs_remaster_disagreeing_isrc_separate",
+      "_note": "Audit D-Nway-5: original + 2011 remaster collapse to the same norm after the remaster strip, but carry different ISRCs → distinct recordings, kept separate.",
+      "lists": [[{ "isrc": "GBN9Y1100123", "norm": "pink floyd|wish you were here" }, { "isrc": "GBN9Y1100777", "norm": "pink floyd|wish you were here" }]],
+      "expected": [["isrc-GBN9Y1100123", "isrc-GBN9Y1100777"]]
+    },
+    {
+      "name": "guard_v4_norm_only_bridges_to_isrc_twin",
+      "lists": [[{ "isrc": "USUM71900764", "norm": "billie eilish|bad guy" }], [{ "norm": "billie eilish|bad guy" }]],
+      "expected": [["isrc-USUM71900764"], ["isrc-USUM71900764"]]
+    },
+    {
+      "name": "guard_v7_two_isrcs_plus_weak_weak_stays_separate",
+      "_note": "Transitivity: the norm-only node must NOT bridge the two conflicting ISRC components through itself.",
+      "lists": [[{ "isrc": "XXAAA0000001", "norm": "a|b" }, { "isrc": "XXBBB0000002", "norm": "a|b" }, { "norm": "a|b" }]],
+      "expected": [["isrc-XXAAA0000001", "isrc-XXBBB0000002", "norm-a|b"]]
+    },
+    {
+      "name": "guard_v8_pure_weak_group_unions",
+      "lists": [[{ "norm": "a|b" }, { "norm": "a|b" }]],
+      "expected": [["norm-a|b", "norm-a|b"]]
+    },
+    {
+      "name": "guard_v9_two_isrcs_plus_two_weak_weak_unite_isrcs_separate",
+      "lists": [[{ "isrc": "XXAAA0000001", "norm": "a|b" }, { "isrc": "XXBBB0000002", "norm": "a|b" }, { "norm": "a|b" }, { "norm": "a|b" }]],
+      "expected": [["isrc-XXAAA0000001", "isrc-XXBBB0000002", "norm-a|b", "norm-a|b"]]
+    },
+    {
+      "name": "guard_v10_mbid_bridged_two_isrcs_one_component_unions_group",
+      "_note": "THE count-COMPONENTS-not-VALUES discriminator (maintainer-flagged): a shared MBID merges two ISRCs into ONE component → cIsrc=1 → the whole group unions, norm-only node included. A naive distinct-ISRC-value count would get 2 and wrongly separate.",
+      "lists": [[{ "isrc": "XXAAA0000001", "mbid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "norm": "a|b" }, { "isrc": "XXBBB0000002", "mbid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "norm": "a|b" }, { "norm": "a|b" }]],
+      "expected": [["isrc-XXAAA0000001", "isrc-XXAAA0000001", "isrc-XXAAA0000001"]]
+    },
+    {
+      "name": "guard_v11_mbid_bridged_pair_plus_unrelated_isrc_separate",
+      "_note": "The MBID-merged multi-ISRC component is ONE; an unrelated third ISRC is a second → cIsrc=2 → don't bridge across.",
+      "lists": [[{ "isrc": "XXAAA0000001", "mbid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "norm": "a|b" }, { "isrc": "XXBBB0000002", "mbid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "norm": "a|b" }, { "isrc": "XXCCC0000003", "norm": "a|b" }]],
+      "expected": [["isrc-XXAAA0000001", "isrc-XXAAA0000001", "isrc-XXCCC0000003"]]
     }
   ]
 }

--- a/tests/fixtures/nway-merge/key-unify-fixtures.json
+++ b/tests/fixtures/nway-merge/key-unify-fixtures.json
@@ -114,6 +114,18 @@
       "_note": "The MBID-merged multi-ISRC component is ONE; an unrelated third ISRC is a second → cIsrc=2 → don't bridge across.",
       "lists": [[{ "isrc": "XXAAA0000001", "mbid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "norm": "a|b" }, { "isrc": "XXBBB0000002", "mbid": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "norm": "a|b" }, { "isrc": "XXCCC0000003", "norm": "a|b" }]],
       "expected": [["isrc-XXAAA0000001", "isrc-XXAAA0000001", "isrc-XXCCC0000003"]]
+    },
+    {
+      "name": "guard_v12_mbid_bridged_node_is_not_a_weak_norm_bridge",
+      "_note": "Pins reading (C): the weak set + the ISRC-component count are COMPONENT-level and GLOBAL. #1 is mbid-only (node-ISRC-free) but its component carries ISRC AAA via the shared MBID (from #0 in a DIFFERENT norm group 'a|one'), so #1 must NOT bridge the pure-norm #3 into a conflicting ISRC. Reading (B) gives #3 -> isrc-AAA (wrong); (C) keeps #3 norm-only. cIsrc=2 in group 'a|two' (compAAA via #1, compBBB via #2).",
+      "lists": [[{ "isrc": "XXAAA0000001", "mbid": "m-shared", "norm": "a|one" }, { "mbid": "m-shared", "norm": "a|two" }, { "isrc": "XXBBB0000002", "norm": "a|two" }, { "norm": "a|two" }]],
+      "expected": [["isrc-XXAAA0000001", "isrc-XXAAA0000001", "isrc-XXBBB0000002", "norm-a|two"]]
+    },
+    {
+      "name": "guard_v13_mbid_only_node_joins_weak_set_under_conflict",
+      "_note": "Rules out reading (A): an mbid-only node NOT bridged to any ISRC is still weak and unions with the pure-norm node (repr = its mbid). (A) would leave it a mbid- singleton.",
+      "lists": [[{ "isrc": "XXAAA0000001", "norm": "a|b" }, { "isrc": "XXBBB0000002", "norm": "a|b" }, { "mbid": "m-weak", "norm": "a|b" }, { "norm": "a|b" }]],
+      "expected": [["isrc-XXAAA0000001", "isrc-XXBBB0000002", "mbid-m-weak", "mbid-m-weak"]]
     }
   ]
 }

--- a/tests/fixtures/nway-merge/no-false-drop-scenarios.json
+++ b/tests/fixtures/nway-merge/no-false-drop-scenarios.json
@@ -1,0 +1,76 @@
+{
+  "_about": "No-false-drop / no-dup-add harness — the LAST identity gate before arming N-way real writes (parachord#911 P3, mobile#289 audit action #5). Each materialize scenario feeds the identity-collision shapes from the audit's D-pairs through computeMaterializeDiff (unify-together diff); each propagation scenario feeds computeNwayPropagationPlan (merge + total-wipe guard). BOTH engines (desktop playlist-materialize.js/playlist-reconcile.js + Kotlin equivalents) MUST produce `expect` for every case AND satisfy the two invariants the runner asserts independently: (1) NO-FALSE-DROP — no removeKey is the unified key of a canonical track; (2) NO-DUP-ADD — no addKey is already a unified key on the remote. The D-pairs are constructed so a NAIVE provider-id diff (or an un-guarded unify) would violate one of these; the unify-based diff does not.",
+  "_semantics": {
+    "track": "{title, artist, isrc?, mbid?} — fed through trackTiers (isrc validated+UPPER, mbid trim+lower from recordingMbid||mbid, norm = '<artist>|<title>' lower+trim+remaster-stripped).",
+    "materialize_expect": "computeMaterializeDiff(canonical, remote) → {addKeys, removeKeys, reorderNeeded}. addKeys = canonical keys absent from remote; removeKeys = remote keys absent from canonical; both deduped, computed on the JOINT unification so a same-song-across-services pair shares one key.",
+    "propagation_expect": "computeNwayPropagationPlan(baselineRepr, copies) → {merged, massChangeAbort} | null. massChangeAbort = merged-empty while baseline non-empty (total-wipe guard); a non-empty large drop is a legitimate edit and is NOT aborted.",
+    "invariants": "Runner-enforced on every materialize scenario regardless of expect: removeKeys ∩ canonicalKeys = ∅ (no-false-drop); addKeys ∩ remoteKeys = ∅ (no-dup-add)."
+  },
+  "materialize": [
+    {
+      "name": "relink_isrc_bridges_norm_drift",
+      "_note": "D-Nway-7: a relinked track keeps its ISRC but drifts its title (remaster suffix) and would carry a new provider URI. A naive URI/norm diff churns (remove old + add new); the ISRC bridge makes it a no-op.",
+      "canonical": [{ "title": "Dreams - 2018 Remaster", "artist": "Fleetwood Mac", "isrc": "USEE10001234" }],
+      "remote": [{ "title": "Dreams", "artist": "Fleetwood Mac", "isrc": "USEE10001234" }],
+      "expect": { "addKeys": [], "removeKeys": [], "reorderNeeded": false }
+    },
+    {
+      "name": "cross_service_same_isrc_no_dup_add",
+      "_note": "D-Nway-3: same recording present on two services (different recording-MBID, same ISRC). A naive per-provider diff adds the 'missing' service copy → a duplicate. The ISRC bridge makes it a no-op.",
+      "canonical": [{ "title": "Bad Guy", "artist": "Billie Eilish", "isrc": "USUM71900764", "mbid": "rec-spotify" }],
+      "remote": [{ "title": "Bad Guy", "artist": "Billie Eilish", "isrc": "USUM71900764", "mbid": "rec-am" }],
+      "expect": { "addKeys": [], "removeKeys": [], "reorderNeeded": false }
+    },
+    {
+      "name": "distinct_isrc_same_norm_no_false_drop",
+      "_note": "D-Nway-4/5: two genuinely distinct recordings (album cut / single edit) sharing a normalized title but with different ISRCs. The norm-bridge guard keeps them separate, so neither is dropped. An un-guarded unify collapses them → the merge believes there's one track → materialize false-removes the other.",
+      "canonical": [{ "title": "Intro", "artist": "The xx", "isrc": "GBBKS0700116" }, { "title": "Intro", "artist": "The xx", "isrc": "GBBKS1300999" }],
+      "remote": [{ "title": "Intro", "artist": "The xx", "isrc": "GBBKS0700116" }, { "title": "Intro", "artist": "The xx", "isrc": "GBBKS1300999" }],
+      "expect": { "addKeys": [], "removeKeys": [], "reorderNeeded": false }
+    },
+    {
+      "name": "mbid_variance_same_norm_no_false_drop",
+      "_note": "2026-06-22 false-remove class: the same song with a different recording-MBID across services (no ISRC). The norm tier bridges them (MBID disagreement never blocks) → no-op. Blocking on MBID would false-remove one.",
+      "canonical": [{ "title": "Creep", "artist": "Radiohead", "mbid": "rec-a" }],
+      "remote": [{ "title": "Creep", "artist": "Radiohead", "mbid": "rec-b" }],
+      "expect": { "addKeys": [], "removeKeys": [], "reorderNeeded": false }
+    },
+    {
+      "name": "genuine_add_is_an_add",
+      "_note": "Control: a track truly absent from the remote is added (the gate must not over-suppress real adds).",
+      "canonical": [{ "title": "A", "artist": "x", "isrc": "USAAA0000001" }, { "title": "B", "artist": "y", "isrc": "USBBB0000002" }],
+      "remote": [{ "title": "A", "artist": "x", "isrc": "USAAA0000001" }],
+      "expect": { "addKeys": ["isrc-USBBB0000002"], "removeKeys": [], "reorderNeeded": false }
+    },
+    {
+      "name": "genuine_remove_with_evidence_is_a_remove",
+      "_note": "Control: a remote track truly absent from canonical (no identity match) is a legitimate evidence-based remove, NOT a false-drop.",
+      "canonical": [{ "title": "A", "artist": "x", "isrc": "USAAA0000001" }],
+      "remote": [{ "title": "A", "artist": "x", "isrc": "USAAA0000001" }, { "title": "B", "artist": "y", "isrc": "USBBB0000002" }],
+      "expect": { "addKeys": [], "removeKeys": ["isrc-USBBB0000002"], "reorderNeeded": false }
+    }
+  ],
+  "propagation": [
+    {
+      "name": "total_wipe_aborts",
+      "_note": "An empty fetch (throttled/partial) for a changed copy must NOT wipe the playlist — merged-empty-while-baseline-nonempty trips massChangeAbort.",
+      "baselineRepr": ["isrc-USAAA0000001", "isrc-USBBB0000002"],
+      "copies": [{ "id": "sp", "keys": [], "changed": true, "editedAt": 5 }],
+      "expect": { "merged": [], "massChangeAbort": true }
+    },
+    {
+      "name": "legit_large_drop_allowed",
+      "_note": "A non-empty large drop (4→1) is a legitimate user edit, NOT aborted.",
+      "baselineRepr": ["isrc-USAAA0000001", "isrc-USBBB0000002", "mbid-c", "mbid-d"],
+      "copies": [{ "id": "sp", "keys": ["isrc-USAAA0000001"], "changed": true, "editedAt": 5 }],
+      "expect": { "merged": ["isrc-USAAA0000001"], "massChangeAbort": false }
+    },
+    {
+      "name": "unchanged_copy_is_noop",
+      "_note": "No changed copy → null (nothing to propagate).",
+      "baselineRepr": ["isrc-USAAA0000001"],
+      "copies": [{ "id": "sp", "keys": ["isrc-USAAA0000001"], "changed": false, "editedAt": 5 }],
+      "expect": null
+    }
+  ]
+}

--- a/tests/sync/no-false-drop-harness.test.js
+++ b/tests/sync/no-false-drop-harness.test.js
@@ -1,0 +1,84 @@
+/**
+ * No-false-drop / no-dup-add harness — the LAST identity gate before N-way real
+ * writes can be armed (parachord#911 P3, mobile#289 audit action #5).
+ *
+ * Drives the audit's identity-collision D-pairs through the real pure pipeline:
+ *   - computeMaterializeDiff (unify-together add/remove diff — Layer B), and
+ *   - computeNwayPropagationPlan (merge + total-wipe guard — Layer A).
+ *
+ * Beyond asserting each scenario's `expect`, the runner INDEPENDENTLY enforces
+ * the two governing invariants on every materialize case, so it proves the gate
+ * rather than echoing the function:
+ *   (1) NO-FALSE-DROP — no removeKey is the unified key of a canonical track;
+ *   (2) NO-DUP-ADD    — no addKey is already a unified key present on the remote,
+ *                       and applying the adds leaves the remote key-set duplicate-free
+ *                       w.r.t. the newly-added keys.
+ *
+ * Scenarios live in the shared fixture tests/fixtures/nway-merge/
+ * no-false-drop-scenarios.json (proposed as the cross-engine contract on
+ * mobile#289 — the Kotlin harness must run the same file to identical results).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { computeMaterializeDiff } = require('../../sync-engine/playlist-materialize');
+const { computeNwayPropagationPlan } = require('../../sync-engine/playlist-reconcile');
+
+const SCEN = JSON.parse(
+  fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'nway-merge', 'no-false-drop-scenarios.json'), 'utf8')
+);
+
+describe('no-false-drop harness — materialize diff (identity collisions)', () => {
+  test('fixture carries both scenario groups', () => {
+    expect(Array.isArray(SCEN.materialize)).toBe(true);
+    expect(Array.isArray(SCEN.propagation)).toBe(true);
+    expect(SCEN.materialize.length).toBeGreaterThanOrEqual(6);
+  });
+
+  for (const s of SCEN.materialize) {
+    test(`${s.name}`, () => {
+      const diff = computeMaterializeDiff(s.canonical, s.remote);
+
+      // 1. Matches the pinned cross-engine expectation.
+      expect({
+        addKeys: diff.addKeys,
+        removeKeys: diff.removeKeys,
+        reorderNeeded: diff.reorderNeeded,
+      }).toEqual(s.expect);
+
+      // 2. INVARIANT — no-false-drop: a canonical track's unified key is never
+      //    in removeKeys (canonicalKeys/remoteKeys come from the SAME joint
+      //    unification, so this is the real identity check, not a re-derivation).
+      const canonicalKeySet = new Set(diff.canonicalKeys);
+      for (const rk of diff.removeKeys) {
+        expect(canonicalKeySet.has(rk)).toBe(false);
+      }
+
+      // 3. INVARIANT — no-dup-add: an addKey is never already on the remote,
+      //    and the post-apply remote key multiset gains no duplicate key.
+      const remoteKeySet = new Set(diff.remoteKeys);
+      for (const ak of diff.addKeys) {
+        expect(remoteKeySet.has(ak)).toBe(false);
+      }
+      const afterApply = diff.remoteKeys
+        .filter((k) => !diff.removeKeys.includes(k))
+        .concat(diff.addKeys);
+      // adds are distinct and disjoint from the surviving remote keys → no new dup.
+      expect(new Set(afterApply).size).toBe(afterApply.length);
+    });
+  }
+});
+
+describe('no-false-drop harness — propagation plan (total-wipe guard)', () => {
+  for (const s of SCEN.propagation) {
+    test(`${s.name}`, () => {
+      const plan = computeNwayPropagationPlan(s.baselineRepr, s.copies);
+      expect(plan).toEqual(s.expect);
+      // INVARIANT — an empty merge against a non-empty baseline must abort
+      // (never silently wipe a mirror on a partial/throttled fetch).
+      if (plan && plan.merged.length === 0 && s.baselineRepr.length > 0) {
+        expect(plan.massChangeAbort).toBe(true);
+      }
+    });
+  }
+});

--- a/tests/sync/playlist-key-unify.test.js
+++ b/tests/sync/playlist-key-unify.test.js
@@ -32,7 +32,7 @@ const UNIFY = JSON.parse(
 describe('unifyTrackKeys — canonical cross-engine fixtures', () => {
   test('fixture file carries the expected case count', () => {
     expect(Array.isArray(UNIFY.cases)).toBe(true);
-    expect(UNIFY.cases.length).toBe(8);
+    expect(UNIFY.cases.length).toBe(16);
   });
 
   for (const c of UNIFY.cases) {
@@ -53,6 +53,54 @@ describe('unifyTrackKeys — additional properties', () => {
     ]);
     // All three unify; strongest tier is isrc -> the single isrc value.
     expect(out).toEqual(['isrc-USABC1234567', 'isrc-USABC1234567', 'isrc-USABC1234567']);
+  });
+
+  // ── Norm-bridge-guard behaviors explicit in the fixture _semantics but not
+  // yet pinned by a shared fixture (proposed to mobile as guard_v12/v13). Lock
+  // the correct reading desktop-side so a refactor can't silently drift.
+
+  test('guard: "component carries ISRC" is GLOBAL across norm groups (not group-local)', () => {
+    // #0 isrc A + mbid M (norm "a|one");  #1 mbid M (norm "a|two") — strong phase
+    // unions #0,#1 via M into one component that carries ISRC A *in group a|one*.
+    // #2 isrc B (norm "a|two");  #3 norm-only (norm "a|two").
+    // Group "a|two" = {#1,#2,#3}. #1 is ISRC-free locally, but its COMPONENT
+    // carries A → cIsrc=2 (compA via #1, compB via #2) → must NOT bridge across.
+    // A group-local reading would see cIsrc=1 and false-merge A and B.
+    const [out] = unifyTrackKeys([
+      [
+        { isrc: 'XXAAA0000001', mbid: 'm-shared', norm: 'a|one' },
+        { mbid: 'm-shared', norm: 'a|two' },
+        { isrc: 'XXBBB0000002', norm: 'a|two' },
+        { norm: 'a|two' },
+      ],
+    ]);
+    expect(out).toEqual([
+      'isrc-XXAAA0000001', // #0
+      'isrc-XXAAA0000001', // #1 — stays with #0's component (A), NOT merged into B
+      'isrc-XXBBB0000002', // #2 — distinct ISRC, kept separate
+      'norm-a|two',        // #3 — weak, alone
+    ]);
+  });
+
+  test('guard: under ISRC conflict the weak set is ISRC-FREE (an mbid-only node joins it)', () => {
+    // Two disagreeing ISRCs (A,B) + an mbid-only node + a pure-norm node, all
+    // same norm. cIsrc=2 → weak = {mbid-only, pure-norm} union together →
+    // mbid repr (strongest in the weak class). A "pure-norm-only" weak reading
+    // would wrongly leave the mbid-only node a singleton.
+    const [out] = unifyTrackKeys([
+      [
+        { isrc: 'XXAAA0000001', norm: 'a|b' },
+        { isrc: 'XXBBB0000002', norm: 'a|b' },
+        { mbid: 'm-weak', norm: 'a|b' },
+        { norm: 'a|b' },
+      ],
+    ]);
+    expect(out).toEqual([
+      'isrc-XXAAA0000001',
+      'isrc-XXBBB0000002',
+      'mbid-m-weak', // mbid-only node + pure-norm node unite → mbid repr
+      'mbid-m-weak',
+    ]);
   });
 
   test('singleton representative == canonicalTrackKey', () => {

--- a/tests/sync/playlist-key-unify.test.js
+++ b/tests/sync/playlist-key-unify.test.js
@@ -32,7 +32,7 @@ const UNIFY = JSON.parse(
 describe('unifyTrackKeys — canonical cross-engine fixtures', () => {
   test('fixture file carries the expected case count', () => {
     expect(Array.isArray(UNIFY.cases)).toBe(true);
-    expect(UNIFY.cases.length).toBe(16);
+    expect(UNIFY.cases.length).toBe(18);
   });
 
   for (const c of UNIFY.cases) {
@@ -54,54 +54,9 @@ describe('unifyTrackKeys — additional properties', () => {
     // All three unify; strongest tier is isrc -> the single isrc value.
     expect(out).toEqual(['isrc-USABC1234567', 'isrc-USABC1234567', 'isrc-USABC1234567']);
   });
-
-  // ── Norm-bridge-guard behaviors explicit in the fixture _semantics but not
-  // yet pinned by a shared fixture (proposed to mobile as guard_v12/v13). Lock
-  // the correct reading desktop-side so a refactor can't silently drift.
-
-  test('guard: "component carries ISRC" is GLOBAL across norm groups (not group-local)', () => {
-    // #0 isrc A + mbid M (norm "a|one");  #1 mbid M (norm "a|two") — strong phase
-    // unions #0,#1 via M into one component that carries ISRC A *in group a|one*.
-    // #2 isrc B (norm "a|two");  #3 norm-only (norm "a|two").
-    // Group "a|two" = {#1,#2,#3}. #1 is ISRC-free locally, but its COMPONENT
-    // carries A → cIsrc=2 (compA via #1, compB via #2) → must NOT bridge across.
-    // A group-local reading would see cIsrc=1 and false-merge A and B.
-    const [out] = unifyTrackKeys([
-      [
-        { isrc: 'XXAAA0000001', mbid: 'm-shared', norm: 'a|one' },
-        { mbid: 'm-shared', norm: 'a|two' },
-        { isrc: 'XXBBB0000002', norm: 'a|two' },
-        { norm: 'a|two' },
-      ],
-    ]);
-    expect(out).toEqual([
-      'isrc-XXAAA0000001', // #0
-      'isrc-XXAAA0000001', // #1 — stays with #0's component (A), NOT merged into B
-      'isrc-XXBBB0000002', // #2 — distinct ISRC, kept separate
-      'norm-a|two',        // #3 — weak, alone
-    ]);
-  });
-
-  test('guard: under ISRC conflict the weak set is ISRC-FREE (an mbid-only node joins it)', () => {
-    // Two disagreeing ISRCs (A,B) + an mbid-only node + a pure-norm node, all
-    // same norm. cIsrc=2 → weak = {mbid-only, pure-norm} union together →
-    // mbid repr (strongest in the weak class). A "pure-norm-only" weak reading
-    // would wrongly leave the mbid-only node a singleton.
-    const [out] = unifyTrackKeys([
-      [
-        { isrc: 'XXAAA0000001', norm: 'a|b' },
-        { isrc: 'XXBBB0000002', norm: 'a|b' },
-        { mbid: 'm-weak', norm: 'a|b' },
-        { norm: 'a|b' },
-      ],
-    ]);
-    expect(out).toEqual([
-      'isrc-XXAAA0000001',
-      'isrc-XXBBB0000002',
-      'mbid-m-weak', // mbid-only node + pure-norm node unite → mbid repr
-      'mbid-m-weak',
-    ]);
-  });
+  // (The global-component-ISRC + component-ISRC-free-weak-set behaviors are now
+  // pinned by the shared fixtures guard_v12/guard_v13 above — see the fixture
+  // loop; the throwaway desktop-local duplicates were removed once they landed.)
 
   test('singleton representative == canonicalTrackKey', () => {
     const track = { mbid: 'b2181aae-5cba-496c-bb0c-b4cc0109ebf8', artist: 'Radiohead', title: 'Creep' };


### PR DESCRIPTION
Implements the **P3 norm-bridge guard** co-designed on [mobile#289](https://github.com/Parachord/parachord-mobile/issues/289), against the canonical 16-vector contract (vendored verbatim from `parachord-mobile docs/nway-key-unify-fixtures.json @ 6dedcb1`). Resolves the standing `TODO(parachord#911)` in `playlist-key-unify.js`.

## Two-phase `unifyTrackKeys`
1. **STRONG** (unconditional): union equal ISRC, then equal MBID. A shared MBID can span two different ISRCs (same recording, reissue) → one component.
2. **NORM** (guarded), per norm group, counting **components** carrying an ISRC after the strong phase: `cIsrc ≤ 1` → union the whole group; `cIsrc ≥ 2` → don't collapse the disagreeing ISRC identities via norm, union only the ISRC-free nodes among themselves. **MBID disagreement never blocks** (asymmetric — a symmetric `cMbid` clause would regress the 2026-06-22 false-remove fix).

All **16 canonical vectors pass** + the existing incident suite; **1921 total green**.

## ⚠️ Awaiting two cross-engine fixtures before merge
Implementing this surfaced two behaviors that are **explicit in the fixture `_semantics` but not yet pinned by any of the 16 fixtures** — and a naive reading diverges (both pass all 16 either way). Both implemented here per the text, with desktop-local tests; **flagged on mobile#289 with proposed shared fixtures**:

1. **"component carries an ISRC" is GLOBAL** — an ISRC-bearing member in a *different* norm group (bridged via MBID) still counts. A group-local read false-merges two distinct ISRCs.
2. **weak set under conflict is COMPONENT-ISRC-free, not node-ISRC-free** — an mbid-only node whose component carries an ISRC must not act as a norm bridge, else it drags a pure-norm node into a conflicting ISRC identity.

**Do not merge** until those two land in the shared JSON and mobile confirms byte-identical Kotlin output. Per the lockstep agreement, neither engine merges until both pass every case + the no-false-drop harness; **N-way real writes stay OFF** regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)