### PR TITLE
fix(sync): collaborators are writable — collaborative edits round-trip to the original (#911)

### DIFF
--- a/main.js
+++ b/main.js
@@ -5487,6 +5487,7 @@ const {
   channelOverrideExcludes,
   computeSyncChannels,
   findNonOwnedSourceConflict,
+  isPlaylistWritable,
 } = require('./sync-engine/playlist-push-candidate');
 
 const SYNC_PROVIDER_DISPLAY = { spotify: 'Spotify', applemusic: 'Apple Music', listenbrainz: 'ListenBrainz' };
@@ -5653,11 +5654,11 @@ function setPlaylistMirrorOnly(localPlaylistId, value) {
 // imports stamp `source: <provider>-import`; owned imports + user-created
 // playlists are writable. (The import path at sync:start sets this from
 // remotePlaylist.isOwnedByUser.)
-function isPlaylistWritable(playlist) {
-  const src = playlist && playlist.source;
-  if (typeof src === 'string' && src.endsWith('-import')) return false;
-  return true;
-}
+// isPlaylistWritable lives in sync-engine/playlist-push-candidate.js (parity
+// anchor + unit-tested); imported in the require block above. Per-copy
+// writability gates the N-way reconcile's source-copy push target (A3/A9):
+// owned + COLLABORATOR → writable (collaborative edits round-trip to the
+// original); followed (non-collaborator) → mirror-only.
 
 async function getNwayProviderToken(providerId) {
   if (providerId === 'spotify') return await ensureValidSpotifyToken();

--- a/sync-engine/playlist-push-candidate.js
+++ b/sync-engine/playlist-push-candidate.js
@@ -193,6 +193,35 @@ function findNonOwnedSourceConflict(localPlaylistId, name, remotePlaylists) {
   );
 }
 
+/**
+ * Per-copy writability for the N-way reconcile (parachord#911 per-copy-writable
+ * contract). The reconcile gates the imported SOURCE copy on `playlist.writable`
+ * (A3) and only writable copies become push targets (A9), so this decides whether
+ * edits ROUND-TRIP back to the source playlist or the source is mirror-only.
+ *
+ * Rules:
+ *   - OWNED playlist (`source` not `-import`) → writable.
+ *   - COLLABORATIVE import (`-import` AND `syncedFrom.isCollaborator === true`) →
+ *     writable: a collaborator can write back to the original (e.g. edits to a
+ *     playlist owned by someone else who made you a collaborator round-trip to
+ *     THEIR playlist, not a new owned copy).
+ *   - FOLLOWED import (`-import`, not a collaborator) → NOT writable: read-only /
+ *     mirror-only; its state reads into the merge but is never pushed back.
+ *
+ * The legacy `-import → false` rule wrongly classified collaborators as read-only,
+ * so collaborative edits never round-tripped (they fell to the create path and
+ * made an owned duplicate — parachord#950 — instead of updating the original).
+ * @param {{source?:string, syncedFrom?:{isCollaborator?:boolean}}} playlist
+ * @returns {boolean}
+ */
+function isPlaylistWritable(playlist) {
+  const src = playlist && playlist.source;
+  if (typeof src === 'string' && src.endsWith('-import')) {
+    return !!(playlist && playlist.syncedFrom && playlist.syncedFrom.isCollaborator === true);
+  }
+  return true;
+}
+
 module.exports = {
   REEXPORT_PROVIDERS,
   SYNC_CHANNEL_PROVIDERS,
@@ -203,4 +232,5 @@ module.exports = {
   channelGateBlocksCreate,
   channelOverrideExcludes,
   findNonOwnedSourceConflict,
+  isPlaylistWritable,
 };

--- a/tests/sync/playlist-writable.test.js
+++ b/tests/sync/playlist-writable.test.js
@@ -1,0 +1,44 @@
+/**
+ * Per-copy writability (parachord#911 contract). The N-way reconcile gates the
+ * imported SOURCE copy on playlist.writable (A3) → only writable copies are push
+ * targets (A9), so this is what decides whether a collaborative playlist's edits
+ * ROUND-TRIP to the original vs. the source being mirror-only.
+ *
+ * The legacy `-import → false` rule wrongly made collaborators read-only, so their
+ * edits never round-tripped (they fell to the create path → owned dupe, #950).
+ */
+
+const { isPlaylistWritable } = require('../../sync-engine/playlist-push-candidate');
+
+describe('isPlaylistWritable', () => {
+  test('owned playlist (non -import source) is writable', () => {
+    expect(isPlaylistWritable({ source: 'spotify-sync' })).toBe(true);
+    expect(isPlaylistWritable({ source: 'local' })).toBe(true);
+    expect(isPlaylistWritable({})).toBe(true);
+    expect(isPlaylistWritable({ id: 'playlist-1' })).toBe(true);
+  });
+
+  test('COLLABORATIVE import is writable — edits round-trip to the original', () => {
+    expect(isPlaylistWritable({
+      source: 'spotify-import',
+      syncedFrom: { resolver: 'spotify', externalId: 'galaxy', isCollaborator: true },
+    })).toBe(true);
+  });
+
+  test('FOLLOWED import (not a collaborator) is NOT writable — mirror-only', () => {
+    expect(isPlaylistWritable({
+      source: 'spotify-import',
+      syncedFrom: { resolver: 'spotify', externalId: 'huff', isCollaborator: false },
+    })).toBe(false);
+    // isCollaborator absent → still read-only (the default followed case).
+    expect(isPlaylistWritable({
+      source: 'spotify-import',
+      syncedFrom: { resolver: 'spotify', externalId: 'huff' },
+    })).toBe(false);
+  });
+
+  test('malformed input is safe (defaults to writable for owned-shaped, false for import)', () => {
+    expect(isPlaylistWritable(null)).toBe(true);
+    expect(isPlaylistWritable({ source: 'applemusic-import' })).toBe(false);
+  });
+});


### PR DESCRIPTION
`isPlaylistWritable` classified **any** `-import` source as non-writable, so a **collaborative** playlist (owner ≠ you, but you can write) was treated as read-only mirror-only — contradicting the #911 per-copy-writable contract (*"collaborators ARE writable"*).

The N-way reconcile gates the imported source copy on `playlist.writable` (A3) and only writable copies become push targets (A9). So with collaborators mis-classified, their edits **never round-tripped to the original** — they fell to the create path and made an owned duplicate instead (the #950 mechanism).

## Fix
```js
function isPlaylistWritable(playlist) {
  const src = playlist && playlist.source;
  if (typeof src === 'string' && src.endsWith('-import')) {
    return !!(playlist.syncedFrom && playlist.syncedFrom.isCollaborator === true);
  }
  return true;
}
```
- **owned** → writable; **collaborative import** → writable; **followed import** (non-collaborator) → mirror-only.

The round-trip **routing already works** — `nwayMirrorsOf` includes the source provider (`syncedFrom.resolver → externalId`), and A3/A9 make a writable source a push target → `materializeToProvider` updates the **original** playlist. So this single classification fix unlocks both claims:
- **Collaborative** → edits round-trip to the original (e.g. Mia's) instead of creating a dupe.
- **Followed** → stays mirror-only, source state wins.

Moved `isPlaylistWritable` into the parity-anchored `playlist-push-candidate.js` and unit-tested it.

## Scope
**Gated off** — N-way real writes stay OFF; this makes the design match the contract for when it arms. **Legacy is unaffected** (it has no writability concept; collaborative round-trip to a Spotify source remains an N-way capability). 468 sync tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)