### PR TITLE
feat(sync): arm N-way for opt-in users — 'new' mode drives playlist sync with real writes (#911)

### DIFF
--- a/app.js
+++ b/app.js
@@ -8189,6 +8189,14 @@ const Parachord = () => {
   // this: run a compute-only reconcile, render the named diff, and only on Accept
   // flip sync_engine_mode to 'new'. { show, loading, summary, error, recomputed }.
   const [nwayMigrationDialog, setNwayMigrationDialog] = useState({ show: false });
+  // Current per-client sync engine ('legacy' | 'shadow' | 'new'), for the
+  // Settings row (offer Preview when not on new, Switch-back when on new).
+  const [nwayEngineMode, setNwayEngineMode] = useState('legacy');
+  useEffect(() => {
+    (async () => {
+      try { const m = await window.electron.store.get('sync_engine_mode'); if (m) setNwayEngineMode(m); } catch {}
+    })();
+  }, []);
 
   // Open the preview: forced dry-run reconcile → render model.
   const startNwayMigration = async () => {
@@ -8222,8 +8230,21 @@ const Parachord = () => {
       return;
     }
     try { await window.electron.store.set('sync_engine_mode', 'new'); } catch {}
+    setNwayEngineMode('new');
     setNwayMigrationDialog({ show: false });
     showToast('Switched to new sync on this device');
+    // Kick an immediate armed reconcile (REAL writes) so the switch takes effect
+    // now instead of waiting for the next cadence tick.
+    try { window.electron.nway.run().catch(() => {}); } catch {}
+  };
+
+  // Revert to legacy (parachord#911). 'new' mode stands legacy down, so without
+  // this a user who switched would have no way back. Flips the mode and resumes
+  // legacy sync on the next cycle.
+  const revertNwayMigration = async () => {
+    try { await window.electron.store.set('sync_engine_mode', 'legacy'); } catch {}
+    setNwayEngineMode('legacy');
+    showToast('Switched back to the classic sync engine');
   };
 
   // Report: copy the full diff (GitHub truncates long prefilled bodies) and open a
@@ -55268,22 +55289,29 @@ useEffect(() => {
                       className: 'px-3 py-1.5 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-lg hover:bg-indigo-100 transition-colors'
                     }, 'Show')
                   ),
-                  // Use new sync — N-way migration preview (parachord#911)
+                  // Use new sync — N-way migration preview / armed state (parachord#911)
                   React.createElement('div', {
                     className: 'flex items-center justify-between py-3'
                   },
                     React.createElement('div', null,
                       React.createElement('div', {
                         className: 'text-sm font-medium text-gray-900'
-                      }, 'Use new sync'),
+                      }, nwayEngineMode === 'new' ? 'New sync is on' : 'Use new sync'),
                       React.createElement('div', {
                         className: 'text-xs text-gray-500 mt-0.5'
-                      }, 'Preview the new sync engine and switch this device over')
+                      }, nwayEngineMode === 'new'
+                        ? 'This device is on the new sync engine. You can switch back anytime.'
+                        : 'Preview the new sync engine and switch this device over')
                     ),
-                    React.createElement('button', {
-                      onClick: () => startNwayMigration(),
-                      className: 'px-3 py-1.5 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-lg hover:bg-indigo-100 transition-colors'
-                    }, 'Preview')
+                    nwayEngineMode === 'new'
+                      ? React.createElement('button', {
+                          onClick: () => revertNwayMigration(),
+                          className: 'px-3 py-1.5 text-xs font-medium text-gray-600 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors'
+                        }, 'Switch back to classic')
+                      : React.createElement('button', {
+                          onClick: () => startNwayMigration(),
+                          className: 'px-3 py-1.5 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-lg hover:bg-indigo-100 transition-colors'
+                        }, 'Preview')
                   )
                 ),
 

--- a/main.js
+++ b/main.js
@@ -5749,10 +5749,18 @@ async function runNwayShadowReconcile(options = {}) {
   // a reconcile on demand without requiring the dev flag); `forceDryRun` pins it
   // to compute-only regardless of nway_propagate (the preview NEVER writes).
   const { force = false, forceDryRun = false } = options;
-  if (!force && !isNwayShadowEnabled()) return { skipped: 'shadow-disabled' };
+  const { nwayShouldRun, nwayDryRun } = require('./sync-engine/sync-engine-mode');
+  const engineMode = getSyncEngineMode();
+  // Run when forced (dev/preview), the shadow dev-flag is on, OR the user armed
+  // 'new' mode via the preview/accept flow (parachord#911 — N-way then DRIVES).
+  if (!nwayShouldRun(engineMode, { force, shadowFlag: isNwayShadowEnabled() })) {
+    return { skipped: 'shadow-disabled' };
+  }
   const { bindProviderToken, makeStoreEffects, runNwayReconcileCycle, createHydrationCache } =
     require('./sync-engine/nway-reconcile-driver');
-  const dryRun = forceDryRun ? true : !isNwayPropagateEnabled();
+  // REAL writes only when armed ('new' mode) or the dev propagate flag; the
+  // migration preview (forceDryRun) NEVER writes.
+  const dryRun = nwayDryRun(engineMode, { forceDryRun, propagateFlag: isNwayPropagateEnabled() });
   const now = Date.now();
   const states = getSyncStates();
   const playlists = store.get('local_playlists') || [];
@@ -5873,6 +5881,35 @@ ipcMain.handle('nway:preview', async () => {
   try { return await runNwayShadowReconcile({ force: true, forceDryRun: true }); }
   catch (e) { return { error: e && e.message }; }
 });
+
+// ARMED DRIVE (parachord#911). When the user has opted into 'new' mode, N-way is
+// the playlist authority and must run on the regular cadence with REAL writes
+// (legacy playlist sync has stood down). runNwayShadowReconcile resolves
+// dryRun=false for 'new' mode itself; this just triggers it. The renderer calls
+// `nway:run` immediately after Accept (so the switch takes effect at once) and
+// the timer below keeps it cadenced. No-op in legacy/shadow (the reconcile
+// returns `skipped` unless armed/forced). A simple in-flight guard prevents
+// overlapping cycles.
+let _nwayDriveInFlight = false;
+async function runNwayArmedDrive(reason) {
+  if (getSyncEngineMode() !== 'new') return { skipped: 'not-armed' };
+  if (_nwayDriveInFlight) return { skipped: 'in-flight' };
+  _nwayDriveInFlight = true;
+  try {
+    console.log(`[nway] armed drive cycle (${reason})`);
+    return await runNwayShadowReconcile();
+  } catch (e) {
+    console.warn('[nway] armed drive cycle failed:', e && e.message);
+    return { error: e && e.message };
+  } finally {
+    _nwayDriveInFlight = false;
+  }
+}
+ipcMain.handle('nway:run', async () => runNwayArmedDrive('renderer-trigger'));
+// Cadence: every 15 min (matches the legacy background-sync floor), plus a
+// delayed initial run so a client that launches already-armed starts syncing.
+setInterval(() => { runNwayArmedDrive('timer'); }, 15 * 60 * 1000);
+setTimeout(() => { runNwayArmedDrive('startup'); }, 90 * 1000);
 
 // ---------------------------------------------------------------------------
 // Achordion playlist-links submission (LB-anchored mirror map)

--- a/preload.js
+++ b/preload.js
@@ -45,6 +45,9 @@ contextBridge.exposeInMainWorld('electron', {
     shadowRun: () => ipcRenderer.invoke('nway:shadow-run'),
     // Migration preview (#911): forced compute-only reconcile → named diff.
     preview: () => ipcRenderer.invoke('nway:preview'),
+    // Armed drive (#911): run an N-way reconcile cycle now — REAL writes when the
+    // client is in 'new' mode, no-op otherwise. Fired right after Accept.
+    run: () => ipcRenderer.invoke('nway:run'),
   },
 
   // Spotify operations

--- a/sync-engine/sync-engine-mode.js
+++ b/sync-engine/sync-engine-mode.js
@@ -33,9 +33,29 @@ function nwayWritesEnabled(modeOrRaw) {
   return normalizeEngineMode(modeOrRaw) === 'new';
 }
 
+// Should the N-way reconcile RUN this invocation at all? (parachord#911 arming.)
+//   - `force`      — the dev shadow-run / migration preview run on demand.
+//   - `shadowFlag` — the `nway_shadow_enabled` dev flag.
+//   - 'new' mode   — the user opted in via the preview/accept flow, so N-way
+//                    DRIVES playlist sync on the regular cadence.
+function nwayShouldRun(modeOrRaw, { force = false, shadowFlag = false } = {}) {
+  return !!force || !!shadowFlag || normalizeEngineMode(modeOrRaw) === 'new';
+}
+
+// Should this run perform REAL writes, or compute-only (dry-run)?
+//   - `forceDryRun`  — the migration preview: NEVER writes, whatever the mode.
+//   - 'new' mode     — armed: real writes (the user accepted the diff).
+//   - `propagateFlag`— the `nway_propagate` dev flag (pre-arming dev testing).
+function nwayDryRun(modeOrRaw, { forceDryRun = false, propagateFlag = false } = {}) {
+  if (forceDryRun) return true;
+  return !(normalizeEngineMode(modeOrRaw) === 'new' || !!propagateFlag);
+}
+
 module.exports = {
   SYNC_ENGINE_MODES,
   normalizeEngineMode,
   legacyPlaylistSyncEnabled,
   nwayWritesEnabled,
+  nwayShouldRun,
+  nwayDryRun,
 };

--- a/tests/sync/sync-engine-mode.test.js
+++ b/tests/sync/sync-engine-mode.test.js
@@ -9,6 +9,8 @@ const {
   normalizeEngineMode,
   legacyPlaylistSyncEnabled,
   nwayWritesEnabled,
+  nwayShouldRun,
+  nwayDryRun,
 } = require('../../sync-engine/sync-engine-mode');
 
 describe('sync-engine-mode', () => {
@@ -51,5 +53,45 @@ describe('sync-engine-mode', () => {
     for (const m of [...SYNC_ENGINE_MODES, undefined, 'garbage']) {
       expect(legacyPlaylistSyncEnabled(m) && nwayWritesEnabled(m)).toBe(false);
     }
+  });
+
+  describe('nwayShouldRun — arming + dev gates', () => {
+    test('armed (new) runs on the cadence with no flags', () => {
+      expect(nwayShouldRun('new')).toBe(true);
+    });
+    test('legacy/shadow do NOT run without force or the shadow flag', () => {
+      expect(nwayShouldRun('legacy')).toBe(false);
+      expect(nwayShouldRun('shadow')).toBe(false);
+    });
+    test('force (preview/dev) runs in any mode', () => {
+      expect(nwayShouldRun('legacy', { force: true })).toBe(true);
+    });
+    test('the shadow dev-flag runs it', () => {
+      expect(nwayShouldRun('shadow', { shadowFlag: true })).toBe(true);
+    });
+  });
+
+  describe('nwayDryRun — real writes only when armed (or the dev propagate flag)', () => {
+    test('new → REAL writes', () => expect(nwayDryRun('new')).toBe(false));
+    test('legacy/shadow → dry-run', () => {
+      expect(nwayDryRun('legacy')).toBe(true);
+      expect(nwayDryRun('shadow')).toBe(true);
+    });
+    test('forceDryRun (the preview) NEVER writes, even when armed', () => {
+      expect(nwayDryRun('new', { forceDryRun: true })).toBe(true);
+    });
+    test('the propagate dev-flag enables writes pre-arming', () => {
+      expect(nwayDryRun('shadow', { propagateFlag: true })).toBe(false);
+    });
+  });
+
+  test('invariant: a non-new client never does real N-way writes on the cadence', () => {
+    // On the regular cadence (no force/flags), only an armed client writes.
+    for (const m of ['legacy', 'shadow', undefined, 'garbage']) {
+      const wouldRun = nwayShouldRun(m);
+      const wouldWrite = wouldRun && !nwayDryRun(m);
+      expect(wouldWrite).toBe(false);
+    }
+    expect(nwayShouldRun('new') && !nwayDryRun('new')).toBe(true);
   });
 });


### PR DESCRIPTION
Makes the preview → accept → report opt-in flow actually **functional**. Until now, accepting set `sync_engine_mode = 'new'` (legacy stands down) but **nothing drove playlist sync** — `runNwayShadowReconcile` only ran via the dev/preview IPCs and was always dry-run. So Accept silently froze playlist sync. This wires the arming the flow was built for.

## What it does
- **Gate + writes** (`sync-engine-mode.js`, pure + tested): `nwayShouldRun` → N-way runs on the regular cadence when armed (`'new'`); `nwayDryRun` → **real writes** when armed (the preview's `forceDryRun` still **never** writes). `runNwayShadowReconcile` uses both.
- **Drive trigger** (`main.js`): a `nway:run` IPC + a **15-min timer** + a **90s startup run**, all routed through `runNwayArmedDrive` (no-op unless `'new'`; in-flight guard so cycles don't overlap).
- **Immediate switch**: Accept fires `nway.run()` so the cutover takes effect at once instead of waiting for the next tick.
- **Revert path (NEW)**: `'new'` mode previously had **no way back** — a stuck user was stranded. Added a **"Switch back to classic"** action + the Settings row reflects the armed state (`revertNwayMigration` → `'legacy'`).

Library/collection sync is unaffected (never mode-gated); only the **playlist** authority moves to N-way in `'new'`.

## Safety
The runtime guarantees are the merged **P3 harness**: no-false-drop / no-dup-add (18 key-unify vectors + 9 scenarios, both engines green) + the total-wipe guard + the materialize degrade paths. The opt-in is a **self-selected, informed** rollout — only users who saw the exact diff and clicked Accept arm it, and they can now revert.

## ⚠️ DO NOT MERGE until live-validated
The real-write materialize path (`materializeToProvider` issuing actual add/remove/replace to **live** Spotify / Apple Music / ListenBrainz) has only ever run against **fake providers** and **dry-run shadow** — never a live API. **Validate on a test account/playlist** (flip a dev client to `'new'`, watch it reconcile a real playlist) before this reaches users.

## Not in this PR (call if you want them)
- **Remote kill-switch** — a flag to disable N-way writes fleet-wide without a build. The per-client revert is the current off-switch; a fleet-wide kill would need a follow-up (could ride the announcements channel).
- **Mobile arming** — mobile also keeps writes OFF. Per-client opt-in + the no-false-drop guarantees make a mixed fleet safe, but ideally mobile arms in parallel (the #946 nudge already tells users to switch all devices).

492 sync tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)