### PR TITLE
fix(sync): spinner on the new-sync preview loading state

### DIFF
--- a/app.js
+++ b/app.js
@@ -63218,7 +63218,13 @@ useEffect(() => {
         React.createElement('div', { style: { overflowY: 'auto', padding: '0 24px', flex: '1 1 auto' } },
           (() => {
             const d = nwayMigrationDialog;
-            if (d.loading) return React.createElement('p', { style: { padding: '16px 0', fontSize: '13px', color: 'var(--text-secondary)', textAlign: 'center' } }, 'Checking your playlists…');
+            if (d.loading) return React.createElement('div', { style: { padding: '30px 0 26px', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '12px' } },
+              React.createElement('svg', { className: 'animate-spin', width: '28', height: '28', viewBox: '0 0 24 24', fill: 'none', style: { color: 'var(--accent-primary)' } },
+                React.createElement('circle', { className: 'opacity-25', cx: '12', cy: '12', r: '10', stroke: 'currentColor', strokeWidth: '4' }),
+                React.createElement('path', { className: 'opacity-75', fill: 'currentColor', d: 'M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z' })
+              ),
+              React.createElement('p', { style: { fontSize: '13px', color: 'var(--text-secondary)', margin: 0 } }, 'Checking your playlists…')
+            );
             if (d.error) return React.createElement('p', { style: { padding: '8px 0 16px', fontSize: '13px', color: '#dc2626' } }, `Couldn't run the preview: ${d.error}`);
             const s = d.summary;
             if (!s) return null;


### PR DESCRIPTION
The "Use new sync" preview's loading state was static text ("Checking your playlists…"), so while the shadow reconcile runs — fetch + unify + diff per playlist, a few seconds on a large library — it looked frozen.

Replaces it with the app's standard accent-colored `animate-spin` spinner centered above the text, so it visibly reads as working. UX-only; same loading branch, no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)