### PR TITLE
fix(sync): N-way materialize parity fixes from the #956 audit — AM augment-all (§2a) + Spotify breaker (§2b)

### DIFF
--- a/main.js
+++ b/main.js
@@ -1657,6 +1657,18 @@ app.whenReady().then(() => {
   // Begin periodic in-app announcements fetch
   startAnnouncementsPolling();
 
+  // Persist the Spotify abuse-mode circuit breaker across restarts (parachord#956
+  // §2b) so a banned client_id isn't re-hammered after a relaunch.
+  try {
+    const spProvider = require('./sync-providers/spotify');
+    if (spProvider && typeof spProvider._setBreakerStore === 'function') {
+      spProvider._setBreakerStore({
+        load: () => store.get('spotify_breaker_state'),
+        save: (s) => store.set('spotify_breaker_state', s),
+      });
+    }
+  } catch (e) { console.warn('[spotify-breaker] persistence wiring failed:', e && e.message); }
+
   // Extract mcp-stdio.js to a stable user-data path (parachord#866).
   //
   // AppImage mounts itself at /tmp/.mount_<RANDOMSUFFIX>/ via FUSE on

--- a/sync-engine/playlist-reconcile.js
+++ b/sync-engine/playlist-reconcile.js
@@ -302,11 +302,20 @@ async function reconcilePlaylist(ctx) {
   // it CAN delete (trackRemoveMode !== 'Unsupported'); an add-only source
   // (Apple Music) can never prove a deletion, so it grants no drop-authority.
   let authoritativeCopyId = null;
+  // Refinement A (parachord#911 / parachord#956 audit §2a): a non-removal-capable
+  // PULL SOURCE (Apple Music — trackRemoveMode 'Unsupported') can NEVER prove a
+  // deletion. Its source copy is AUGMENT-ALL in A6 — every lacked baseline key is
+  // re-added, bypassing the missingStreak gate — so a transient/partial AM fetch
+  // can't read as a deletion and propagate a real removal to the writable mirrors.
+  // Without this, an AM-sourced track AM omits from a complete fetch for >= 2
+  // cycles falls through the streak gate and DELETE-WINS drops it fleet-wide.
+  let addOnlyPullSourceId = null;
   if (pullSource && pullSource.providerId) {
     const sourceProvider = providerById[pullSource.providerId];
     const canDelete = sourceProvider && sourceProvider.capabilities
       && sourceProvider.capabilities.trackRemoveMode !== 'Unsupported';
-    authoritativeCopyId = canDelete ? pullSource.providerId : null;
+    if (canDelete) authoritativeCopyId = pullSource.providerId;
+    else addOnlyPullSourceId = pullSource.providerId; // non-removal-capable → augment-all
   } else if (playlist.sourceUrl) {
     authoritativeCopyId = 'local'; // hosted XSPF — local mirror IS the source
   }
@@ -361,9 +370,13 @@ async function reconcilePlaylist(ctx) {
     if (lacked.length === 0) return copy;
     const toReadd = copy.id === authoritativeCopyId
       ? lacked.filter((k) => !authoritativeDropped.has(k))
-      : lacked.filter(
-        (k) => !authoritativeDropped.has(k) && isProviderPendingForKey(cache, copy.id, k, keyToTrack)
-      );
+      : copy.id === addOnlyPullSourceId
+        // Refinement A — a non-removal-capable PULL SOURCE (AM) is AUGMENT-ALL:
+        // re-add EVERY lacked key, no streak gate. Its absence is never a delete.
+        ? lacked
+        : lacked.filter(
+          (k) => !authoritativeDropped.has(k) && isProviderPendingForKey(cache, copy.id, k, keyToTrack)
+        );
     return toReadd.length ? { ...copy, keys: copy.keys.concat(toReadd) } : copy;
   });
 

--- a/sync-engine/spotify-breaker.js
+++ b/sync-engine/spotify-breaker.js
@@ -1,0 +1,53 @@
+// Spotify abuse-mode circuit breaker (parachord#956 audit §2b).
+//
+// Spotify rate-limits the WHOLE client_id, and an abuse-mode ban OUTLASTS its
+// own Retry-After by 12+ hours. Honoring Retry-After + a per-call-tree retry cap
+// can back off WITHIN one request chain but not ACROSS calls — the next op (next
+// playlist, next sync tick, next user play) builds a fresh request and re-hammers
+// the still-banned client_id, prolonging the ban for the whole client_id fleet.
+//
+// This breaker carries state ACROSS calls (and, when the caller persists the
+// snapshot, across restarts): once a 429 exhausts retries, it OPENS with an
+// escalating cooldown that fail-fasts every Spotify call until it expires; a
+// successful call closes it and resets the escalation. Mirrors the LB-hydration
+// cooldown pattern already in-tree. PURE — persistence is injected by the caller.
+
+const MINUTE_MS = 60 * 1000;
+const HOUR_MS = 60 * MINUTE_MS;
+
+// Escalating cooldown by consecutive trips: first ban 1h, repeats 6h (mobile parity).
+function cooldownMsForLevel(level) {
+  return level <= 1 ? 1 * HOUR_MS : 6 * HOUR_MS;
+}
+
+function createSpotifyBreaker() {
+  let openUntil = 0;
+  let level = 0;
+  return {
+    // Open right now? Caller should fail-fast (no API call) while true.
+    isOpen(now) { return now < openUntil; },
+    msRemaining(now) { return Math.max(0, openUntil - now); },
+    // A 429 exhausted retries → open / escalate. Returns true (state changed).
+    trip(now) {
+      level += 1;
+      openUntil = now + cooldownMsForLevel(level);
+      return true;
+    },
+    // A successful Spotify call → close + reset escalation. Returns true iff it
+    // actually changed state (so the caller only persists on a real transition).
+    recordSuccess() {
+      if (!openUntil && !level) return false;
+      openUntil = 0;
+      level = 0;
+      return true;
+    },
+    snapshot() { return { openUntil, level }; },
+    restore(s) {
+      if (!s || typeof s !== 'object') return;
+      openUntil = Number(s.openUntil) || 0;
+      level = Number(s.level) || 0;
+    },
+  };
+}
+
+module.exports = { createSpotifyBreaker, cooldownMsForLevel, HOUR_MS };

--- a/sync-providers/applemusic.js
+++ b/sync-providers/applemusic.js
@@ -476,6 +476,17 @@ const AppleMusicSyncProvider = {
     return track.appleMusicId || track.appleMusicCatalogId || null;
   },
 
+  // N-way ADD primitive (parachord#956 §2c). AM has no removal API (Unsupported),
+  // but it CAN append via POST — without this, the executor's Unsupported-branch
+  // appendAdds hit the throwing default (incremental-primitives.js) and armed AM
+  // mirrors silently never received any additions. token is the JSON
+  // { developerToken, userToken } the N-way driver binds onto the call.
+  async addPlaylistTracks(externalId, catalogIds, token) {
+    if (!Array.isArray(catalogIds) || catalogIds.length === 0) return 0;
+    const { developerToken, userToken } = JSON.parse(token);
+    return this._postTracksToPlaylist(externalId, catalogIds, developerToken, userToken);
+  },
+
   async deletePlaylist(playlistId, token, _refreshTokenCb) {
     const { developerToken, userToken } = JSON.parse(token);
     const resp = await fetch(

--- a/sync-providers/spotify.js
+++ b/sync-providers/spotify.js
@@ -7,6 +7,28 @@ const SPOTIFY_API_BASE = 'https://api.spotify.com/v1';
 
 const { pickConfidentMatch } = require('./confidence-scoring');
 
+// Abuse-mode circuit breaker (parachord#956 audit §2b). Carries rate-limit state
+// across calls so a banned client_id isn't re-hammered every cycle. main.js wires
+// persistence via _setBreakerStore (load on startup, save on every transition);
+// absent → in-memory only (still stops in-session re-hammering).
+const { createSpotifyBreaker } = require('../sync-engine/spotify-breaker');
+const _spotifyBreaker = createSpotifyBreaker();
+let _spotifyBreakerSave = null;
+function _setBreakerStore(io) {
+  if (io && typeof io.load === 'function') { try { _spotifyBreaker.restore(io.load()); } catch {} }
+  _spotifyBreakerSave = (io && typeof io.save === 'function') ? io.save : null;
+}
+function _persistBreaker() { if (_spotifyBreakerSave) { try { _spotifyBreakerSave(_spotifyBreaker.snapshot()); } catch {} } }
+// Throw if the breaker is open (skip the API call to avoid prolonging the ban).
+function _breakerGuard() {
+  const now = Date.now();
+  if (_spotifyBreaker.isOpen(now)) {
+    throw new Error(`Spotify rate-limit cooldown active (${Math.ceil(_spotifyBreaker.msRemaining(now) / 60000)} min left); skipping to avoid prolonging the ban`);
+  }
+}
+function _breakerTrip() { _spotifyBreaker.trip(Date.now()); _persistBreaker(); }
+function _breakerSuccess() { if (_spotifyBreaker.recordSuccess()) _persistBreaker(); }
+
 /**
  * Normalize a string for ID generation (lowercase, remove special chars)
  */
@@ -27,6 +49,7 @@ const generateTrackId = (artist, title, album) => {
 const MAX_RETRIES = 5;
 
 const spotifyRequest = async (endpoint, token, options = {}, _retryCount = 0) => {
+  if (_retryCount === 0) _breakerGuard(); // §2b: fail-fast while the abuse cooldown is open
   const url = endpoint.startsWith('http') ? endpoint : `${SPOTIFY_API_BASE}${endpoint}`;
   const { method = 'GET', body, refreshToken } = options;
 
@@ -42,6 +65,7 @@ const spotifyRequest = async (endpoint, token, options = {}, _retryCount = 0) =>
   if (!response.ok) {
     if (response.status === 429) {
       if (_retryCount >= MAX_RETRIES) {
+        _breakerTrip(); // §2b: open the escalating cooldown — stop re-hammering next cycle
         throw new Error('Spotify API rate limit exceeded after maximum retries');
       }
       const retryAfter = parseInt(response.headers.get('Retry-After') || '5', 10);
@@ -74,6 +98,7 @@ const spotifyRequest = async (endpoint, token, options = {}, _retryCount = 0) =>
     throw new Error(`Spotify API error: ${response.status} ${response.statusText}`);
   }
 
+  _breakerSuccess(); // §2b: a good response closes the cooldown + resets escalation
   // Some endpoints return 201 with snapshot_id, others return empty
   const text = await response.text();
   return text ? JSON.parse(text) : { success: true };
@@ -92,6 +117,7 @@ const spotifyRequest = async (endpoint, token, options = {}, _retryCount = 0) =>
  */
 const spotifyFetch = async (endpoint, token, allItems = [], onProgress, refreshToken, _retryCount = 0, isCancelled = null) => {
   if (isCancelled?.()) return null;
+  if (_retryCount === 0 && allItems.length === 0) _breakerGuard(); // §2b: fail-fast at the start of a fetch while the cooldown is open
   const url = endpoint.startsWith('http') ? endpoint : `${SPOTIFY_API_BASE}${endpoint}`;
 
   // Validate pagination URLs stay on the expected host
@@ -112,6 +138,7 @@ const spotifyFetch = async (endpoint, token, allItems = [], onProgress, refreshT
   if (!response.ok) {
     if (response.status === 429) {
       if (_retryCount >= MAX_RETRIES) {
+        _breakerTrip(); // §2b: open the escalating cooldown
         throw new Error('Spotify API rate limit exceeded after maximum retries');
       }
       // Rate limited - get retry-after header
@@ -145,6 +172,7 @@ const spotifyFetch = async (endpoint, token, allItems = [], onProgress, refreshT
     throw new Error(`Spotify API error: ${response.status} ${response.statusText}`);
   }
 
+  _breakerSuccess(); // §2b: good response closes the cooldown
   const data = await response.json();
   const items = data.items || [];
   const combined = [...allItems, ...items];
@@ -892,5 +920,9 @@ const SpotifySyncProvider = {
     };
   }
 };
+
+// Persistence wiring for the §2b abuse-mode breaker (main.js calls this once at
+// startup with electron-store-backed load/save).
+SpotifySyncProvider._setBreakerStore = _setBreakerStore;
 
 module.exports = SpotifySyncProvider;

--- a/tests/sync/applemusic-add-primitive.test.js
+++ b/tests/sync/applemusic-add-primitive.test.js
@@ -1,0 +1,42 @@
+/**
+ * AM N-way ADD primitive (parachord#956 §2c). AM is trackRemoveMode 'Unsupported'
+ * but CAN append via POST. Without an addPlaylistTracks primitive, the materialize
+ * executor's Unsupported branch hit the throwing default and armed AM mirrors
+ * silently never received additions. This pins the primitive + that it's wired to
+ * the real POST path.
+ */
+
+const am = require('../../sync-providers/applemusic');
+const { withIncrementalDefaults } = require('../../sync-providers/incremental-primitives');
+
+const TOKEN = JSON.stringify({ developerToken: 'dev', userToken: 'usr' });
+
+describe('AM addPlaylistTracks primitive — armed additions land', () => {
+  afterEach(() => { delete global.fetch; });
+
+  test('AM implements addPlaylistTracks (no longer backfilled by the throwing stub)', () => {
+    expect(typeof am.addPlaylistTracks).toBe('function');
+    const ready = withIncrementalDefaults(am);
+    expect(ready.addPlaylistTracks).toBe(am.addPlaylistTracks); // the real fn, not the stub
+  });
+
+  test('POSTs catalog ids to the playlist tracks endpoint with the bound token', async () => {
+    const calls = [];
+    global.fetch = jest.fn(async (url, init) => { calls.push({ url, init }); return { ok: true, json: async () => ({}) }; });
+    await am.addPlaylistTracks('p.123', ['1452906710', '999'], TOKEN);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toContain('/me/library/playlists/p.123/tracks');
+    expect(calls[0].init.method).toBe('POST');
+    expect(JSON.parse(calls[0].init.body).data).toEqual([
+      { id: '1452906710', type: 'songs' },
+      { id: '999', type: 'songs' },
+    ]);
+    expect(calls[0].init.headers['Music-User-Token']).toBe('usr');
+  });
+
+  test('empty add is a no-op (never POSTs an empty batch)', async () => {
+    global.fetch = jest.fn();
+    expect(await am.addPlaylistTracks('p.1', [], TOKEN)).toBe(0);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/sync/playlist-reconcile.test.js
+++ b/tests/sync/playlist-reconcile.test.js
@@ -538,4 +538,46 @@ describe('reconcile — shadow (dryRun) mode', () => {
     expect(sp.removeByNativeIdCalls).toEqual([]);
     expect(sp.remote.length).toBe(2);
   });
+
+  // V6 (Refinement A, parachord#956 audit §2a) — a non-removal-capable PULL
+  // SOURCE (Apple Music) can never prove a deletion. Even after a materialized
+  // track is OMITTED from AM's complete fetch for >= the missingStreak threshold,
+  // its absence must NOT propagate a real delete to the writable mirrors — the
+  // AM source copy is augment-all. Pre-fix this dropped the track fleet-wide.
+  test('V6 AM-add-only-source-declined-augment-all — AM source omission never deletes a mirror track', async () => {
+    const h = new Harness('applemusic-pl');
+    const am = h.add(new FakeProvider('applemusic', 'Unsupported'));
+    const lb = h.add(new FakeProvider('listenbrainz', 'ByPosition'));
+    h.pullSource = { providerId: 'applemusic', externalId: am._ext };
+    h.seed([mk('m1'), mk('m2'), mk('m3')]);
+    h.warmCache('applemusic', 'm2'); // m2 materialized on AM (resolvedId set → streak gate would fire)
+
+    // Two consecutive COMPLETE AM fetches that OMIT m2 (rotate-out / AM fetch
+    // flakiness). Each bumps missingStreak; at 2 the streak gate would normally
+    // stop protecting it.
+    h.drift(am, [mk('m1'), mk('m3')]);
+    await h.cycle(); // cycle 1 → missingStreak('applemusic', m2) = 1
+    h.drift(am, [mk('m1'), mk('m3')]);
+    await h.cycle(); // cycle 2 → missingStreak = 2 (pre-fix: m2 dropped fleet-wide here)
+
+    expect(lb.removeByPositionCalls).toEqual([]);     // NO delete propagated to the writable mirror
+    expect(mbidsOf(lb.remote).has('m2')).toBe(true);  // m2 survives on LB
+    expect(h.state.baseline.tracks.length).toBe(3);   // baseline did NOT shrink (residue kept)
+  });
+
+  // Counter-case: a REMOVAL-CAPABLE source (Spotify, followed → immediate
+  // authority) DOES propagate its drop — confirms augment-all is scoped to
+  // non-removal-capable sources, not all pull sources.
+  test('V6b removal-capable source still deletes (augment-all is non-removal-capable-only)', async () => {
+    const h = new Harness('spotify-pl');
+    const sp = h.add(new FakeProvider('spotify', 'ByNativeId'));
+    const lb = h.add(new FakeProvider('listenbrainz', 'ByPosition'));
+    h.pullSource = { providerId: 'spotify', externalId: sp._ext };
+    h.playlist.writable = false; // a followed source is immediate-authority (rotate-out drops at once)
+    h.seed([mk('m1'), mk('m2'), mk('m3')]);
+    h.drift(sp, [mk('m1'), mk('m3')]); // Spotify (the source) genuinely drops m2
+    await h.cycle();
+    expect(lb.removeByPositionCalls.length).toBe(1);  // a real source delete DOES propagate
+    expect(mbidsOf(lb.remote).has('m2')).toBe(false);
+  });
 });

--- a/tests/sync/spotify-breaker.test.js
+++ b/tests/sync/spotify-breaker.test.js
@@ -1,0 +1,74 @@
+/**
+ * Spotify abuse-mode circuit breaker (parachord#956 audit §2b). Pure escalation
+ * logic + the spotify.js fail-fast wiring (a banned client_id isn't re-hammered
+ * across calls).
+ */
+
+const { createSpotifyBreaker, cooldownMsForLevel, HOUR_MS } = require('../../sync-engine/spotify-breaker');
+const spotify = require('../../sync-providers/spotify');
+
+describe('createSpotifyBreaker — escalating cooldown', () => {
+  test('cooldownMsForLevel: 1st ban 1h, repeats 6h', () => {
+    expect(cooldownMsForLevel(1)).toBe(1 * HOUR_MS);
+    expect(cooldownMsForLevel(2)).toBe(6 * HOUR_MS);
+    expect(cooldownMsForLevel(5)).toBe(6 * HOUR_MS);
+  });
+
+  test('trip opens with an escalating cooldown; isOpen reflects it', () => {
+    const b = createSpotifyBreaker();
+    const t = 1_000_000;
+    expect(b.isOpen(t)).toBe(false);
+    b.trip(t);                                   // level 1 → 1h
+    expect(b.isOpen(t)).toBe(true);
+    expect(b.isOpen(t + HOUR_MS - 1)).toBe(true);
+    expect(b.isOpen(t + HOUR_MS + 1)).toBe(false);
+    b.trip(t + 2 * HOUR_MS);                      // level 2 → 6h
+    expect(b.isOpen(t + 2 * HOUR_MS + 6 * HOUR_MS - 1)).toBe(true);
+    expect(b.isOpen(t + 2 * HOUR_MS + 6 * HOUR_MS + 1)).toBe(false);
+  });
+
+  test('recordSuccess closes + resets escalation (and reports whether it changed)', () => {
+    const b = createSpotifyBreaker();
+    expect(b.recordSuccess()).toBe(false);       // nothing to reset
+    b.trip(5);
+    expect(b.recordSuccess()).toBe(true);        // closed
+    expect(b.isOpen(6)).toBe(false);
+    // After reset, the next trip starts at level 1 (1h), not the escalated 6h.
+    b.trip(10);
+    expect(b.isOpen(10 + HOUR_MS - 1)).toBe(true);
+    expect(b.isOpen(10 + HOUR_MS + 1)).toBe(false);
+  });
+
+  test('snapshot / restore round-trips (cross-restart persistence)', () => {
+    const a = createSpotifyBreaker();
+    a.trip(100);
+    const snap = a.snapshot();
+    const b = createSpotifyBreaker();
+    b.restore(snap);
+    expect(b.snapshot()).toEqual(snap);
+    expect(b.isOpen(100)).toBe(true);
+    b.restore(null); // malformed → no-op, no throw
+    expect(b.isOpen(100)).toBe(true);
+  });
+});
+
+describe('spotify.js fail-fast while the breaker is open', () => {
+  const FUTURE = 1; // restore an open breaker
+  afterEach(() => {
+    // Reset the module-level breaker to closed so state doesn't leak across tests.
+    spotify._setBreakerStore({ load: () => ({ openUntil: 0, level: 0 }) });
+    delete global.fetch;
+  });
+
+  test('resolveTracks makes NO Spotify call while the cooldown is open', async () => {
+    global.fetch = jest.fn();
+    // Open the breaker far into the future via the persistence-restore hook.
+    spotify._setBreakerStore({ load: () => ({ openUntil: Date.now() + 6 * HOUR_MS, level: 2 }) });
+    const { resolved, unresolved } = await spotify.resolveTracks(
+      [{ title: 'X', artist: 'Y' }], 'tok'
+    );
+    expect(global.fetch).not.toHaveBeenCalled(); // fail-fast: no hammering the banned client_id
+    expect(resolved).toEqual([]);
+    expect(unresolved).toEqual([{ artist: 'Y', title: 'X' }]);
+  });
+});


### PR DESCRIPTION
The two gaps the [PR #956 materialize-parity audit](https://github.com/Parachord/parachord/pull/956) found against mobile's live-validated contract. **#956 (arming) is blocked on this PR.**

## §2a (must-fix, high — data-loss class) — AM add-only source is augment-all
The adversarial verify in the audit reproduced this end-to-end: when the pull source is **Apple Music** (`trackRemoveMode: 'Unsupported'`), `authoritativeCopyId` is nulled, so the AM source copy fell into A6's **streak-gated** branch. A track materialized onto AM that AM omits from its complete fetch for ≥2 cycles fails `isProviderPendingForKey` → not re-added → merge's **delete-wins drops it and propagates a physical removal to the writable mirrors** (e.g. LB). AM is exactly the churn/partial-fetch-prone provider this guarantee exists to protect.

**Fix:** port Refinement A (desktop port plan L173/L227; mobile-validated live) — a **non-removal-capable pull source is augment-all**: every lacked baseline key is re-added, bypassing the streak gate, so a transient/partial AM fetch can never read as a deletion.

**Regression test:** `V6 AM-add-only-source-declined-augment-all` (+ `V6b` confirming a removal-capable source still propagates a real drop, so the fix is scoped). **V6 fails without the fix, passes with it** (verified by neutralizing the branch).

## §2b (recommended, medium) — Spotify abuse-mode circuit breaker
Spotify rate-limits the whole `client_id` and an abuse-mode ban outlasts its `Retry-After` by **12+h**. Desktop only honored `Retry-After` + a per-call-tree retry cap, so the next op re-issued at retry 0 and **re-hammered the still-banned `client_id`** — and arming N-way raises request volume, raising the odds of tripping it.

**Fix:** `sync-engine/spotify-breaker.js` (pure, tested) — an **escalating cooldown (1h→6h**, mobile parity) that carries state across calls. `spotifyRequest` + `spotifyFetch` fail-fast while open, trip it on 429-after-`MAX_RETRIES`, and close it on a good response. `main.js` persists the snapshot to electron-store so a ban **survives restart** (mirrors the LB-hydration cooldown pattern already in-tree).

## Scope / safety
- §2a is a reconcile **correctness** fix valuable independent of arming (it fixes data loss whenever N-way runs, shadow or armed) — hence its own PR.
- **1964 tests green** (incl. the full no-false-drop harness + the new V6/V6b + breaker tests).

## Remaining before #956 can arm
A scoped **live write pass** (per the audit's live-pass checklist): one playlist per provider with an **AM-sourced playlist explicitly included** (confirms §2a holds live), the Spotify abuse-mode breaker, the `expectedCount`-provenance of the partial-fetch floor, and the AM-no-`addPlaylistTracks` adjacent gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)