### PR TITLE
feat(sync): cross-device migration nudge in the new-sync preview (#946)

### DIFF
--- a/app.js
+++ b/app.js
@@ -63253,6 +63253,15 @@ useEffect(() => {
                 React.createElement('div', { style: { fontSize: '12px', color: 'var(--text-secondary)', lineHeight: '1.45' } }, pp.reason === 'total-wipe' ? "New sync declined a full-replace it couldn't verify, and left it untouched. Your tracks are safe." : 'New sync skipped an unverifiable change and left it untouched.')
               ));
             });
+            // Cross-device nudge (parachord#946, parity with mobile). `sync_engine_mode`
+            // is per-client with no account-level coordinator, so flipping one device
+            // but not the others leaves the user in mixed mode on shared remotes until
+            // all match. Shown in every summary case (changes, no-changes, protected),
+            // before Accept.
+            rows.push(React.createElement('div', { key: 'xdevice', style: { marginTop: '8px', padding: '9px 11px', borderRadius: '8px', backgroundColor: 'rgba(124,58,237,0.07)', border: '1px solid rgba(124,58,237,0.25)' } },
+              React.createElement('span', { style: { fontSize: '12px', color: 'var(--text-secondary)', lineHeight: '1.45' } },
+                'Using Parachord on another device (mobile, etc.)? Switch it to new sync too — running the old and new engines on the same playlists can churn them until all your devices match.')
+            ));
             return React.createElement('div', { style: { paddingBottom: '8px' } }, ...rows);
           })()
         ),


### PR DESCRIPTION
Adds the cross-device "switch your other clients too" nudge to the desktop migration preview modal (the `describePlan` / preview flow from #939) — parity with mobile's brick-#5 preview.

## Why
`sync_engine_mode` is per-client with no account-level coordinator. Flipping one device but not the others leaves the user in **mixed mode on shared remotes**, which churns playlists until every client matches — the exact coexistence gap the migration plan (`docs/plans/2026-06-28-legacy-to-nway-sync-migration.md`) calls out. The nudge is the UX half of keeping a user's clients aligned, and it's easy to forget once you've flipped one device.

## What
A subtle accent-tinted note in the preview modal body, pushed as the final row so it renders in **every summary case** (changes, no-changes, protected), before Accept:

> Using Parachord on another device (mobile, etc.)? Switch it to new sync too — running the old and new engines on the same playlists can churn them until all your devices match.

UX-only — arms nothing, no engine change. N-way real writes stay OFF.

It renders alongside the existing diff content (removal warning, per-playlist diff, protected list), so it's visible whether or not the preview found changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)